### PR TITLE
Uncomment impl IntoResponse for Result<T: IntoResponse, U: IntoResponse>

### DIFF
--- a/src/response/into_response.rs
+++ b/src/response/into_response.rs
@@ -69,23 +69,23 @@ impl IntoResponse for &'_ str {
 //     }
 // }
 
-// impl<T: IntoResponse, U: IntoResponse> IntoResponse for Result<T, U> {
-//     fn into_response(self) -> Response {
-//         match self {
-//             Ok(r) => r.into_response(),
-//             Err(r) => {
-//                 let res = r.into_response();
-//                 if res.status().is_success() {
-//                     panic!(
-//                         "Attempted to yield error response with success code {:?}",
-//                         res.status()
-//                     )
-//                 }
-//                 res
-//             }
-//         }
-//     }
-// }
+impl<T: IntoResponse, U: IntoResponse> IntoResponse for Result<T, U> {
+    fn into_response(self) -> Response {
+        match self {
+            Ok(r) => r.into_response(),
+            Err(r) => {
+                let res = r.into_response();
+                if res.status().is_success() {
+                    panic!(
+                        "Attempted to yield error response with success code {:?}",
+                        res.status()
+                    )
+                }
+                res
+            }
+        }
+    }
+}
 
 impl IntoResponse for Response {
     fn into_response(self) -> Response {


### PR DESCRIPTION
Was commented-out in 3aea1d9baba1a13b by @yoshuawuyts.

Not sure shy it was commented out. Maybe a different approach was to be pursued?

My motivation to uncomment was that I want my endpoint handler to have Result<T, E> return type, so that I can use `?` operator directly in it. I was not able to implement this in my crate due to Rust orphan rules.

If this is a desired change, I can add tests. If not, I'd be glad for any advice how to achieve the goal differently.