### PR TITLE
Enable middleware::RequestLogger again

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@
 
 mod endpoint;
 mod error;
-mod middleware;
+pub mod middleware;
 mod redirect;
 mod request;
 mod response;

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -13,13 +13,13 @@ use crate::{Request, Response};
 // mod cookies;
 // mod cors;
 // mod default_headers;
-// mod logger;
+mod logger;
 
 // pub use compression::{Compression, Decompression};
 // pub use cookies::CookiesMiddleware;
 // pub use cors::{Cors, Origin};
 // pub use default_headers::DefaultHeaders;
-// pub use logger::RequestLogger;
+pub use logger::RequestLogger;
 
 /// Middleware that wraps around remaining middleware chain.
 pub trait Middleware<State>: 'static + Send + Sync {


### PR DESCRIPTION
`middleware::RequestLogger` made disabled recently, but it can work also in the newest version. I enabled it again. This will resolve #366 .