### PR TITLE
Add Route::all and Route::nest

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -37,7 +37,8 @@ impl<State: 'static> Router<State> {
     }
 
     pub(crate) fn add_all(&mut self, path: &str, ep: impl Endpoint<State>) {
-        self.all_method_router.add(path, Box::new(move |cx| Box::pin(ep.call(cx))))
+        self.all_method_router
+            .add(path, Box::new(move |cx| Box::pin(ep.call(cx))))
     }
 
     pub(crate) fn route(&self, path: &str, method: http::Method) -> Selection<'_, State> {
@@ -50,10 +51,7 @@ impl<State: 'static> Router<State> {
                 endpoint: &**handler,
                 params,
             }
-        } else if let Ok(Match { handler, params }) = self
-            .all_method_router
-            .recognize(path)
-        {
+        } else if let Ok(Match { handler, params }) = self.all_method_router.recognize(path) {
             Selection {
                 endpoint: &**handler,
                 params,

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -54,11 +54,26 @@ impl<'a, State: 'static> Route<'a, State> {
 
     /// Treat the current path as a prefix, and strip prefixes from requests.
     ///
+    /// This method is marked unstable as its name might change in the near future.
+    ///
     /// Endpoints will be given a path with the prefix removed.
     #[cfg(any(feature = "unstable", feature = "docs"))]
     #[cfg_attr(feature = "docs", doc(cfg(unstable)))]
     pub fn strip_prefix(&mut self) -> &mut Self {
         self.prefix = true;
+        self
+    }
+
+    /// Nest a [`Server`] at the current path.
+    ///
+    /// [`Server`]: struct.Server.html
+    pub fn nest_service(&mut self, service: crate::Server<State>) -> &mut Self
+    where
+        State: Send + Sync + 'static,
+    {
+        self.prefix = true;
+        self.all(service.into_http_service());
+        self.prefix = false;
         self
     }
 
@@ -71,6 +86,21 @@ impl<'a, State: 'static> Route<'a, State> {
             wildcard.router.add(&wildcard.path, method, ep);
         } else {
             self.router.add(&self.path, method, ep);
+        }
+        self
+    }
+
+    /// Add an endpoint for all HTTP methods, as a fallback.
+    ///
+    /// Routes with specific HTTP methods will be tried first.
+    pub fn all(&mut self, ep: impl Endpoint<State>) -> &mut Self {
+        if self.prefix {
+            let ep = StripPrefixEndpoint::new(ep);
+            self.router.add_all(&self.path, ep.clone());
+            let wildcard = self.at("*--tide-path-rest");
+            wildcard.router.add_all(&wildcard.path, ep);
+        } else {
+            self.router.add_all(&self.path, ep);
         }
         self
     }

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -47,11 +47,6 @@ impl<'a, State: 'static> Route<'a, State> {
         }
     }
 
-    pub fn nest(&mut self, f: impl FnOnce(&mut Route<'a, State>)) -> &mut Self {
-        f(self);
-        self
-    }
-
     /// Treat the current path as a prefix, and strip prefixes from requests.
     ///
     /// This method is marked unstable as its name might change in the near future.
@@ -67,7 +62,7 @@ impl<'a, State: 'static> Route<'a, State> {
     /// Nest a [`Server`] at the current path.
     ///
     /// [`Server`]: struct.Server.html
-    pub fn nest_service(&mut self, service: crate::Server<State>) -> &mut Self
+    pub fn nest(&mut self, service: crate::Server<State>) -> &mut Self
     where
         State: Send + Sync + 'static,
     {

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -12,7 +12,7 @@ fn nested() {
 
     let mut outer = tide::new();
     // Nest the inner app on /foo
-    outer.at("/foo").nest_service(inner);
+    outer.at("/foo").nest(inner);
 
     let mut server = make_server(outer.into_http_service()).unwrap();
 
@@ -45,13 +45,13 @@ fn nested_middleware() {
     }
 
     let mut app = tide::new();
-    app.at("/foo").nest(|route| {
-        let mut app = tide::new();
-        app.middleware(test_middleware);
-        app.at("/echo").get(echo_path);
-        app.at("/:foo/bar").strip_prefix().get(echo_path);
-        route.nest_service(app);
-    });
+
+    let mut inner_app = tide::new();
+    inner_app.middleware(test_middleware);
+    inner_app.at("/echo").get(echo_path);
+    inner_app.at("/:foo/bar").strip_prefix().get(echo_path);
+    app.at("/foo").nest(inner_app);
+
     app.at("/bar").get(echo_path);
 
     let mut server = make_server(app.into_http_service()).unwrap();

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -12,10 +12,7 @@ fn nested() {
 
     let mut outer = tide::new();
     // Nest the inner app on /foo
-    outer
-        .at("/foo")
-        .strip_prefix()
-        .get(inner.into_http_service());
+    outer.at("/foo").nest_service(inner);
 
     let mut server = make_server(outer.into_http_service()).unwrap();
 
@@ -53,7 +50,7 @@ fn nested_middleware() {
         app.middleware(test_middleware);
         app.at("/echo").get(echo_path);
         app.at("/:foo/bar").strip_prefix().get(echo_path);
-        route.strip_prefix().get(app.into_http_service());
+        route.nest_service(app);
     });
     app.at("/bar").get(echo_path);
 


### PR DESCRIPTION
Follow-up of #364.

`Route::all` catches all HTTP methods. This is mandatory for nesting story, but I missed this somehow.

This PR also adds a convenience method `nest_service`, which turns on nesting flag temporarily and calls `all`.