### PR TITLE
Add a method to get a mutable reference to the request headers.

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -113,6 +113,11 @@ impl<State> Request<State> {
         self.request.headers()
     }
 
+    /// Access the request's headers for mutation.
+    pub fn headers_mut(&mut self) -> &mut HeaderMap {
+        self.request.headers_mut()
+    }
+
     /// Get an HTTP header.
     ///
     /// # Examples


### PR DESCRIPTION
This is very useful in middleware.