### PR TITLE
Static files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ serde = { version = "1.0.102", features = ["derive"] }
 structopt = "0.3.3"
 surf = "2.0.0-alpha.1"
 futures = "0.3.1"
+femme = "1.3.0"
 
 [[test]]
 name = "nested"

--- a/examples/static_file.rs
+++ b/examples/static_file.rs
@@ -1,0 +1,12 @@
+use async_std::task;
+
+fn main() -> Result<(), std::io::Error> {
+    femme::start(log::LevelFilter::Info).unwrap();
+    task::block_on(async {
+        let mut app = tide::new();
+        app.at("/").get(|_| async move { Ok("visit /src/*") });
+        app.at("/src").serve_dir("src/")?;
+        app.listen("127.0.0.1:8080").await?;
+        Ok(())
+    })
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -302,6 +302,11 @@ impl<State> Request<State> {
         let locked_jar = cookie_data.content.read().unwrap();
         locked_jar.get(name).cloned()
     }
+
+    /// Get the length of the body.
+    pub fn len(&self) -> Option<usize> {
+        self.request.len()
+    }
 }
 
 impl<State> Read for Request<State> {

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -64,6 +64,11 @@ impl Response {
         self
     }
 
+    /// Get the length of the body.
+    pub fn len(&self) -> Option<usize> {
+        self.res.len()
+    }
+
     /// Insert an HTTP header.
     pub fn set_header(
         mut self,
@@ -119,6 +124,11 @@ impl Response {
         self.res
             .set_body(http_types::Body::from_reader(reader, None));
         self.set_mime(mime::APPLICATION_OCTET_STREAM)
+    }
+
+    /// Set the body reader.
+    pub fn set_body(&mut self, body: impl Into<Body>) {
+        self.res.set_body(body);
     }
 
     /// Encode a struct as a form and set as the response body.

--- a/src/server/serve_dir.rs
+++ b/src/server/serve_dir.rs
@@ -1,0 +1,79 @@
+use async_std::fs::File;
+use async_std::io::BufReader;
+use http_types::{Body, StatusCode};
+
+use crate::{Endpoint, Request, Response, Result};
+
+use std::path::{Path, PathBuf};
+
+type BoxFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + 'a + Send>>;
+pub struct ServeDir {
+    prefix: String,
+    dir: PathBuf,
+}
+
+impl ServeDir {
+    /// Create a new instance of `ServeDir`.
+    pub(crate) fn new(prefix: String, dir: PathBuf) -> Self {
+        Self { prefix, dir }
+    }
+}
+
+impl<State> Endpoint<State> for ServeDir {
+    fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, Result<Response>> {
+        let path = req.uri().path();
+        let path = path.replacen(&self.prefix, "", 1);
+        let path = path.trim_start_matches('/');
+        let mut dir = self.dir.clone();
+        for p in Path::new(path) {
+            dir.push(&p);
+        }
+        log::info!("Requested file: {:?}", dir);
+
+        Box::pin(async move {
+            let file = match async_std::fs::canonicalize(&dir).await {
+                Err(_) => {
+                    // This needs to return the same status code as the
+                    // unauthorized case below to ensure we don't leak
+                    // information of which files exist to adversaries.
+                    log::warn!("File not found: {:?}", dir);
+                    return Ok(Response::new(StatusCode::NotFound));
+                }
+                Ok(mut file_path) => {
+                    // Verify this is a sub-path of the original dir.
+                    let mut file_iter = (&mut file_path).iter();
+                    if !dir.iter().all(|lhs| Some(lhs) == file_iter.next()) {
+                        // This needs to return the same status code as the
+                        // 404 case above to ensure we don't leak
+                        // information about the local fs to adversaries.
+                        log::warn!("Unauthorized attempt to read: {:?}", file_path);
+                        return Ok(Response::new(StatusCode::NotFound));
+                    }
+
+                    // Open the file and send back the contents.
+                    match File::open(&file_path).await {
+                        Ok(file) => file,
+                        Err(_) => {
+                            log::warn!("Could not open {:?}", file_path);
+                            return Ok(Response::new(StatusCode::InternalServerError));
+                        }
+                    }
+                }
+            };
+
+            let len = match file.metadata().await {
+                Ok(metadata) => metadata.len() as usize,
+                Err(_) => {
+                    log::warn!("Could not retrieve metadata");
+                    return Ok(Response::new(StatusCode::InternalServerError));
+                }
+            };
+
+            let body = Body::from_reader(BufReader::new(file), Some(len));
+            // TODO: fix related bug where async-h1 crashes on large files
+            let mut res = Response::new(StatusCode::Ok);
+            res.set_body(body);
+            Ok(res)
+        })
+    }
+}

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -3,6 +3,7 @@ use http_service_mock::make_server;
 use http_types::headers::{HeaderName, HeaderValue};
 use http_types::{Method, Request, Url};
 use std::str::FromStr;
+use tide::{Middleware, Next};
 
 #[async_std::test]
 async fn nested() {
@@ -36,24 +37,37 @@ async fn nested() {
 #[async_std::test]
 async fn nested_middleware() {
     let echo_path = |req: tide::Request<()>| async move { Ok(req.uri().path().to_string()) };
-    fn test_middleware(
-        req: tide::Request<()>,
-        next: tide::Next<'_, ()>,
-    ) -> BoxFuture<'_, tide::Result<tide::Response>> {
-        Box::pin(async move {
-            let res = next.run(req).await?;
-            let res = res.set_header(
-                HeaderName::from_ascii("X-Tide-Test".to_owned().into_bytes()).unwrap(),
-                "1",
-            );
-            Ok(res)
-        })
+
+    #[derive(Debug, Clone, Default)]
+    pub struct TestMiddleware;
+
+    impl TestMiddleware {
+        pub fn new() -> Self {
+            Self {}
+        }
+    }
+
+    impl<State: Send + Sync + 'static> Middleware<State> for TestMiddleware {
+        fn handle<'a>(
+            &'a self,
+            req: tide::Request<State>,
+            next: Next<'a, State>,
+        ) -> BoxFuture<'a, tide::Result<tide::Response>> {
+            Box::pin(async move {
+                let res = next.run(req).await?;
+                let res = res.set_header(
+                    HeaderName::from_ascii("X-Tide-Test".to_owned().into_bytes()).unwrap(),
+                    "1",
+                );
+                Ok(res)
+            })
+        }
     }
 
     let mut app = tide::new();
 
     let mut inner_app = tide::new();
-    inner_app.middleware(test_middleware);
+    inner_app.middleware(TestMiddleware::new());
     inner_app.at("/echo").get(echo_path);
     inner_app.at("/:foo/bar").strip_prefix().get(echo_path);
     app.at("/foo").nest(inner_app);

--- a/tests/route_middleware.rs
+++ b/tests/route_middleware.rs
@@ -4,6 +4,7 @@ use http_types::{headers::HeaderName, Method, Request};
 use std::convert::TryInto;
 use tide::Middleware;
 
+#[derive(Debug)]
 struct TestMiddleware(HeaderName, &'static str);
 
 impl TestMiddleware {


### PR DESCRIPTION
Init static file serving support. This depends on https://github.com/http-rs/tide/pull/414.

```rust
#[async_std::main]
async fn main() -> tide::Result<()> {
    let mut app = tide::new();
    app.at("/").serve_dir("/public");
    app.listen("127.0.0.1:8080").await?;
    Ok(())
}
```