### PR TITLE
Remove intermediate Service struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,10 +179,10 @@ mod redirect;
 mod request;
 mod response;
 mod router;
+mod server;
 mod utils;
 
 pub mod prelude;
-pub mod server;
 
 pub use endpoint::Endpoint;
 pub use redirect::redirect;

--- a/src/middleware/cors.rs
+++ b/src/middleware/cors.rs
@@ -288,7 +288,7 @@ mod test {
                 .allow_credentials(true),
         );
 
-        let mut server = make_server(app.into_http_service()).unwrap();
+        let mut server = make_server(app).unwrap();
 
         let mut req = http_types::Request::new(http_types::Method::Options, endpoint_url());
         req.insert_header(http_types::headers::ORIGIN, ALLOW_ORIGIN)
@@ -327,7 +327,7 @@ mod test {
         let mut app = app();
         app.middleware(Cors::new());
 
-        let mut server = make_server(app.into_http_service()).unwrap();
+        let mut server = make_server(app).unwrap();
         let res = server.simulate(request()).unwrap();
 
         assert_eq!(res.status(), 200);
@@ -349,7 +349,7 @@ mod test {
                 .expose_headers(EXPOSE_HEADER.parse::<HeaderValue>().unwrap()),
         );
 
-        let mut server = make_server(app.into_http_service()).unwrap();
+        let mut server = make_server(app).unwrap();
         let res = server.simulate(request()).unwrap();
 
         assert_eq!(res.status(), 200);
@@ -364,7 +364,7 @@ mod test {
         let mut app = app();
         app.middleware(Cors::new().allow_credentials(true));
 
-        let mut server = make_server(app.into_http_service()).unwrap();
+        let mut server = make_server(app).unwrap();
         let res = server.simulate(request()).unwrap();
 
         assert_eq!(res.status(), 200);
@@ -381,7 +381,7 @@ mod test {
         let mut app = app();
         let origins = vec![ALLOW_ORIGIN, "foo.com", "bar.com"];
         app.middleware(Cors::new().allow_origin(origins.clone()));
-        let mut server = make_server(app.into_http_service()).unwrap();
+        let mut server = make_server(app).unwrap();
 
         for origin in origins {
             let mut request = http_types::Request::new(http_types::Method::Get, endpoint_url());
@@ -406,7 +406,7 @@ mod test {
 
         let request = http_types::Request::new(http_types::Method::Get, endpoint_url());
 
-        let mut server = make_server(app.into_http_service()).unwrap();
+        let mut server = make_server(app).unwrap();
         let res = server.simulate(request).unwrap();
 
         assert_eq!(res.status(), 200);
@@ -422,7 +422,7 @@ mod test {
             .insert_header(http_types::headers::ORIGIN, "unauthorize-origin.net")
             .unwrap();
 
-        let mut server = make_server(app.into_http_service()).unwrap();
+        let mut server = make_server(app).unwrap();
         let res = server.simulate(request).unwrap();
 
         assert_eq!(res.status(), 401);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -10,12 +10,10 @@ use http_service::HttpService;
 
 use std::pin::Pin;
 
+use crate::middleware::{Middleware, Next};
+use crate::router::{Router, Selection};
 use crate::utils::BoxFuture;
-use crate::{
-    middleware::{Middleware, Next},
-    router::{Router, Selection},
-    Endpoint, Request, Response,
-};
+use crate::{Endpoint, Request, Response};
 
 mod route;
 
@@ -136,9 +134,9 @@ pub use route::Route;
 ///// ```
 #[allow(missing_debug_implementations)]
 pub struct Server<State> {
-    router: Router<State>,
-    middleware: Vec<Arc<dyn Middleware<State>>>,
-    state: State,
+    router: Arc<Router<State>>,
+    state: Arc<State>,
+    middleware: Arc<Vec<Arc<dyn Middleware<State>>>>,
 }
 
 impl Server<()> {
@@ -201,11 +199,11 @@ impl<State: Send + Sync + 'static> Server<State> {
     /// ```
     pub fn with_state(state: State) -> Server<State> {
         Server {
-            router: Router::new(),
-            middleware: vec![Arc::new(
+            router: Arc::new(Router::new()),
+            middleware: Arc::new(vec![Arc::new(
                 crate::middleware::cookies::CookiesMiddleware::new(),
-            )],
-            state,
+            )]),
+            state: Arc::new(state),
         }
     }
 
@@ -256,7 +254,8 @@ impl<State: Send + Sync + 'static> Server<State> {
     /// match or not, which means that the order of adding resources has no
     /// effect.
     pub fn at<'a>(&'a mut self, path: &'a str) -> Route<'a, State> {
-        Route::new(&mut self.router, path.to_owned())
+        let router = Arc::get_mut(&mut self.router).unwrap();
+        Route::new(router, path.to_owned())
     }
 
     /// Add middleware to an application.
@@ -270,7 +269,8 @@ impl<State: Send + Sync + 'static> Server<State> {
     /// Middleware can only be added at the "top level" of an application,
     /// and is processed in the order in which it is applied.
     pub fn middleware(&mut self, m: impl Middleware<State>) -> &mut Self {
-        self.middleware.push(Arc::new(m));
+        let middleware = Arc::get_mut(&mut self.middleware).unwrap();
+        middleware.push(Arc::new(m));
         self
     }
 
@@ -278,12 +278,13 @@ impl<State: Send + Sync + 'static> Server<State> {
     ///
     /// This lower-level method lets you host a Tide application within an HTTP
     /// server of your choice, via the `http_service` interface crate.
-    pub fn into_http_service(self) -> Service<State> {
-        Service {
-            router: Arc::new(self.router),
-            state: Arc::new(self.state),
-            middleware: Arc::new(self.middleware),
-        }
+    pub fn into_http_service(self) -> Self {
+        self
+        // Service {
+        //     router: Arc::new(self.router),
+        //     state: Arc::new(self.state),
+        //     middleware: Arc::new(self.middleware),
+        // }
     }
 
     /// Asynchronously serve the app at the given address.
@@ -301,18 +302,7 @@ impl<State: Send + Sync + 'static> Server<State> {
     }
 }
 
-/// An instantiated Tide server.
-///
-/// This type is useful only in conjunction with the [`HttpService`] trait,
-/// i.e. for hosting a Tide app within some custom HTTP server.
-#[allow(missing_debug_implementations)]
-pub struct Service<State> {
-    router: Arc<Router<State>>,
-    state: Arc<State>,
-    middleware: Arc<Vec<Arc<dyn Middleware<State>>>>,
-}
-
-impl<State> Clone for Service<State> {
+impl<State> Clone for Server<State> {
     fn clone(&self) -> Self {
         Self {
             router: self.router.clone(),
@@ -333,7 +323,7 @@ impl Future for ReadyFuture {
     }
 }
 
-impl<State: Sync + Send + 'static> HttpService for Service<State> {
+impl<State: Sync + Send + 'static> HttpService for Server<State> {
     type Connection = ();
     type ConnectionFuture = ReadyFuture;
     type ConnectionError = io::Error;
@@ -373,7 +363,7 @@ impl<State: Sync + Send + 'static> HttpService for Service<State> {
 }
 
 impl<State: Sync + Send + 'static, InnerState: Sync + Send + 'static> Endpoint<State>
-    for Service<InnerState>
+    for Server<InnerState>
 {
     fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, crate::Result<Response>> {
         let Request {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -254,7 +254,8 @@ impl<State: Send + Sync + 'static> Server<State> {
     /// match or not, which means that the order of adding resources has no
     /// effect.
     pub fn at<'a>(&'a mut self, path: &'a str) -> Route<'a, State> {
-        let router = Arc::get_mut(&mut self.router).unwrap();
+        let router = Arc::get_mut(&mut self.router)
+            .expect("Registering routes is not possible after the Server has started");
         Route::new(router, path.to_owned())
     }
 
@@ -269,7 +270,8 @@ impl<State: Send + Sync + 'static> Server<State> {
     /// Middleware can only be added at the "top level" of an application,
     /// and is processed in the order in which it is applied.
     pub fn middleware(&mut self, m: impl Middleware<State>) -> &mut Self {
-        let middleware = Arc::get_mut(&mut self.middleware).unwrap();
+        let middleware = Arc::get_mut(&mut self.middleware)
+            .expect("Registering middleware is not possible after the Server has started");
         middleware.push(Arc::new(m));
         self
     }

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -87,7 +87,7 @@ impl<'a, State: 'static> Route<'a, State> {
         InnerState: Send + Sync + 'static,
     {
         self.prefix = true;
-        self.all(service.into_http_service());
+        self.all(service);
         self.prefix = false;
         self
     }

--- a/tests/cookies.rs
+++ b/tests/cookies.rs
@@ -43,7 +43,7 @@ fn app() -> crate::Server<()> {
 
 fn make_request(endpoint: &str) -> http_types::Response {
     let app = app();
-    let mut server = make_server(app.into_http_service()).unwrap();
+    let mut server = make_server(app).unwrap();
     let mut req = http_types::Request::new(
         http_types::Method::Get,
         format!("http://example.com{}", endpoint).parse().unwrap(),

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -14,7 +14,7 @@ async fn nested() {
     // Nest the inner app on /foo
     outer.at("/foo").nest(inner);
 
-    let mut server = make_server(outer.into_http_service()).unwrap();
+    let mut server = make_server(outer).unwrap();
 
     let req = Request::new(
         Method::Get,
@@ -60,7 +60,7 @@ async fn nested_middleware() {
 
     app.at("/bar").get(echo_path);
 
-    let mut server = make_server(app.into_http_service()).unwrap();
+    let mut server = make_server(app).unwrap();
 
     let req = Request::new(
         Method::Get,
@@ -98,7 +98,7 @@ async fn nested_with_different_state() {
     outer.at("/").get(|_| async move { Ok("Hello, world!") });
     outer.at("/foo").nest(inner);
 
-    let mut server = make_server(outer.into_http_service()).unwrap();
+    let mut server = make_server(outer).unwrap();
 
     let req = Request::new(Method::Get, Url::parse("http://example.com/foo").unwrap());
     let res = server.simulate(req).unwrap();

--- a/tests/querystring.rs
+++ b/tests/querystring.rs
@@ -36,7 +36,7 @@ fn get_server() -> TestBackend<Server<()>> {
     let mut app = Server::new();
     app.at("/").get(handler);
     app.at("/optional").get(optional_handler);
-    make_server(app.into_http_service()).unwrap()
+    make_server(app).unwrap()
 }
 
 #[test]

--- a/tests/querystring.rs
+++ b/tests/querystring.rs
@@ -1,9 +1,9 @@
-use async_std::io::prelude::ReadExt;
+use async_std::prelude::*;
 use futures::executor::block_on;
 use http_service_mock::{make_server, TestBackend};
 use http_types::StatusCode;
 use serde::Deserialize;
-use tide::{server::Service, IntoResponse, Request, Response, Server};
+use tide::{IntoResponse, Request, Response, Server};
 
 #[derive(Deserialize)]
 struct Params {
@@ -32,7 +32,7 @@ async fn optional_handler(cx: Request<()>) -> tide::Result<Response> {
     }
 }
 
-fn get_server() -> TestBackend<Service<()>> {
+fn get_server() -> TestBackend<Server<()>> {
     let mut app = Server::new();
     app.at("/").get(handler);
     app.at("/optional").get(optional_handler);

--- a/tests/route_middleware.rs
+++ b/tests/route_middleware.rs
@@ -44,7 +44,7 @@ fn route_middleware() {
         .post(echo_path)
         .reset_middleware()
         .put(echo_path);
-    let mut server = make_server(app.into_http_service()).unwrap();
+    let mut server = make_server(app).unwrap();
 
     let req = Request::new(Method::Get, "http://localhost/foo".parse().unwrap());
     let res = server.simulate(req).unwrap();
@@ -86,7 +86,7 @@ fn app_and_route_middleware() {
     app.at("/bar")
         .middleware(TestMiddleware::with_header_name("X-Bar", "bar"))
         .get(echo_path);
-    let mut server = make_server(app.into_http_service()).unwrap();
+    let mut server = make_server(app).unwrap();
 
     let req = Request::new(Method::Get, "http://localhost/foo".parse().unwrap());
     let res = server.simulate(req).unwrap();
@@ -130,7 +130,7 @@ fn nested_app_with_route_middleware() {
     app.at("/bar")
         .middleware(TestMiddleware::with_header_name("X-Bar", "bar"))
         .nest(inner);
-    let mut server = make_server(app.into_http_service()).unwrap();
+    let mut server = make_server(app).unwrap();
 
     let req = Request::new(Method::Get, "http://localhost/foo".parse().unwrap());
     let res = server.simulate(req).unwrap();
@@ -176,7 +176,7 @@ fn subroute_not_nested() {
     app.at("/parent/child") // /parent/child, not nested
         .middleware(TestMiddleware::with_header_name("X-Child", "child"))
         .get(echo_path);
-    let mut server = make_server(app.into_http_service()).unwrap();
+    let mut server = make_server(app).unwrap();
 
     let req = Request::new(
         Method::Get,


### PR DESCRIPTION
This implements `HttpService` directly on `Server` removing the need for the intermediate `Service` struct. This allows us to remove `into_http_service` and the `server` submodule making e.g. nesting apps really easy.

## Examples

```rust
let mut app = tide::new();
let mut inner_app = tide::new();
inner_app.at("/").get(|_| async { Ok("hello world") });
app.at("/foo").nest(inner_app);
app.listen("localhost:8080").await?;
```

## Future directions

In https://github.com/http-rs/http-types/pull/94 we've introduced the (experimental) Client and Server traits. The hope is that these can replace `http-client` and `http-service` including on Tide directly. Because these traits don't carry a connection this would allow us to bypass `http_service_mock::make_server` and `http_mock_service::TestBackend::simulate` calls entirely by simply calling `app.recv_req` instead, making it really easy to test applications:

```rust
let mut app = tide::new();
app.at("/").get(|_| async { Ok("hello world") });

let req = Request::new(Method::Get, "http://localhost:8080");
let res = app.recv_req(req).await?;
```