### PR TITLE
Replace utils::BoxFuture with futures::future::BoxFuture

### DIFF
--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -1,6 +1,7 @@
 use async_std::future::Future;
 
-use crate::utils::BoxFuture;
+use futures::future::BoxFuture;
+
 use crate::{response::IntoResponse, Request, Response};
 
 /// An HTTP request handler.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,6 @@ mod redirect;
 mod request;
 mod response;
 mod router;
-mod utils;
 
 pub mod prelude;
 pub mod server;

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,12 +1,13 @@
 //! Middleware types.
 
+use futures::future::BoxFuture;
+
 use std::sync::Arc;
 
 #[doc(inline)]
 pub use http_service::HttpService;
 
 use crate::endpoint::DynEndpoint;
-use crate::utils::BoxFuture;
 use crate::{Request, Response};
 
 // mod compression;

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -1,4 +1,5 @@
-use crate::utils::BoxFuture;
+use futures::future::BoxFuture;
+
 use crate::{Endpoint, Request, Response};
 
 /// Redirect a route to another route.

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,8 +1,9 @@
 use route_recognizer::{Match, Params, Router as MethodRouter};
 use std::collections::HashMap;
 
+use futures::future::BoxFuture;
+
 use crate::endpoint::{DynEndpoint, Endpoint};
-use crate::utils::BoxFuture;
 use crate::{Request, Response};
 
 /// The routing table used by `Server`

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -9,9 +9,10 @@ use async_std::task::{Context, Poll};
 
 use http_service::HttpService;
 
+use futures::future::BoxFuture;
+
 use std::pin::Pin;
 
-use crate::utils::BoxFuture;
 use crate::{
     middleware::{Middleware, Next},
     router::{Router, Selection},

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -1,4 +1,5 @@
-use crate::utils::BoxFuture;
+use futures::future::BoxFuture;
+
 use crate::{router::Router, Endpoint, Response};
 
 /// A handle to a route.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,0 @@
-use std::future::Future;
-use std::pin::Pin;
-
-/// An owned dynamically typed [`Future`] for use in cases where you can't
-/// statically type your result or need to add some indirection.
-pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;


### PR DESCRIPTION
Currently, `utils` module only exists for `BoxFuture` type alias declaration.

However, since:

* this type alias exists already in `futures` crate
* `futures` crate is already a dependency of `tide`

all references to `utils::BoxFuture` can be replaced with `futures::future::BoxFuture` and the `utils` module deleted.