### PR TITLE
don't print to console by default

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -302,7 +302,7 @@ impl<State: Send + Sync + 'static> Server<State> {
         }
 
         let listener = TcpListener::bind(addr).await?;
-        println!("Server is listening on: http://{}", listener.local_addr()?);
+        log::info!("Server is listening on: http://{}", listener.local_addr()?);
         let http_service = self.into_http_service();
 
         let res = http_service_hyper::Server::builder(listener.incoming())


### PR DESCRIPTION
Follow-up to https://github.com/http-rs/tide/pull/347. Disables console printing by default. Thanks!