### PR TITLE
Add Response::file_body

### DIFF
--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -148,7 +148,7 @@ impl Response {
     }
 
     /// Send a File as the response body.
-    pub async fn body_file(mut self, file: async_std::fs::File) -> http_types::Result<Response> {
+    pub async fn body_file(mut self, file: async_std::fs::File) -> async_std::io::Result<Response> {
         let metadata = file.metadata().await?;
         let len = metadata.len() as usize;
         let reader = async_std::io::BufReader::new(file);

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -147,6 +147,16 @@ impl Response {
         Ok(self.set_mime(mime::APPLICATION_JSON))
     }
 
+    /// Send a File as the response body.
+    pub async fn body_file(mut self, file: async_std::fs::File) -> http_types::Result<Response> {
+        let metadata = file.metadata().await?;
+        let len = metadata.len() as usize;
+        let reader = async_std::io::BufReader::new(file);
+        self.res
+            .set_body(http_types::Body::from_reader(reader, Some(len)));
+        Ok(self)
+    }
+
     // fn body_multipart(&mut self) -> BoxTryFuture<Multipart<Cursor<Vec<u8>>>> {
     //     const BOUNDARY: &str = "boundary=";
     //     let boundary = self.headers().get("content-type").and_then(|ct| {


### PR DESCRIPTION
This PR adds a method to tide::Response which incrementally improves sending a file with a content-size.

Before this change:
```rust
        app.at("/some_file").get(|_| async {
            let path = "./some_file.txt";
            let file = async_std::fs::File::open(path).await?;
            let size = file.metadata().await?.len();
            Response::new(StatusCode::Ok)
                .body(BufReader::new(file))
                .set_header(headers::CONTENT_LENGTH, size.to_string())
                .set_mime(mime_guess::from_path(path).first()?)
        });
```

After this change:
```rust
        app.at("/some_file").get(|_| async {
            let path = "./some_file.txt";
            let file = async_std::fs::File::open(path).await?;
            Response::new(StatusCode::Ok)
                .body_file(file).await?
                .set_mime(mime_guess::from_path(path).first()?)
        });
```

This PR also passes the length into the http client along with the body, allowing for optimizations or conditional logic based on the size. It would be really nice as a user of tide if body_file also guessed mime type, but this does not attempt to do that.