### PR TITLE
fix: context moved

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -79,9 +79,8 @@ impl<State> Request<State> {
     }
 
     /// Set a local value.
-    pub fn set_local<T: Send + Sync + 'static>(mut self, val: T) -> Self {
-        self.request.extensions_mut().insert(val);
-        self
+    pub fn set_local<T: Send + Sync + 'static>(&mut self, val: T) -> Option<T> {
+        self.request.extensions_mut().insert(val)
     }
 
     ///  Access app-global state.


### PR DESCRIPTION
If we want to execute multiple times `cx.set_local(value)`.