### PR TITLE
Options Method

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -179,7 +179,6 @@ pub struct Resource<'a, Data> {
 struct ResourceData<Data> {
     endpoints: HashMap<http::Method, BoxedEndpoint<Data>>,
     middleware: Vec<Arc<dyn Middleware<Data> + Send + Sync>>,
-    method_options: Vec<String>,
 }
 
 impl<'a, Data: Send + Sync + Clone + 'static> Resource<'a, Data> {
@@ -206,7 +205,6 @@ impl<'a, Data: Send + Sync + Clone + 'static> Resource<'a, Data> {
             let new_resource = ResourceData {
                 endpoints: HashMap::new(),
                 middleware: self.middleware_base.clone(),
-                method_options: Vec::new(),
             };
             *resource = Some(new_resource);
         }
@@ -215,14 +213,11 @@ impl<'a, Data: Send + Sync + Clone + 'static> Resource<'a, Data> {
             panic!("A {} endpoint already exists for this path", method)
         }
 
-        resource.method_options.push(method.as_str().to_string());
-        let method_options = resource.method_options.join(", ");
         if !resource.endpoints.contains_key(&http::Method::OPTIONS) {
             let callback = async move || {
                 http::Response::builder()
                     .status(http::status::StatusCode::OK)
                     .header("Content-Type", "text/plain")
-                    .header("Access-Control-Allow-Methods", method_options.clone())
                     .body(Body::empty())
                     .unwrap()
             };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Tide will now automatically implement the `OPTIONS` method by checking which methods are available for a specific path. Currently, the implementation fails to compile with this error message and I am stuck trying to figure out what the issue is :/

```bash
error[E0277]: the trait bound `[closure@src/router.rs:214:26: 222:14 option_header:_]: endpoint::Endpoint<Data, _>` is not satisfied
   --> src/router.rs:214:18
    |
214 |             self.options(async || {
    |                  ^^^^^^^ the trait `endpoint::Endpoint<Data, _>` is not implemented for `[closure@src/router.rs:214:26: 222:14 option_header:_]`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0277`.
error: Could not compile `tide`.

To learn more, run the command again with --verbose.
```

Any help would be greatly appreciated!

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
closes #51 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not yet, implementation currently does not compile
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rust-net-web/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
