### PR TITLE
Add optional simd-json support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ futures = { version = "0.3.1", optional = true }
 http = { version = "0.2.0", optional = true }
 tokio = { version = "0.2.13", optional = true }
 url = "2.1.1"
+simd-json = { version = "0.3.2", optional = true }
 
 [dev-dependencies]
 async-std = { version = "1.4.0", features = ["unstable", "attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ futures = { version = "0.3.1", optional = true }
 http = { version = "0.2.0", optional = true }
 tokio = { version = "0.2.13", optional = true }
 url = "2.1.1"
-simd-json = { version = "0.3.2", optional = true }
+simd-json = { version = "0.3.7", optional = true }
 
 [dev-dependencies]
 async-std = { version = "1.4.0", features = ["unstable", "attributes"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,6 +166,9 @@
 //! changes we make. Also as time goes on you may find that fewer and fewer changes occur, until we
 //! eventually remove this notice entirely. The goal of Tide is to build a premier HTTP experience
 //! for Async Rust. We have a long journey ahead of us. But we're excited you're here with us!
+//!
+//! # Features
+//! - __`simd-json`:__ uses simd-json instead of serde for json parsing. Note: you got to pass `-C target-feature=+avx,+avx2,+sse4.2` to `RUSTFLAGS` if this is enabled.
 
 #![cfg_attr(feature = "docs", feature(doc_cfg))]
 // #![warn(missing_docs)]

--- a/src/request.rs
+++ b/src/request.rs
@@ -270,7 +270,8 @@ impl<State> Request<State> {
         {
             let mut body_bytes = self.body_bytes().await?;
             Ok(simd_json::from_slice(&mut body_bytes).map_err(io::Error::from)?)
-        }    }
+        }
+    }
 
     /// Get the URL querystring.
     pub fn query<'de, T: Deserialize<'de>>(&'de self) -> Result<T, crate::Error> {

--- a/src/request.rs
+++ b/src/request.rs
@@ -261,9 +261,16 @@ impl<State> Request<State> {
     /// If the body cannot be interpreted as valid json for the target type `T`,
     /// an `Err` is returned.
     pub async fn body_json<T: serde::de::DeserializeOwned>(&mut self) -> std::io::Result<T> {
-        let body_bytes = self.body_bytes().await?;
-        Ok(serde_json::from_slice(&body_bytes).map_err(|_| std::io::ErrorKind::InvalidData)?)
-    }
+        #[cfg(not(feature = "simd-json"))]
+        {
+            let body_bytes = self.body_bytes().await?;
+            Ok(serde_json::from_slice(&body_bytes).map_err(|_| std::io::ErrorKind::InvalidData)?)
+        }
+        #[cfg(feature = "simd-json")]
+        {
+            let mut body_bytes = self.body_bytes().await?;
+            Ok(simd_json::from_slice(&mut body_bytes).map_err(io::Error::from)?)
+        }    }
 
     /// Get the URL querystring.
     pub fn query<'de, T: Deserialize<'de>>(&'de self) -> Result<T, crate::Error> {

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -142,8 +142,15 @@ impl Response {
     /// # Mime
     ///
     /// The encoding is set to `application/json`.
+    #[cfg(not(feature = "simd-json"))]
     pub fn body_json(mut self, json: &impl Serialize) -> serde_json::Result<Self> {
         self.res.set_body(serde_json::to_vec(json)?);
+        Ok(self.set_mime(mime::APPLICATION_JSON))
+    }
+
+    #[cfg(feature = "simd-json")]
+    pub fn body_json(mut self, json: &impl Serialize) -> simd_json::Result<Self> {
+        *self.res.body_mut() = simd_json::to_vec(json)?.into();
         Ok(self.set_mime(mime::APPLICATION_JSON))
     }
 


### PR DESCRIPTION
This adds the simd-json as a feature flag to use SIMD accelerated JSON parsing.

This might warrant a note in the README about cpu features required (AVX2 or SSE4.1) to use the flag but I didn't find a section in the README on features and wasn't sure if you want one added so I'll just open this for suggestions :).

( same as https://github.com/http-rs/surf/pull/154 )