### PR TITLE
Make Endpoint::call generic over lifetime

### DIFF
--- a/examples/json.rs
+++ b/examples/json.rs
@@ -11,8 +11,8 @@ fn main() -> io::Result<()> {
     task::block_on(async {
         let mut app = tide::new();
 
-        app.at("/submit").post(|mut req: tide::Request<()>| {
-            async move {
+        app.at("/submit")
+            .post(|mut req: tide::Request<()>| async move {
                 let cat: Cat = req.body_json().await.unwrap();
                 println!("cat name: {}", cat.name);
 
@@ -20,8 +20,7 @@ fn main() -> io::Result<()> {
                     name: "chashu".into(),
                 };
                 tide::Response::new(200).body_json(&cat).unwrap()
-            }
-        });
+            });
 
         app.listen("127.0.0.1:8080").await?;
         Ok(())

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -52,7 +52,7 @@ impl<'a, State: 'static> Next<'a, State> {
             self.next_middleware = next;
             current.handle(req, self)
         } else {
-            (self.endpoint)(req)
+            self.endpoint.call(req)
         }
     }
 }

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -1,8 +1,4 @@
-use async_std::future;
-use async_std::task::{Context, Poll};
-
-use std::pin::Pin;
-
+use crate::utils::BoxFuture;
 use crate::{Endpoint, Request, Response};
 
 /// Redirect a route to another route.
@@ -21,7 +17,7 @@ use crate::{Endpoint, Request, Response};
 /// app.listen("127.0.0.1:8080").await?;
 /// #
 /// # Ok(()) }) }
-/// ````
+/// ```
 pub fn redirect<State>(location: impl AsRef<str>) -> impl Endpoint<State> {
     let location = location.as_ref().to_owned();
     Redirect { location }
@@ -33,22 +29,8 @@ pub struct Redirect {
 }
 
 impl<State> Endpoint<State> for Redirect {
-    type Fut = Future;
-
-    fn call(&self, _req: Request<State>) -> Self::Fut {
+    fn call<'a>(&'a self, _req: Request<State>) -> BoxFuture<'a, Response> {
         let res = Response::new(307).set_header("Location", &self.location);
-        Future { res: Some(res) }
-    }
-}
-
-/// Future returned from `redirect`.
-pub struct Future {
-    res: Option<Response>,
-}
-
-impl future::Future for Future {
-    type Output = Response;
-    fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
-        Poll::Ready(self.res.take().unwrap())
+        Box::pin(async move { res })
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -37,8 +37,7 @@ impl<State: 'static> Router<State> {
     }
 
     pub(crate) fn add_all(&mut self, path: &str, ep: impl Endpoint<State>) {
-        self.all_method_router
-            .add(path, Box::new(ep))
+        self.all_method_router.add(path, Box::new(ep))
     }
 
     pub(crate) fn route(&self, path: &str, method: http::Method) -> Selection<'_, State> {

--- a/src/router.rs
+++ b/src/router.rs
@@ -33,12 +33,12 @@ impl<State: 'static> Router<State> {
         self.method_map
             .entry(method)
             .or_insert_with(MethodRouter::new)
-            .add(path, Box::new(move |cx| Box::pin(ep.call(cx))))
+            .add(path, Box::new(ep))
     }
 
     pub(crate) fn add_all(&mut self, path: &str, ep: impl Endpoint<State>) {
         self.all_method_router
-            .add(path, Box::new(move |cx| Box::pin(ep.call(cx))))
+            .add(path, Box::new(ep))
     }
 
     pub(crate) fn route(&self, path: &str, method: http::Method) -> Selection<'_, State> {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -361,9 +361,7 @@ impl<State: Sync + Send + 'static> HttpService for Service<State> {
     fn respond(&self, _conn: &mut (), req: http_service::Request) -> Self::ResponseFuture {
         let req = Request::new(self.state.clone(), req, Vec::new());
         let service = self.clone();
-        Box::pin(async move {
-            Ok(service.call(req).await.into())
-        })
+        Box::pin(async move { Ok(service.call(req).await.into()) })
     }
 }
 

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -1,4 +1,5 @@
-use crate::{router::Router, Endpoint};
+use crate::utils::BoxFuture;
+use crate::{router::Router, Endpoint, Response};
 
 /// A handle to a route.
 ///
@@ -172,9 +173,7 @@ impl<E> Clone for StripPrefixEndpoint<E> {
 }
 
 impl<State, E: Endpoint<State>> Endpoint<State> for StripPrefixEndpoint<E> {
-    type Fut = E::Fut;
-
-    fn call(&self, mut req: crate::Request<State>) -> Self::Fut {
+    fn call<'a>(&'a self, mut req: crate::Request<State>) -> BoxFuture<'a, Response> {
         let rest = req.rest().unwrap_or("");
         let mut path_and_query = format!("/{}", rest);
         let uri = req.uri();

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -93,11 +93,9 @@ fn nested_middleware() {
 fn nested_with_different_state() {
     let mut outer = tide::new();
     let mut inner = tide::with_state(42);
-    inner.at("/").get(|req: tide::Request<i32>| {
-        async move {
-            let num = req.state();
-            format!("the number is {}", num)
-        }
+    inner.at("/").get(|req: tide::Request<i32>| async move {
+        let num = req.state();
+        format!("the number is {}", num)
     });
     outer.at("/").get(|_| async move { "Hello, world!" });
     outer.at("/foo").nest(inner);

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -9,11 +9,9 @@ fn hello_world() -> Result<(), surf::Exception> {
     task::block_on(async {
         let server = task::spawn(async {
             let mut app = tide::new();
-            app.at("/").get(|mut req: tide::Request<()>| {
-                async move {
-                    assert_eq!(req.body_string().await.unwrap(), "nori".to_string());
-                    tide::Response::new(200).body_string("says hello".to_string())
-                }
+            app.at("/").get(|mut req: tide::Request<()>| async move {
+                assert_eq!(req.body_string().await.unwrap(), "nori".to_string());
+                tide::Response::new(200).body_string("says hello".to_string())
             });
             app.listen("localhost:8080").await?;
             Result::<(), surf::Exception>::Ok(())
@@ -67,13 +65,11 @@ fn json() -> Result<(), surf::Exception> {
     task::block_on(async {
         let server = task::spawn(async {
             let mut app = tide::new();
-            app.at("/").get(|mut req: tide::Request<()>| {
-                async move {
-                    let mut counter: Counter = req.body_json().await.unwrap();
-                    assert_eq!(counter.count, 0);
-                    counter.count = 1;
-                    tide::Response::new(200).body_json(&counter).unwrap()
-                }
+            app.at("/").get(|mut req: tide::Request<()>| async move {
+                let mut counter: Counter = req.body_json().await.unwrap();
+                assert_eq!(counter.count, 0);
+                counter.count = 1;
+                tide::Response::new(200).body_json(&counter).unwrap()
             });
             app.listen("localhost:8082").await?;
             Result::<(), surf::Exception>::Ok(())


### PR DESCRIPTION
This is a breaking change.

Make `Endpoint::call` generic over lifetime like `Middleware::handle`.