### PR TITLE
fix docs build

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,7 @@
 //! eventually remove this notice entirely. The goal of Tide is to build a premier HTTP experience
 //! for Async Rust. We have a long journey ahead of us. But we're excited you're here with us!
 
+#![cfg_attr(feature = "docs", feature(doc_cfg))]
 // #![warn(missing_docs)]
 #![warn(missing_debug_implementations, rust_2018_idioms)]
 #![doc(test(attr(deny(rust_2018_idioms, warnings))))]


### PR DESCRIPTION
https://docs.rs/crate/tide/0.5.0 currently isn't building. This fixes that. Thanks!