### PR TITLE
Per-route middleware

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -1,7 +1,7 @@
 use route_recognizer::{Match, Params, Router as MethodRouter};
 use std::collections::HashMap;
 
-use crate::endpoint::{DynEndpoint, Endpoint};
+use crate::endpoint::DynEndpoint;
 use crate::utils::BoxFuture;
 use crate::{Request, Response};
 
@@ -29,15 +29,15 @@ impl<State: 'static> Router<State> {
         }
     }
 
-    pub(crate) fn add(&mut self, path: &str, method: http::Method, ep: impl Endpoint<State>) {
+    pub(crate) fn add(&mut self, path: &str, method: http::Method, ep: Box<DynEndpoint<State>>) {
         self.method_map
             .entry(method)
             .or_insert_with(MethodRouter::new)
-            .add(path, Box::new(ep))
+            .add(path, ep)
     }
 
-    pub(crate) fn add_all(&mut self, path: &str, ep: impl Endpoint<State>) {
-        self.all_method_router.add(path, Box::new(ep))
+    pub(crate) fn add_all(&mut self, path: &str, ep: Box<DynEndpoint<State>>) {
+        self.all_method_router.add(path, ep)
     }
 
     pub(crate) fn route(&self, path: &str, method: http::Method) -> Selection<'_, State> {

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -35,8 +35,6 @@ impl<'a, State: 'static> Route<'a, State> {
     }
 
     /// Extend the route with the given `path`.
-    ///
-    /// The returned route won't have any middleware applied.
     pub fn at<'b>(&'b mut self, path: &str) -> Route<'b, State> {
         let mut p = self.path.clone();
 
@@ -51,7 +49,7 @@ impl<'a, State: 'static> Route<'a, State> {
         Route {
             router: &mut self.router,
             path: p,
-            middleware: Vec::new(),
+            middleware: self.middleware.clone(),
             prefix: false,
         }
     }

--- a/tests/route_middleware.rs
+++ b/tests/route_middleware.rs
@@ -1,11 +1,15 @@
-use async_std::io::prelude::*;
-use futures::executor::block_on;
 use futures::future::BoxFuture;
 use http_service::Body;
 use http_service_mock::make_server;
 use tide::Middleware;
 
-struct TestMiddleware(&'static str);
+struct TestMiddleware(&'static str, &'static str);
+
+impl TestMiddleware {
+    fn with_header_name(name: &'static str, value: &'static str) -> Self {
+        Self(name, value)
+    }
+}
 
 impl<State: Send + Sync + 'static> Middleware<State> for TestMiddleware {
     fn handle<'a>(
@@ -15,7 +19,7 @@ impl<State: Send + Sync + 'static> Middleware<State> for TestMiddleware {
     ) -> BoxFuture<'a, tide::Response> {
         Box::pin(async move {
             let res = next.run(req).await;
-            res.set_header("X-Tide-Test", self.0)
+            res.set_header(self.0, self.1)
         })
     }
 }
