### PR TITLE
Redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,16 +24,27 @@ easier to write APIs with Tide out of the box.
 
 ## Example
 
+Create a "hello world" app:
 ```rust
-use async_std::task;
+#[async_std::main]
+async fn main() -> Result<(), std::io::Error> {
+    let mut app = tide::new();
+    app.at("/").get(|_| async move { "Hello, world!" });
+    app.listen("127.0.0.1:8080").await?;
+    Ok(())
+}
+```
 
-fn main() -> Result<(), std::io::Error> {
-    task::block_on(async {
-        let mut app = tide::new();
-        app.at("/").get(|_| async move { "Hello, world!" });
-        app.listen("127.0.0.1:8080").await?;
-        Ok(())
-    })
+Redirect from `/nori` to `/chashu`:
+
+```rust
+#[async_std::main]
+async fn main() -> Result<(), std::io::Error> {
+    let mut app = tide::new();
+    app.at("/chashu").get(|_| async move { "meow" });
+    app.at("/nori").get(tide::redirect("/chashu"));
+    app.listen("127.0.0.1:8080").await?;
+    Ok(())
 }
 ```
 
@@ -47,6 +58,7 @@ fn main() -> Result<(), std::io::Error> {
 - Added a `new` free function, a shorthand for `Server::new`.
 - Added a `with_state` free function, a shorthand for `Server::with_state`.
 - Added `Result` type alias (replaces `EndpointResult`).
+- Added a `redirect` free function to redirect from one endpoint to another.
 
 ### Changed
 

--- a/backup/examples/messages.rs
+++ b/backup/examples/messages.rs
@@ -1,7 +1,7 @@
 use http::status::StatusCode;
 use serde::{Deserialize, Serialize};
 use std::sync::Mutex;
-use tide::{error::ResultExt, response, Request, Result, Server};
+use tide::{Request, Result, ResultExt, Server};
 
 #[derive(Default)]
 struct Database {
@@ -56,7 +56,7 @@ async fn set_message(mut cx: Request<Database>) -> Result<()> {
 async fn get_message(cx: Request<Database>) -> Result {
     let id = cx.param("id").client_err()?;
     if let Some(msg) = cx.state().get(id) {
-        Ok(response::json(msg))
+        Ok(cx.body_json())
     } else {
         Err(StatusCode::NOT_FOUND)?
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@
 mod endpoint;
 mod error;
 mod middleware;
+mod redirect;
 mod request;
 mod response;
 mod router;
@@ -86,6 +87,7 @@ pub mod server;
 
 pub use endpoint::Endpoint;
 pub use error::{Error, Result, ResultExt};
+pub use redirect::redirect;
 pub use request::Request;
 
 #[doc(inline)]

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -22,7 +22,7 @@ use crate::{Request, Response, Endpoint};
 /// #
 /// # Ok(()) }) }
 /// ````
-pub async fn redirect<State>(location: impl AsRef<str>) -> impl Endpoint<State> {
+pub fn redirect<State>(location: impl AsRef<str>) -> impl Endpoint<State> {
     let location = location.as_ref().to_owned();
     Redirect { location }
 }

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -1,9 +1,9 @@
-use async_std::task::{Context, Poll};
 use async_std::future;
+use async_std::task::{Context, Poll};
 
 use std::pin::Pin;
 
-use crate::{Request, Response, Endpoint};
+use crate::{Endpoint, Request, Response};
 
 /// Redirect a route to another route.
 ///
@@ -52,4 +52,3 @@ impl future::Future for Future {
         Poll::Ready(self.res.take().unwrap())
     }
 }
-

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -1,0 +1,55 @@
+use async_std::task::{Context, Poll};
+use async_std::future;
+
+use std::pin::Pin;
+
+use crate::{Request, Response, Endpoint};
+
+/// Redirect a route to another route.
+///
+/// The route will be redirected with a `307, temporary redirect` on a route with the same HTTP
+/// method.
+///
+/// # Examples
+/// ```no_run
+/// # use futures::executor::block_on;
+/// # fn main() -> Result<(), std::io::Error> { block_on(async {
+/// #
+/// let mut app = tide::new();
+/// app.at("/").get(|_| async move { "meow" });
+/// app.at("/nori").get(tide::redirect("/"));
+/// app.listen("127.0.0.1:8080").await?;
+/// #
+/// # Ok(()) }) }
+/// ````
+pub async fn redirect<State>(location: impl AsRef<str>) -> impl Endpoint<State> {
+    let location = location.as_ref().to_owned();
+    Redirect { location }
+}
+
+/// The route that we redirect to
+pub struct Redirect {
+    location: String,
+}
+
+impl<State> Endpoint<State> for Redirect {
+    type Fut = Future;
+
+    fn call(&self, _req: Request<State>) -> Self::Fut {
+        let res = Response::new(307).set_header("Location", &self.location);
+        Future { res: Some(res) }
+    }
+}
+
+/// Future returned from `redirect`.
+pub struct Future {
+    res: Option<Response>,
+}
+
+impl future::Future for Future {
+    type Output = Response;
+    fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Poll::Ready(self.res.take().unwrap())
+    }
+}
+

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -37,104 +37,109 @@ pub use route::Route;
 /// - Middleware extends the base Tide framework with additional request or
 /// response processing, such as compression, default headers, or logging. To
 /// add middleware to an app, use the [`Server::middleware`] method.
-/////
-///// # Hello, world!
-/////
-///// You can start a simple Tide application that listens for `GET` requests at path `/hello`
-///// on `127.0.0.1:8000` with:
-/////
-///// ```rust, no_run
-/////
-///// let mut app = tide::Server::new();
-///// app.at("/hello").get(|_| async move {"Hello, world!"});
-///// // app.run("127.0.0.1:8000").unwrap();
-///// ```
-/////
-///// # Routing and parameters
-/////
-///// Tide's routing system is simple and similar to many other frameworks. It
-///// uses `:foo` for "wildcard" URL segments, and `*foo` to match the rest of a
-///// URL (which may include multiple segments). Here's an example using wildcard
-///// segments as parameters to endpoints:
-/////
-///// ```no_run
-///// use tide::error::ResultExt;
-/////
-///// async fn hello(cx: tide::Request<()>) -> tide::Result<String> {
-/////     let user: String = cx.param("user")?;
-/////     Ok(format!("Hello, {}!", user))
-///// }
-/////
-///// async fn goodbye(cx: tide::Request<()>) -> tide::Result<String> {
-/////     let user: String = cx.param("user")?;
-/////     Ok(format!("Goodbye, {}.", user))
-///// }
-/////
-///// let mut app = tide::Server::new();
-/////
-///// app.at("/hello/:user").get(hello);
-///// app.at("/goodbye/:user").get(goodbye);
-///// app.at("/").get(|_| async move {
-/////     "Use /hello/{your name} or /goodbye/{your name}"
-///// });
-/////
-///// // app.run("127.0.0.1:8000").unwrap();
-///// ```
-/////
-///// You can learn more about routing in the [`Server::at`] documentation.
-/////
-///// # Serverlication state
-/////
-///// ```rust,no_run
-///// use http::status::StatusCode;
-///// use serde::{Deserialize, Serialize};
-///// use std::sync::Mutex;
-///// use tide::{error::ResultExt, Server, Request, Result};
-/////
-///// #[derive(Default)]
-///// struct Database {
-/////     contents: Mutex<Vec<Message>>,
-///// }
-/////
-///// #[derive(Serialize, Deserialize, Clone)]
-///// struct Message {
-/////     author: Option<String>,
-/////     contents: String,
-///// }
-/////
-///// impl Database {
-/////     fn insert(&self, msg: Message) -> usize {
-/////         let mut table = self.contents.lock().unwrap();
-/////         table.push(msg);
-/////         table.len() - 1
-/////     }
-/////
-/////     fn get(&self, id: usize) -> Option<Message> {
-/////         self.contents.lock().unwrap().get(id).cloned()
-/////     }
-///// }
-/////
-///// async fn new_message(mut cx: Request<Database>) -> Result<String> {
-/////     let msg = cx.body_json().await?;
-/////     Ok(cx.state().insert(msg).to_string())
-///// }
-/////
-///// async fn get_message(cx: Request<Database>) -> Result {
-/////     let id = cx.param("id").unwrap();
-/////     if let Some(msg) = cx.state().get(id) {
-/////         Ok(response::json(msg))
-/////     } else {
-/////         Err(StatusCode::NOT_FOUND)?
-/////     }
-///// }
-/////
-///// fn main() {
-/////     let mut app = Server::with_state(Database::default());
-/////     app.at("/message").post(new_message);
-/////     app.at("/message/:id").get(get_message);
-/////     // app.run("127.0.0.1:8000").unwrap();
-///// }
-///// ```
+///
+/// # Hello, world!
+///
+/// You can start a simple Tide application that listens for `GET` requests at path `/hello`
+/// on `127.0.0.1:8000` with:
+///
+/// ```rust, no_run
+/// # #![allow(unused_must_use)]
+/// # async {
+/// let mut app = tide::Server::new();
+/// app.at("/hello").get(|_| async move {"Hello, world!"});
+/// app.listen("127.0.0.1:8000").await.unwrap();
+/// # };
+/// ```
+///
+/// # Routing and parameters
+///
+/// Tide's routing system is simple and similar to many other frameworks. It
+/// uses `:foo` for "wildcard" URL segments, and `*foo` to match the rest of a
+/// URL (which may include multiple segments). Here's an example using wildcard
+/// segments as parameters to endpoints:
+///
+/// ```rust, no_run
+/// use tide::ResultExt;
+///
+/// # async {
+/// async fn hello(cx: tide::Request<()>) -> tide::Result<String> {
+///     let user: String = cx.param("user").client_err()?;
+///     Ok(format!("Hello, {}!", user))
+/// }
+///
+/// async fn goodbye(cx: tide::Request<()>) -> tide::Result<String> {
+///     let user: String = cx.param("user").client_err()?;
+///     Ok(format!("Goodbye, {}.", user))
+/// }
+///
+/// let mut app = tide::Server::new();
+///
+/// app.at("/hello/:user").get(hello);
+/// app.at("/goodbye/:user").get(goodbye);
+/// app.at("/").get(|_| async move {
+///     "Use /hello/{your name} or /goodbye/{your name}"
+/// });
+///
+/// app.listen("127.0.0.1:8000").await.unwrap();
+/// # };
+/// ```
+///
+/// You can learn more about routing in the [`Server::at`] documentation.
+///
+/// # Serverlication state
+///
+/// ```rust, no_run
+///
+/// use http::status::StatusCode;
+/// use serde::{Deserialize, Serialize};
+/// use std::sync::Mutex;
+/// use tide::{Server, Request, Result, ResultExt};
+///
+/// #[derive(Default)]
+/// struct Database {
+///     contents: Mutex<Vec<Message>>,
+/// }
+///
+/// #[derive(Serialize, Deserialize, Clone)]
+/// struct Message {
+///     author: Option<String>,
+///     contents: String,
+/// }
+///
+/// impl Database {
+///     fn insert(&self, msg: Message) -> usize {
+///         let mut table = self.contents.lock().unwrap();
+///         table.push(msg);
+///         table.len() - 1
+///     }
+///
+///     fn get(&self, id: usize) -> Option<Message> {
+///         self.contents.lock().unwrap().get(id).cloned()
+///     }
+/// }
+///
+/// async fn new_message(mut cx: Request<Database>) -> Result<String> {
+///     let msg = cx.body_json().await.client_err()?;
+///     Ok(cx.state().insert(msg).to_string())
+/// }
+///
+/// fn get_message(cx: Request<Database>) -> Result {
+///     let id = cx.param("id").client_err()?;
+///     if let Some(msg) = cx.state().get(id) {
+///         Ok(cx.body_json())
+///     } else {
+///         Err(StatusCode::NOT_FOUND)?
+///     }
+/// }
+///
+/// fn main() {
+///     let mut app = Server::with_state(Database::default());
+///     app.at("/message").post(new_message);
+///     app.at("/message/:id").get(get_message);
+///     app.run("127.0.0.1:8000").unwrap();
+/// }
+/// ```
 #[allow(missing_debug_implementations)]
 pub struct Server<State> {
     router: Router<State>,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -37,109 +37,104 @@ pub use route::Route;
 /// - Middleware extends the base Tide framework with additional request or
 /// response processing, such as compression, default headers, or logging. To
 /// add middleware to an app, use the [`Server::middleware`] method.
-///
-/// # Hello, world!
-///
-/// You can start a simple Tide application that listens for `GET` requests at path `/hello`
-/// on `127.0.0.1:8000` with:
-///
-/// ```rust, no_run
-/// # #![allow(unused_must_use)]
-/// # async {
-/// let mut app = tide::Server::new();
-/// app.at("/hello").get(|_| async move {"Hello, world!"});
-/// app.listen("127.0.0.1:8000").await.unwrap();
-/// # };
-/// ```
-///
-/// # Routing and parameters
-///
-/// Tide's routing system is simple and similar to many other frameworks. It
-/// uses `:foo` for "wildcard" URL segments, and `*foo` to match the rest of a
-/// URL (which may include multiple segments). Here's an example using wildcard
-/// segments as parameters to endpoints:
-///
-/// ```rust, no_run
-/// use tide::ResultExt;
-///
-/// # async {
-/// async fn hello(cx: tide::Request<()>) -> tide::Result<String> {
-///     let user: String = cx.param("user").client_err()?;
-///     Ok(format!("Hello, {}!", user))
-/// }
-///
-/// async fn goodbye(cx: tide::Request<()>) -> tide::Result<String> {
-///     let user: String = cx.param("user").client_err()?;
-///     Ok(format!("Goodbye, {}.", user))
-/// }
-///
-/// let mut app = tide::Server::new();
-///
-/// app.at("/hello/:user").get(hello);
-/// app.at("/goodbye/:user").get(goodbye);
-/// app.at("/").get(|_| async move {
-///     "Use /hello/{your name} or /goodbye/{your name}"
-/// });
-///
-/// app.listen("127.0.0.1:8000").await.unwrap();
-/// # };
-/// ```
-///
-/// You can learn more about routing in the [`Server::at`] documentation.
-///
-/// # Serverlication state
-///
-/// ```rust, no_run
-///
-/// use http::status::StatusCode;
-/// use serde::{Deserialize, Serialize};
-/// use std::sync::Mutex;
-/// use tide::{Server, Request, Result, ResultExt};
-///
-/// #[derive(Default)]
-/// struct Database {
-///     contents: Mutex<Vec<Message>>,
-/// }
-///
-/// #[derive(Serialize, Deserialize, Clone)]
-/// struct Message {
-///     author: Option<String>,
-///     contents: String,
-/// }
-///
-/// impl Database {
-///     fn insert(&self, msg: Message) -> usize {
-///         let mut table = self.contents.lock().unwrap();
-///         table.push(msg);
-///         table.len() - 1
-///     }
-///
-///     fn get(&self, id: usize) -> Option<Message> {
-///         self.contents.lock().unwrap().get(id).cloned()
-///     }
-/// }
-///
-/// async fn new_message(mut cx: Request<Database>) -> Result<String> {
-///     let msg = cx.body_json().await.client_err()?;
-///     Ok(cx.state().insert(msg).to_string())
-/// }
-///
-/// fn get_message(cx: Request<Database>) -> Result {
-///     let id = cx.param("id").client_err()?;
-///     if let Some(msg) = cx.state().get(id) {
-///         Ok(cx.body_json())
-///     } else {
-///         Err(StatusCode::NOT_FOUND)?
-///     }
-/// }
-///
-/// fn main() {
-///     let mut app = Server::with_state(Database::default());
-///     app.at("/message").post(new_message);
-///     app.at("/message/:id").get(get_message);
-///     app.run("127.0.0.1:8000").unwrap();
-/// }
-/// ```
+/////
+///// # Hello, world!
+/////
+///// You can start a simple Tide application that listens for `GET` requests at path `/hello`
+///// on `127.0.0.1:8000` with:
+/////
+///// ```rust, no_run
+/////
+///// let mut app = tide::Server::new();
+///// app.at("/hello").get(|_| async move {"Hello, world!"});
+///// // app.run("127.0.0.1:8000").unwrap();
+///// ```
+/////
+///// # Routing and parameters
+/////
+///// Tide's routing system is simple and similar to many other frameworks. It
+///// uses `:foo` for "wildcard" URL segments, and `*foo` to match the rest of a
+///// URL (which may include multiple segments). Here's an example using wildcard
+///// segments as parameters to endpoints:
+/////
+///// ```no_run
+///// use tide::error::ResultExt;
+/////
+///// async fn hello(cx: tide::Request<()>) -> tide::Result<String> {
+/////     let user: String = cx.param("user")?;
+/////     Ok(format!("Hello, {}!", user))
+///// }
+/////
+///// async fn goodbye(cx: tide::Request<()>) -> tide::Result<String> {
+/////     let user: String = cx.param("user")?;
+/////     Ok(format!("Goodbye, {}.", user))
+///// }
+/////
+///// let mut app = tide::Server::new();
+/////
+///// app.at("/hello/:user").get(hello);
+///// app.at("/goodbye/:user").get(goodbye);
+///// app.at("/").get(|_| async move {
+/////     "Use /hello/{your name} or /goodbye/{your name}"
+///// });
+/////
+///// // app.run("127.0.0.1:8000").unwrap();
+///// ```
+/////
+///// You can learn more about routing in the [`Server::at`] documentation.
+/////
+///// # Serverlication state
+/////
+///// ```rust,no_run
+///// use http::status::StatusCode;
+///// use serde::{Deserialize, Serialize};
+///// use std::sync::Mutex;
+///// use tide::{error::ResultExt, Server, Request, Result};
+/////
+///// #[derive(Default)]
+///// struct Database {
+/////     contents: Mutex<Vec<Message>>,
+///// }
+/////
+///// #[derive(Serialize, Deserialize, Clone)]
+///// struct Message {
+/////     author: Option<String>,
+/////     contents: String,
+///// }
+/////
+///// impl Database {
+/////     fn insert(&self, msg: Message) -> usize {
+/////         let mut table = self.contents.lock().unwrap();
+/////         table.push(msg);
+/////         table.len() - 1
+/////     }
+/////
+/////     fn get(&self, id: usize) -> Option<Message> {
+/////         self.contents.lock().unwrap().get(id).cloned()
+/////     }
+///// }
+/////
+///// async fn new_message(mut cx: Request<Database>) -> Result<String> {
+/////     let msg = cx.body_json().await?;
+/////     Ok(cx.state().insert(msg).to_string())
+///// }
+/////
+///// async fn get_message(cx: Request<Database>) -> Result {
+/////     let id = cx.param("id").unwrap();
+/////     if let Some(msg) = cx.state().get(id) {
+/////         Ok(response::json(msg))
+/////     } else {
+/////         Err(StatusCode::NOT_FOUND)?
+/////     }
+///// }
+/////
+///// fn main() {
+/////     let mut app = Server::with_state(Database::default());
+/////     app.at("/message").post(new_message);
+/////     app.at("/message/:id").get(get_message);
+/////     // app.run("127.0.0.1:8000").unwrap();
+///// }
+///// ```
 #[allow(missing_debug_implementations)]
 pub struct Server<State> {
     router: Router<State>,


### PR DESCRIPTION
Adds redirects to Tide. Closes #348. Thanks!

## Examples

Redirect from `/nori` to `/chashu`:

```rust
#[async_std::main]
async fn main() -> Result<(), std::io::Error> {
    let mut app = tide::new();
    app.at("/chashu").get(|_| async move { "meow" });
    app.at("/nori").get(tide::redirect("/chashu"));
    app.listen("127.0.0.1:8080").await?;
    Ok(())
}
```