### PR TITLE
Update async-std and bytes dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,15 +38,15 @@ route-recognizer = "0.1.13"
 serde = "1.0.102"
 serde_json = "1.0.41"
 serde_qs = "0.5.0"
-async-std = { version = "1.0.1", features = ["unstable"] }
+async-std = { version = "1.5" }
 pin-project-lite = "0.1.0"
 mime = "0.3.14"
 cookie = { version="0.12.0", features = ["percent-encode"]}
 
 [dev-dependencies]
-async-std = { version = "1.0.1", features = ["unstable", "attributes"] }
+async-std = { version = "1.5", features = ["unstable", "attributes"] }
 basic-cookies = "0.1.3"
-bytes = "0.4.12"
+bytes = "0.5"
 futures-fs = "0.0.5"
 futures-util = { version = "0.3.0", features = ["compat"] }
 http-service-mock = "0.4.0"


### PR DESCRIPTION
We can tackle hyper 0.13 next, but let's get the low hanging fruit first.