### PR TITLE
impl Endpoint for Service, for service nesting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,14 +37,20 @@ jobs:
     - name: check unstable
       uses: actions-rs/cargo@v1
       with:
-        command:  check
-        args: --all --benches --bins --examples --tests
+        command: check
+        args: --all --benches --bins --examples --tests --features unstable
 
     - name: tests
       uses: actions-rs/cargo@v1
       with:
         command: test
         args: --all
+
+    - name: tests unstable
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --all --features unstable
 
   check_fmt_and_docs:
     name: Checking fmt and docs
@@ -66,4 +72,4 @@ jobs:
       run: cargo fmt --all -- --check
 
     - name: Docs
-      run: cargo doc
+      run: cargo doc --features unstable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,14 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/http-rs/tide"
 
+[package.metadata.docs.rs]
+features = ["docs"]
+rustdoc-args = ["--cfg", "feature=\"docs\""]
+
 [features]
 default = ["hyper-server"]
 hyper-server = ["http-service-hyper"]
+docs = ["unstable"]
 unstable = []
 
 [dependencies]
@@ -50,3 +55,8 @@ percent-encoding = "2.1.0"
 serde = { version = "1.0.102", features = ["derive"] }
 structopt = "0.3.3"
 surf = "1.0.3"
+
+[[test]]
+name = "nested"
+path = "tests/nested.rs"
+required-features = ["unstable"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::mutex_atomic, clippy::module_inception)]
 #![doc(test(attr(deny(rust_2018_idioms, warnings))))]
 #![doc(test(attr(allow(unused_extern_crates, unused_variables))))]
+#![cfg_attr(feature = "docs", feature(doc_cfg))]
 
 //! # Serve the web
 //!

--- a/src/request.rs
+++ b/src/request.rs
@@ -19,10 +19,10 @@ pin_project_lite::pin_project! {
     /// communication between middleware and endpoints.
     #[derive(Debug)]
     pub struct Request<State> {
-        state: Arc<State>,
+        pub(crate) state: Arc<State>,
         #[pin]
-        request: http_service::Request,
-        route_params: Params,
+        pub(crate) request: http_service::Request,
+        pub(crate) route_params: Vec<Params>,
     }
 }
 
@@ -30,7 +30,7 @@ impl<State> Request<State> {
     pub(crate) fn new(
         state: Arc<State>,
         request: http::Request<Body>,
-        route_params: Params,
+        route_params: Vec<Params>,
     ) -> Request<State> {
         Request {
             state,
@@ -106,7 +106,7 @@ impl<State> Request<State> {
     ///
     /// Panic if `key` is not a parameter for the route.
     pub fn param<T: FromStr>(&self, key: &str) -> Result<T, T::Err> {
-        self.route_params.find(key).unwrap().parse()
+        self.route_params.iter().rev().filter_map(|params| params.find(key)).next().unwrap().parse()
     }
 
     /// Reads the entire request body into a byte buffer.

--- a/src/request.rs
+++ b/src/request.rs
@@ -106,7 +106,13 @@ impl<State> Request<State> {
     ///
     /// Panic if `key` is not a parameter for the route.
     pub fn param<T: FromStr>(&self, key: &str) -> Result<T, T::Err> {
-        self.route_params.iter().rev().filter_map(|params| params.find(key)).next().unwrap().parse()
+        self.route_params
+            .iter()
+            .rev()
+            .filter_map(|params| params.find(key))
+            .next()
+            .unwrap()
+            .parse()
     }
 
     /// Reads the entire request body into a byte buffer.

--- a/src/request.rs
+++ b/src/request.rs
@@ -115,6 +115,12 @@ impl<State> Request<State> {
             .parse()
     }
 
+    pub(crate) fn rest(&self) -> Option<&str> {
+        self.route_params
+            .last()
+            .and_then(|params| params.find("--tide-path-rest"))
+    }
+
     /// Reads the entire request body into a byte buffer.
     ///
     /// This method can be called after the body has already been read, but will

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -336,7 +336,7 @@ impl<State: Sync + Send + 'static> Endpoint<State> for Service<State> {
                 next_middleware: &middleware,
             };
 
-            next.run(req).await.into()
+            next.run(req).await
         })
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -315,7 +315,11 @@ impl<State: Sync + Send + 'static> Endpoint<State> for Service<State> {
     type Fut = BoxFuture<'static, Response>;
 
     fn call(&self, req: Request<State>) -> Self::Fut {
-        let Request { request: req, mut route_params, .. } = req;
+        let Request {
+            request: req,
+            mut route_params,
+            ..
+        } = req;
         let path = req.uri().path().to_owned();
         let method = req.method().to_owned();
         let router = self.router.clone();

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -12,6 +12,10 @@ use crate::{router::Router, Endpoint};
 pub struct Route<'a, State> {
     router: &'a mut Router<State>,
     path: String,
+    /// Indicates whether the path of current route is treated as a prefix. Set by
+    /// [`strip_prefix`].
+    ///
+    /// [`strip_prefix`]: #method.strip_prefix
     prefix: bool,
 }
 

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -12,11 +12,16 @@ use crate::{router::Router, Endpoint};
 pub struct Route<'a, State> {
     router: &'a mut Router<State>,
     path: String,
+    prefix: bool,
 }
 
 impl<'a, State: 'static> Route<'a, State> {
     pub(crate) fn new(router: &'a mut Router<State>, path: String) -> Route<'a, State> {
-        Route { router, path }
+        Route {
+            router,
+            path,
+            prefix: false,
+        }
     }
 
     /// Extend the route with the given `path`.
@@ -34,6 +39,7 @@ impl<'a, State: 'static> Route<'a, State> {
         Route {
             router: &mut self.router,
             path: p,
+            prefix: false,
         }
     }
 
@@ -42,9 +48,24 @@ impl<'a, State: 'static> Route<'a, State> {
         self
     }
 
