### PR TITLE
fix(response): do not set the same header twice with body_string #365

### DIFF
--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -93,7 +93,11 @@ impl Response {
     /// The encoding is set to `text/plain; charset=utf-8`.
     pub fn body_string(mut self, string: String) -> Self {
         *self.res.body_mut() = string.into_bytes().into();
-        self.set_mime(mime::TEXT_PLAIN_UTF_8)
+        if self.res.headers().get("Content-Type").is_none() {
+            self.set_mime(mime::TEXT_PLAIN_UTF_8)
+        } else {
+            self
+        }
     }
 
     /// Pass a string as the request body.


### PR DESCRIPTION
I tried to solve the issue #365 let me know if I should implement this in another way.

Signed-off-by: Benjamin Coenen <5719034+bnjjj@users.noreply.github.com>