### PR TITLE
bind to an unused port in integration tests

### DIFF
--- a/tests/chunked-encode-large.rs
+++ b/tests/chunked-encode-large.rs
@@ -1,3 +1,4 @@
+mod test_utils;
 use async_std::io::Cursor;
 use async_std::prelude::*;
 use async_std::task;
@@ -67,22 +68,23 @@ const TEXT: &'static str = concat![
 
 #[async_std::test]
 async fn chunked_large() -> Result<(), http_types::Error> {
-    let server = task::spawn(async {
+    let bind = test_utils::determine_port_to_bind().await;
+    let server = task::spawn(async move {
         let mut app = tide::new();
-        app.at("/").get(|mut _req: tide::Request<()>| async move {
+        app.at("/").get(|mut _req: tide::Request<()>| async {
             let body = Cursor::new(TEXT.to_owned());
             let res = Response::new(StatusCode::Ok)
                 .body(body)
                 .set_header(headers::CONTENT_TYPE, "text/plain; charset=utf-8");
             Ok(res)
         });
-        app.listen("localhost:8080").await?;
+        app.listen(&bind).await?;
         Result::<(), http_types::Error>::Ok(())
     });
 
-    let client = task::spawn(async {
+    let client = task::spawn(async move {
         task::sleep(Duration::from_millis(100)).await;
-        let mut res = surf::get("http://localhost:8080").await?;
+        let mut res = surf::get(format!("http://{}", bind)).await?;
         assert_eq!(res.status(), 200);
         assert_eq!(
             res.header(&"transfer-encoding".parse().unwrap()),

--- a/tests/chunked-encode-large.rs
+++ b/tests/chunked-encode-large.rs
@@ -68,7 +68,7 @@ const TEXT: &'static str = concat![
 
 #[async_std::test]
 async fn chunked_large() -> Result<(), http_types::Error> {
-    let bind = test_utils::determine_port_to_bind().await;
+    let bind = test_utils::find_port().await;
     let server = task::spawn(async move {
         let mut app = tide::new();
         app.at("/").get(|mut _req: tide::Request<()>| async {

--- a/tests/chunked-encode-small.rs
+++ b/tests/chunked-encode-small.rs
@@ -17,7 +17,7 @@ const TEXT: &'static str = concat![
 
 #[async_std::test]
 async fn chunked_large() -> Result<(), http_types::Error> {
-    let bind = test_utils::determine_port_to_bind().await;
+    let port = test_utils::find_port().await;
     let server = task::spawn(async move {
         let mut app = tide::new();
         app.at("/").get(|mut _req: tide::Request<()>| async move {
@@ -27,13 +27,13 @@ async fn chunked_large() -> Result<(), http_types::Error> {
                 .set_header(headers::CONTENT_TYPE, "text/plain; charset=utf-8");
             Ok(res)
         });
-        app.listen(&bind).await?;
+        app.listen(&port).await?;
         Result::<(), http_types::Error>::Ok(())
     });
 
     let client = task::spawn(async move {
         task::sleep(Duration::from_millis(100)).await;
-        let mut res = surf::get(format!("http://{}", bind)).await?;
+        let mut res = surf::get(format!("http://{}", port)).await?;
         assert_eq!(res.status(), 200);
         assert_eq!(
             res.header(&"transfer-encoding".parse().unwrap()),

--- a/tests/chunked-encode-small.rs
+++ b/tests/chunked-encode-small.rs
@@ -1,3 +1,4 @@
+mod test_utils;
 use async_std::io::Cursor;
 use async_std::prelude::*;
 use async_std::task;
@@ -16,7 +17,8 @@ const TEXT: &'static str = concat![
 
 #[async_std::test]
 async fn chunked_large() -> Result<(), http_types::Error> {
-    let server = task::spawn(async {
+    let bind = test_utils::determine_port_to_bind().await;
+    let server = task::spawn(async move {
         let mut app = tide::new();
         app.at("/").get(|mut _req: tide::Request<()>| async move {
             let body = Cursor::new(TEXT.to_owned());
@@ -25,13 +27,13 @@ async fn chunked_large() -> Result<(), http_types::Error> {
                 .set_header(headers::CONTENT_TYPE, "text/plain; charset=utf-8");
             Ok(res)
         });
-        app.listen("localhost:8080").await?;
+        app.listen(&bind).await?;
         Result::<(), http_types::Error>::Ok(())
     });
 
-    let client = task::spawn(async {
+    let client = task::spawn(async move {
         task::sleep(Duration::from_millis(100)).await;
-        let mut res = surf::get("http://localhost:8080").await?;
+        let mut res = surf::get(format!("http://{}", bind)).await?;
         assert_eq!(res.status(), 200);
         assert_eq!(
             res.header(&"transfer-encoding".parse().unwrap()),

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 #[test]
 fn hello_world() -> Result<(), http_types::Error> {
     task::block_on(async {
-        let bind = test_utils::determine_port_to_bind().await;
+        let port = test_utils::find_port().await;
         let server = task::spawn(async move {
             let mut app = tide::new();
             app.at("/").get(|mut req: tide::Request<()>| async move {
@@ -17,13 +17,13 @@ fn hello_world() -> Result<(), http_types::Error> {
                 let res = tide::Response::new(StatusCode::Ok).body_string("says hello".to_string());
                 Ok(res)
             });
-            app.listen(&bind).await?;
+            app.listen(&port).await?;
             Result::<(), http_types::Error>::Ok(())
         });
 
         let client = task::spawn(async move {
             task::sleep(Duration::from_millis(100)).await;
-            let string = surf::get(format!("http://{}", bind))
+            let string = surf::get(format!("http://{}", port))
                 .body_string("nori".to_string())
                 .recv_string()
                 .await?;
@@ -38,18 +38,18 @@ fn hello_world() -> Result<(), http_types::Error> {
 #[test]
 fn echo_server() -> Result<(), http_types::Error> {
     task::block_on(async {
-        let bind = test_utils::determine_port_to_bind().await;
+        let port = test_utils::find_port().await;
         let server = task::spawn(async move {
             let mut app = tide::new();
             app.at("/").get(|req| async move { Ok(req) });
 
-            app.listen(&bind).await?;
+            app.listen(&port).await?;
             Result::<(), http_types::Error>::Ok(())
         });
 
         let client = task::spawn(async move {
             task::sleep(Duration::from_millis(100)).await;
-            let string = surf::get(format!("http://{}", bind))
+            let string = surf::get(format!("http://{}", port))
                 .body_string("chashu".to_string())
                 .recv_string()
                 .await?;
@@ -69,7 +69,7 @@ fn json() -> Result<(), http_types::Error> {
     }
 
     task::block_on(async {
-        let bind = test_utils::determine_port_to_bind().await;
+        let port = test_utils::find_port().await;
         let server = task::spawn(async move {
             let mut app = tide::new();
             app.at("/").get(|mut req: tide::Request<()>| async move {
@@ -79,13 +79,13 @@ fn json() -> Result<(), http_types::Error> {
                 let res = tide::Response::new(StatusCode::Ok).body_json(&counter)?;
                 Ok(res)
             });
-            app.listen(&bind).await?;
+            app.listen(&port).await?;
             Result::<(), http_types::Error>::Ok(())
         });
 
         let client = task::spawn(async move {
             task::sleep(Duration::from_millis(100)).await;
-            let counter: Counter = surf::get(format!("http://{}", &bind))
+            let counter: Counter = surf::get(format!("http://{}", &port))
                 .body_json(&Counter { count: 0 })?
                 .recv_json()
                 .await?;

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -1,4 +1,4 @@
-pub async fn determine_port_to_bind() -> async_std::net::SocketAddr {
+pub async fn find_port() -> async_std::net::SocketAddr {
     async_std::net::TcpListener::bind("localhost:0")
         .await
         .unwrap()

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -1,0 +1,7 @@
+pub async fn determine_port_to_bind() -> async_std::net::SocketAddr {
+    async_std::net::TcpListener::bind("localhost:0")
+        .await
+        .unwrap()
+        .local_addr()
+        .unwrap()
+}


### PR DESCRIPTION
Prior to this PR, if a machine has a server running on any of the ports used for testing (808x), tests would fail in unclear ways.  Because socket reuse flags are platform dependent, this PR finds an unused port by temporarily binding to port 0 and using the assigned port.