### PR TITLE
Add redirect submodule

### DIFF
--- a/examples/graphql.rs
+++ b/examples/graphql.rs
@@ -2,7 +2,7 @@ use async_std::task;
 use http_types::StatusCode;
 use juniper::RootNode;
 use std::sync::RwLock;
-use tide::{Request, Response, Server};
+use tide::{redirect, Request, Response, Server};
 
 #[derive(Clone)]
 struct User {
@@ -105,7 +105,7 @@ fn main() -> std::io::Result<()> {
         let mut app = Server::with_state(State {
             users: RwLock::new(Vec::new()),
         });
-        app.at("/").get(tide::redirect("/graphiql"));
+        app.at("/").get(redirect::permanent("/graphiql"));
         app.at("/graphql").post(handle_graphql);
         app.at("/graphiql").get(handle_graphiql);
         app.listen("0.0.0.0:8080").await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,6 @@
 
 mod endpoint;
 pub mod middleware;
-mod redirect;
 mod request;
 mod response;
 mod router;
@@ -192,9 +191,9 @@ mod server;
 mod utils;
 
 pub mod prelude;
+pub mod redirect;
 
 pub use endpoint::Endpoint;
-pub use redirect::redirect;
 pub use request::Request;
 
 #[doc(inline)]

--- a/src/redirect/mod.rs
+++ b/src/redirect/mod.rs
@@ -1,0 +1,22 @@
+//! HTTP redirection endpoints.
+//!
+//! # Examples
+//!
+//! ```no_run
+//! # use futures::executor::block_on;
+//! # fn main() -> Result<(), std::io::Error> { block_on(async {
+//! #
+//! use tide::redirect;
+//!
+//! let mut app = tide::new();
+//! app.at("/").get(|_| async move { Ok("meow") });
+//! app.at("/nori").get(redirect::temporary("/"));
+//! app.listen("127.0.0.1:8080").await?;
+//! #
+//! # Ok(()) }) }
+//! ```
+mod permanent;
+mod temporary;
+
+pub use permanent::{permanent, PermanentRedirect};
+pub use temporary::{temporary, TemporaryRedirect};

--- a/src/redirect/permanent.rs
+++ b/src/redirect/permanent.rs
@@ -1,36 +1,39 @@
 use crate::utils::BoxFuture;
 use crate::{Endpoint, Request, Response};
 
-/// Redirect a route to another route.
+/// Redirect a route permanently to another route.
 ///
-/// The route will be redirected with a `307, temporary redirect` on a route with the same HTTP
-/// method.
+/// The route will be permanently with a `301, permanent redirect` on a route
+/// with the same HTTP method.
 ///
 /// # Examples
 /// ```no_run
 /// # use futures::executor::block_on;
 /// # fn main() -> Result<(), std::io::Error> { block_on(async {
 /// #
+/// use tide::redirect;
+///
 /// let mut app = tide::new();
 /// app.at("/").get(|_| async move { Ok("meow") });
-/// app.at("/nori").get(tide::redirect("/"));
+/// app.at("/nori").get(redirect::permanent("/"));
 /// app.listen("127.0.0.1:8080").await?;
 /// #
 /// # Ok(()) }) }
 /// ```
-pub fn redirect<State>(location: impl AsRef<str>) -> impl Endpoint<State> {
+pub fn permanent(location: impl AsRef<str>) -> PermanentRedirect {
     let location = location.as_ref().to_owned();
-    Redirect { location }
+    PermanentRedirect { location }
 }
 
-/// The route that we redirect to
-pub struct Redirect {
+/// A permanent redirection endpoint.
+#[derive(Debug, Clone)]
+pub struct PermanentRedirect {
     location: String,
 }
 
-impl<State> Endpoint<State> for Redirect {
+impl<State> Endpoint<State> for PermanentRedirect {
     fn call<'a>(&'a self, _req: Request<State>) -> BoxFuture<'a, crate::Result<Response>> {
-        let res = Response::redirect_temp(&self.location);
+        let res = Response::redirect_permanent(&self.location);
         Box::pin(async move { Ok(res) })
     }
 }

--- a/src/redirect/temporary.rs
+++ b/src/redirect/temporary.rs
@@ -1,0 +1,39 @@
+use crate::utils::BoxFuture;
+use crate::{Endpoint, Request, Response};
+
+/// Redirect a route temporarily to another route.
+///
+/// The route will be redirected with a `307, temporary redirect` on a route with the same HTTP
+/// method.
+///
+/// # Examples
+/// ```no_run
+/// # use futures::executor::block_on;
+/// # fn main() -> Result<(), std::io::Error> { block_on(async {
+/// #
+/// use tide::redirect;
+///
+/// let mut app = tide::new();
+/// app.at("/").get(|_| async move { Ok("meow") });
+/// app.at("/nori").get(redirect::temporary("/"));
+/// app.listen("127.0.0.1:8080").await?;
+/// #
+/// # Ok(()) }) }
+/// ```
+pub fn temporary(location: impl AsRef<str>) -> TemporaryRedirect {
+    let location = location.as_ref().to_owned();
+    TemporaryRedirect { location }
+}
+
+/// A temporary redirection endpoint.
+#[derive(Debug, Clone)]
+pub struct TemporaryRedirect {
+    location: String,
+}
+
+impl<State> Endpoint<State> for TemporaryRedirect {
+    fn call<'a>(&'a self, _req: Request<State>) -> BoxFuture<'a, crate::Result<Response>> {
+        let res = Response::redirect_temporary(&self.location);
+        Box::pin(async move { Ok(res) })
+    }
+}

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -64,14 +64,14 @@ impl Response {
     /// # #[allow(dead_code)]
     /// async fn route_handler(request: Request<()>) -> tide::Result<Response> {
     ///     if let Some(canonical_redirect) = canonicalize(request.uri()) {
-    ///         Ok(Response::redirect_perm(canonical_redirect))
+    ///         Ok(Response::redirect_permanent(canonical_redirect))
     ///     } else {
     ///          //...
     /// #        Ok(Response::new(http_types::StatusCode::Ok)) // ...
     ///     }
     /// }
     /// ```
-    pub fn redirect_perm(location: impl AsRef<str>) -> Self {
+    pub fn redirect_permanent(location: impl AsRef<str>) -> Self {
         Response::new(StatusCode::PermanentRedirect)
             .set_header("location".parse().unwrap(), location)
     }
@@ -87,14 +87,14 @@ impl Response {
     /// # #[allow(dead_code)]
     /// async fn route_handler(request: Request<()>) -> tide::Result<Response> {
     ///     if let Some(sale_url) = special_sale_today() {
-    ///         Ok(Response::redirect_temp(sale_url))
+    ///         Ok(Response::redirect_temporary(sale_url))
     ///     } else {
     ///         //...
     /// #       Ok(Response::new(http_types::StatusCode::Ok)) //...
     ///     }
     /// }
     /// ```
-    pub fn redirect_temp(location: impl AsRef<str>) -> Self {
+    pub fn redirect_temporary(location: impl AsRef<str>) -> Self {
         Response::new(StatusCode::TemporaryRedirect)
             .set_header("location".parse().unwrap(), location)
     }


### PR DESCRIPTION
Follow-up to https://github.com/http-rs/tide/pull/435. Now supports both permanent and temporary redirects, and updated all vocabulary in Tide to be consistent with one another. Thanks!

__edit:__ closes #82

## Screenshot

Tide's docs landing now looks really clean:

![Screenshot_2020-04-22 tide - Rust](https://user-images.githubusercontent.com/2467194/79970606-74089580-8493-11ea-8862-f939d6928fcb.png)