+    /// Treat the current path as a prefix, and strip prefixes from requests.
+    ///
+    /// Endpoints will be given a path with the prefix removed.
+    pub fn strip_prefix(&mut self) -> &mut Self {
+        self.prefix = true;
+        self
+    }
+
     /// Add an endpoint for the given HTTP method
     pub fn method(&mut self, method: http::Method, ep: impl Endpoint<State>) -> &mut Self {
-        self.router.add(&self.path, method, ep);
+        if self.prefix {
+            let ep = StripPrefixEndpoint::new(ep);
+            self.router.add(&self.path, method.clone(), ep.clone());
+            let wildcard = self.at("*--tide-path-rest");
+            wildcard.router.add(&wildcard.path, method, ep);
+        } else {
+            self.router.add(&self.path, method, ep);
+        }
         self
     }
 
@@ -100,5 +121,46 @@ impl<'a, State: 'static> Route<'a, State> {
     pub fn trace(&mut self, ep: impl Endpoint<State>) -> &mut Self {
         self.method(http::Method::TRACE, ep);
         self
+    }
+}
+
+#[derive(Debug)]
+struct StripPrefixEndpoint<E>(std::sync::Arc<E>);
+
+impl<E> StripPrefixEndpoint<E> {
+    fn new(ep: E) -> Self {
+        Self(std::sync::Arc::new(ep))
+    }
+}
+
+impl<E> Clone for StripPrefixEndpoint<E> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<State, E: Endpoint<State>> Endpoint<State> for StripPrefixEndpoint<E> {
+    type Fut = E::Fut;
+
+    fn call(&self, mut req: crate::Request<State>) -> Self::Fut {
+        let rest = req.rest().unwrap_or("");
+        let mut path_and_query = format!("/{}", rest);
+        let uri = req.uri();
+        if let Some(query) = uri.query() {
+            path_and_query.push('?');
+            path_and_query.push_str(query);
+        }
+        let mut new_uri = http::Uri::builder();
+        if let Some(scheme) = uri.scheme_part() {
+            new_uri.scheme(scheme.clone());
+        }
+        if let Some(authority) = uri.authority_part() {
+            new_uri.authority(authority.clone());
+        }
+        new_uri.path_and_query(path_and_query.as_str());
+        let new_uri = new_uri.build().unwrap();
+        *req.request.uri_mut() = new_uri;
+
+        self.0.call(req)
     }
 }

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -55,6 +55,8 @@ impl<'a, State: 'static> Route<'a, State> {
     /// Treat the current path as a prefix, and strip prefixes from requests.
     ///
     /// Endpoints will be given a path with the prefix removed.
