### PR TITLE
Add Response::redirect

### DIFF
--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -1,6 +1,4 @@
 use crate::utils::BoxFuture;
-use http_types::StatusCode;
-
 use crate::{Endpoint, Request, Response};
 
 /// Redirect a route to another route.
@@ -32,8 +30,7 @@ pub struct Redirect {
 
 impl<State> Endpoint<State> for Redirect {
     fn call<'a>(&'a self, _req: Request<State>) -> BoxFuture<'a, crate::Result<Response>> {
-        let res = Response::new(StatusCode::TemporaryRedirect)
-            .set_header("location".parse().unwrap(), self.location.clone());
+        let res = Response::redirect_temp(&self.location);
         Box::pin(async move { Ok(res) })
     }
 }

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -53,6 +53,52 @@ impl Response {
         }
     }
 
+    /// Creates a response that represents a permanent redirect to `location`.
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use tide::{Response, Request};
+    /// # fn canonicalize(uri: &url::Url) -> Option<&url::Url> { None }
+    /// # #[allow(dead_code)]
+    /// async fn route_handler(request: Request<()>) -> tide::Result<Response> {
+    ///     if let Some(canonical_redirect) = canonicalize(request.uri()) {
+    ///         Ok(Response::redirect_perm(canonical_redirect))
+    ///     } else {
+    ///          //...
+    /// #        Ok(Response::new(http_types::StatusCode::Ok)) // ...
+    ///     }
+    /// }
+    /// ```
+    pub fn redirect_perm(location: impl AsRef<str>) -> Self {
+        Response::new(StatusCode::PermanentRedirect)
+            .set_header("location".parse().unwrap(), location)
+    }
+
+    /// Creates a response that represents a temporary redirect to `location`.
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use tide::{Response, Request};
+    /// # fn special_sale_today() -> Option<String> { None }
+    /// # #[allow(dead_code)]
+    /// async fn route_handler(request: Request<()>) -> tide::Result<Response> {
+    ///     if let Some(sale_url) = special_sale_today() {
+    ///         Ok(Response::redirect_temp(sale_url))
+    ///     } else {
+    ///         //...
+    /// #       Ok(Response::new(http_types::StatusCode::Ok)) //...
+    ///     }
+    /// }
+    /// ```
+    pub fn redirect_temp(location: impl AsRef<str>) -> Self {
+        Response::new(StatusCode::TemporaryRedirect)
+            .set_header("location".parse().unwrap(), location)
+    }
+
     /// Returns the statuscode.
     pub fn status(&self) -> http_types::StatusCode {
         self.res.status()


### PR DESCRIPTION
The Redirect endpoint is a special case ("always redirect") of the broader need to conditionally redirect based on some logic within a route handler. This PR moves the creation of a temporary redirect into Response and uses that in the Redirect endpoint. Accidentally, this also eliminates a string clone, since set_header only needs a &str.