@@ -28,52 +32,55 @@ async fn echo_path<State>(req: tide::Request<State>) -> String {
 fn route_middleware() {
     let mut app = tide::new();
     let mut foo_route = app.at("/foo");
-    foo_route.middleware(TestMiddleware("foo")).get(echo_path);
-    foo_route
-        .at("/bar")
-        .middleware(TestMiddleware("bar"))
+    foo_route // /foo
+        .middleware(TestMiddleware::with_header_name("X-Foo", "foo"))
         .get(echo_path);
-    foo_route.post(echo_path).reset_middleware().put(echo_path);
+    foo_route
+        .at("/bar") // nested, /foo/bar
+        .middleware(TestMiddleware::with_header_name("X-Bar", "bar"))
+        .get(echo_path);
+    foo_route // /foo
+        .post(echo_path)
+        .reset_middleware()
+        .put(echo_path);
     let mut server = make_server(app.into_http_service()).unwrap();
 
-    let mut buf = Vec::new();
     let req = http::Request::get("/foo").body(Body::empty()).unwrap();
     let res = server.simulate(req).unwrap();
-    assert_eq!(
-        res.headers().get("X-Tide-Test"),
-        Some(&"foo".parse().unwrap())
-    );
-    assert_eq!(res.status(), 200);
-    block_on(res.into_body().read_to_end(&mut buf)).unwrap();
-    assert_eq!(&*buf, &*b"/foo");
+    assert_eq!(res.headers().get("X-Foo"), Some(&"foo".parse().unwrap()));
 
-    buf.clear();
     let req = http::Request::post("/foo").body(Body::empty()).unwrap();
     let res = server.simulate(req).unwrap();
-    assert_eq!(
-        res.headers().get("X-Tide-Test"),
-        Some(&"foo".parse().unwrap())
-    );
-    assert_eq!(res.status(), 200);
-    block_on(res.into_body().read_to_end(&mut buf)).unwrap();
-    assert_eq!(&*buf, &*b"/foo");
+    assert_eq!(res.headers().get("X-Foo"), Some(&"foo".parse().unwrap()));
 
-    buf.clear();
     let req = http::Request::put("/foo").body(Body::empty()).unwrap();
     let res = server.simulate(req).unwrap();
-    assert_eq!(res.headers().get("X-Tide-Test"), None);
-    assert_eq!(res.status(), 200);
-    block_on(res.into_body().read_to_end(&mut buf)).unwrap();
-    assert_eq!(&*buf, &*b"/foo");
+    assert_eq!(res.headers().get("X-Foo"), None);
 
-    buf.clear();
     let req = http::Request::get("/foo/bar").body(Body::empty()).unwrap();
     let res = server.simulate(req).unwrap();
+    assert_eq!(res.headers().get("X-Foo"), Some(&"foo".parse().unwrap()));
+    assert_eq!(res.headers().get("X-Bar"), Some(&"bar".parse().unwrap()));
+}
+
+#[test]
+fn subroute_not_nested() {
+    let mut app = tide::new();
+    app.at("/parent") // /parent
+        .middleware(TestMiddleware::with_header_name("X-Parent", "Parent"))
+        .get(echo_path);
+    app.at("/parent/child") // /parent/child, not nested
+        .middleware(TestMiddleware::with_header_name("X-Child", "child"))
+        .get(echo_path);
+    let mut server = make_server(app.into_http_service()).unwrap();
+
+    let req = http::Request::get("/parent/child")
+        .body(Body::empty())
+        .unwrap();
+    let res = server.simulate(req).unwrap();
+    assert_eq!(res.headers().get("X-Parent"), None);
     assert_eq!(
-        res.headers().get("X-Tide-Test"),
-        Some(&"bar".parse().unwrap())
+        res.headers().get("X-Child"),
+        Some(&"child".parse().unwrap())
     );
-    assert_eq!(res.status(), 200);
-    block_on(res.into_body().read_to_end(&mut buf)).unwrap();
-    assert_eq!(&*buf, &*b"/foo/bar");
 }

--- a/tests/route_middleware.rs
+++ b/tests/route_middleware.rs
@@ -1,0 +1,81 @@
+use async_std::io::prelude::*;
+use futures::executor::block_on;
+use futures::future::BoxFuture;
+use http_service::Body;
+use http_service_mock::make_server;
+use tide::Middleware;
+
+struct TestMiddleware(&'static str);
+
+impl<State: Send + Sync + 'static> Middleware<State> for TestMiddleware {
+    fn handle<'a>(
+        &'a self,
+        req: tide::Request<State>,
+        next: tide::Next<'a, State>,
+    ) -> BoxFuture<'a, tide::Response> {
+        Box::pin(async move {
+            let res = next.run(req).await;
+            res.set_header("X-Tide-Test", self.0)
+        })
+    }
+}
+
+async fn echo_path<State>(req: tide::Request<State>) -> String {
+    req.uri().path().to_string()
+}
+
+#[test]
+fn route_middleware() {
+    let mut app = tide::new();
+    let mut foo_route = app.at("/foo");
+    foo_route.middleware(TestMiddleware("foo"))
+        .get(echo_path);
+    foo_route.at("/bar")
+        .middleware(TestMiddleware("bar"))
+        .get(echo_path);
+    foo_route.post(echo_path)
+        .reset_middleware()
+        .put(echo_path);
+    let mut server = make_server(app.into_http_service()).unwrap();
+
+    let mut buf = Vec::new();
+    let req = http::Request::get("/foo").body(Body::empty()).unwrap();
+    let res = server.simulate(req).unwrap();
+    assert_eq!(
+        res.headers().get("X-Tide-Test"),
+        Some(&"foo".parse().unwrap())
+    );
+    assert_eq!(res.status(), 200);
+    block_on(res.into_body().read_to_end(&mut buf)).unwrap();
+    assert_eq!(&*buf, &*b"/foo");
+
+    buf.clear();
+    let req = http::Request::post("/foo").body(Body::empty()).unwrap();
+    let res = server.simulate(req).unwrap();
+    assert_eq!(
+        res.headers().get("X-Tide-Test"),
+        Some(&"foo".parse().unwrap())
+    );
+    assert_eq!(res.status(), 200);
+    block_on(res.into_body().read_to_end(&mut buf)).unwrap();
+    assert_eq!(&*buf, &*b"/foo");
+
+    buf.clear();
+    let req = http::Request::put("/foo").body(Body::empty()).unwrap();
+    let res = server.simulate(req).unwrap();
+    assert_eq!(res.headers().get("X-Tide-Test"), None);
+    assert_eq!(res.status(), 200);
+    block_on(res.into_body().read_to_end(&mut buf)).unwrap();
+    assert_eq!(&*buf, &*b"/foo");
+
+    buf.clear();
+    let req = http::Request::get("/foo/bar").body(Body::empty()).unwrap();
+    let res = server.simulate(req).unwrap();
+    assert_eq!(
+        res.headers().get("X-Tide-Test"),
+        Some(&"bar".parse().unwrap())
+    );
+    assert_eq!(res.status(), 200);
+    block_on(res.into_body().read_to_end(&mut buf)).unwrap();
+    assert_eq!(&*buf, &*b"/foo/bar");
+}

--- a/tests/route_middleware.rs
+++ b/tests/route_middleware.rs
@@ -28,14 +28,12 @@ async fn echo_path<State>(req: tide::Request<State>) -> String {
 fn route_middleware() {
     let mut app = tide::new();
     let mut foo_route = app.at("/foo");
-    foo_route.middleware(TestMiddleware("foo"))
-        .get(echo_path);
-    foo_route.at("/bar")
+    foo_route.middleware(TestMiddleware("foo")).get(echo_path);
+    foo_route
+        .at("/bar")
         .middleware(TestMiddleware("bar"))
         .get(echo_path);
-    foo_route.post(echo_path)
-        .reset_middleware()
-        .put(echo_path);
+    foo_route.post(echo_path).reset_middleware().put(echo_path);
     let mut server = make_server(app.into_http_service()).unwrap();
 
     let mut buf = Vec::new();


### PR DESCRIPTION
This PR adds per-route middleware support. Current design is as follows:

* `Route::middleware` applies given middleware to the route.
* Following `Route::method` (and `Route::all`) will apply middleware given before.
* Middleware list for the route can be reset using `Route::reset_middleware`.
* When `Route::at` is called, per-route middleware applied to the parent will be applied to the child route by default. This can be reset using `.reset_middleware()`.

Feel free to comment if there is better design!

---

Closes #320.