+    #[cfg(any(feature = "unstable", feature = "docs"))]
+    #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
     pub fn strip_prefix(&mut self) -> &mut Self {
         self.prefix = true;
         self

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -1,18 +1,21 @@
 use async_std::io::prelude::*;
 use futures::executor::block_on;
+use futures::future::BoxFuture;
 use http_service::Body;
 use http_service_mock::make_server;
 
 #[test]
 fn nested() {
     let mut inner = tide::new();
-    // Removing prefixes isn't implemented yet, so write prefixes everywhere
-    inner.at("/foo/foo").get(|_| async { "foo" });
-    inner.at("/foo/bar").get(|_| async { "bar" });
+    inner.at("/foo").get(|_| async { "foo" });
+    inner.at("/bar").get(|_| async { "bar" });
 
     let mut outer = tide::new();
     // Nest the inner app on /foo
-    outer.at("/foo/*").get(inner.into_http_service());
+    outer
+        .at("/foo")
+        .strip_prefix()
+        .get(inner.into_http_service());
 
     let mut server = make_server(outer.into_http_service()).unwrap();
 
@@ -29,4 +32,62 @@ fn nested() {
     assert_eq!(res.status(), 200);
     block_on(res.into_body().read_to_end(&mut buf)).unwrap();
     assert_eq!(&*buf, &*b"bar");
+}
+
+#[test]
+fn nested_middleware() {
+    let echo_path = |req: tide::Request<()>| async move { req.uri().path().to_string() };
+    fn test_middleware(
+        req: tide::Request<()>,
+        next: tide::Next<'_, ()>,
+    ) -> BoxFuture<'_, tide::Response> {
+        Box::pin(async move {
+            let res = next.run(req).await;
+            res.set_header("X-Tide-Test", "1")
+        })
+    }
+
+    let mut app = tide::new();
+    app.at("/foo").nest(|route| {
+        let mut app = tide::new();
+        app.middleware(test_middleware);
+        app.at("/echo").get(echo_path);
+        app.at("/:foo/bar").strip_prefix().get(echo_path);
+        route.strip_prefix().get(app.into_http_service());
+    });
+    app.at("/bar").get(echo_path);
+
+    let mut server = make_server(app.into_http_service()).unwrap();
+
+    let mut buf = Vec::new();
+    let req = http::Request::get("/foo/echo").body(Body::empty()).unwrap();
+    let res = server.simulate(req).unwrap();
+    assert_eq!(
+        res.headers().get("X-Tide-Test"),
+        Some(&"1".parse().unwrap())
+    );
+    assert_eq!(res.status(), 200);
+    block_on(res.into_body().read_to_end(&mut buf)).unwrap();
+    assert_eq!(&*buf, &*b"/echo");
+
+    buf.clear();
+    let req = http::Request::get("/foo/x/bar")
+        .body(Body::empty())
+        .unwrap();
+    let res = server.simulate(req).unwrap();
+    assert_eq!(
+        res.headers().get("X-Tide-Test"),
+        Some(&"1".parse().unwrap())
+    );
+    assert_eq!(res.status(), 200);
+    block_on(res.into_body().read_to_end(&mut buf)).unwrap();
+    assert_eq!(&*buf, &*b"/");
+
+    buf.clear();
+    let req = http::Request::get("/bar").body(Body::empty()).unwrap();
+    let res = server.simulate(req).unwrap();
+    assert_eq!(res.headers().get("X-Tide-Test"), None);
+    assert_eq!(res.status(), 200);
+    block_on(res.into_body().read_to_end(&mut buf)).unwrap();
+    assert_eq!(&*buf, &*b"/bar");
 }

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -1,0 +1,36 @@
+use async_std::io::prelude::*;
+use futures::executor::block_on;
+use http_service::Body;
+use http_service_mock::make_server;
+
+#[test]
+fn nested() {
+    let mut inner = tide::new();
+    // Removing prefixes isn't implemented yet, so write prefixes everywhere
+    inner.at("/foo/foo").get(|_| async { "foo" });
+    inner.at("/foo/bar").get(|_| async { "bar" });
+
+    let mut outer = tide::new();
+    // Nest the inner app on /foo
+    outer.at("/foo/*").get(inner.into_http_service());
+
+    let mut server = make_server(outer.into_http_service()).unwrap();
+
+    let mut buf = Vec::new();
+    let req = http::Request::get("/foo/foo")
+        .body(Body::empty())
+        .unwrap();
+    let res = server.simulate(req).unwrap();
+    assert_eq!(res.status(), 200);
+    block_on(res.into_body().read_to_end(&mut buf)).unwrap();
+    assert_eq!(&*buf, &*b"foo");
+
+    buf.clear();
+    let req = http::Request::get("/foo/bar")
+        .body(Body::empty())
+        .unwrap();
+    let res = server.simulate(req).unwrap();
+    assert_eq!(res.status(), 200);
+    block_on(res.into_body().read_to_end(&mut buf)).unwrap();
+    assert_eq!(&*buf, &*b"bar");
+}

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -17,18 +17,14 @@ fn nested() {
     let mut server = make_server(outer.into_http_service()).unwrap();
 
     let mut buf = Vec::new();
-    let req = http::Request::get("/foo/foo")
-        .body(Body::empty())
-        .unwrap();
+    let req = http::Request::get("/foo/foo").body(Body::empty()).unwrap();
     let res = server.simulate(req).unwrap();
     assert_eq!(res.status(), 200);
     block_on(res.into_body().read_to_end(&mut buf)).unwrap();
     assert_eq!(&*buf, &*b"foo");
 
     buf.clear();
-    let req = http::Request::get("/foo/bar")
-        .body(Body::empty())
-        .unwrap();
+    let req = http::Request::get("/foo/bar").body(Body::empty()).unwrap();
     let res = server.simulate(req).unwrap();
     assert_eq!(res.status(), 200);
     block_on(res.into_body().read_to_end(&mut buf)).unwrap();


### PR DESCRIPTION
~~This is a half-baked version of nesting. Need to strip the path prefix, but I feel this is a good first step!~~ Nevermind, I managed to write necessary mechanics for nesting.

- `HttpService` impl is refactored to use `Endpoint` impl internally.
- Added `Route::strip_prefix`. When used, this will strip the route path prefix from request before passing it to the endpoint.

With this PR, we can finally nest Tide services!

```rust
let mut inner = tide::new();
inner.at("/").get(|_| async { "root" });
inner.at("/foo").get(|_| async { "foo" });
inner.at("/bar").get(|_| async { "bar" });

let mut outer = tide::new();
outer
    .at("/nested")
    .strip_prefix() // catch /nested and /nested/*
    .get(inner.into_http_service()); // the prefix /nested will be stripped here
```

Might need a better name for `strip_prefix`, like `prefixed`?