### PR TITLE
Adds log submodule

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ unstable = []
 http-types = "1.0.1"
 http-service = "0.5.0"
 http-service-h1 = { version = "0.1.0", optional = true }
-log = "0.4.8"
 route-recognizer = "0.1.13"
 serde = "1.0.102"
 serde_json = "1.0.41"
@@ -45,6 +44,7 @@ futures = { version = "0.3.1", optional = true }
 http = { version = "0.2.0", optional = true }
 tokio = { version = "0.2.13", optional = true }
 url = "2.1.1"
+kv-log-macro = "1.0.4"
 
 [dev-dependencies]
 async-std = { version = "1.4.0", features = ["unstable", "attributes"] }

--- a/examples/static_file.rs
+++ b/examples/static_file.rs
@@ -1,7 +1,8 @@
 use async_std::task;
+use tide::log;
 
 fn main() -> Result<(), std::io::Error> {
-    femme::start(log::LevelFilter::Info).unwrap();
+    femme::start(log::Level::Info.to_level_filter()).unwrap();
     task::block_on(async {
         let mut app = tide::new();
         app.at("/").get(|_| async move { Ok("visit /src/*") });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,6 +191,7 @@ mod router;
 mod server;
 mod utils;
 
+pub mod log;
 pub mod prelude;
 
 pub use endpoint::Endpoint;

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,22 @@
+//! Event logging types.
+//!
+//! # Examples
+//!
+//! ```no_run
+//! use tide::log;
+//!
+//! // `tide::log` requires starting a third-party logger such as `femme`. We may
+//! // ship such a logger as part of Tide in the future.
+//! femme::start(log::Level::Info.to_level_filter()).unwrap();
+//!
+//! log::info!("Hello cats");
+//! log::debug!("{} wants tuna", "Nori");
+//! log::error!("We're out of tuna!");
+//! log::info!("{} are hungry", "cats", {
+//!     cat_1: "Chashu",
+//!     cat_2: "Nori",
+//! });
+//! ```
+
+pub use kv_log_macro::{debug, error, info, log, trace, warn};
+pub use kv_log_macro::{max_level, Level};

--- a/src/middleware/logger.rs
+++ b/src/middleware/logger.rs
@@ -1,3 +1,4 @@
+use crate::log;
 use crate::{
     middleware::{Middleware, Next},
     Request, Response,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -10,6 +10,7 @@ use http_service::HttpService;
 use std::fmt::Debug;
 use std::pin::Pin;
 
+use crate::log;
 use crate::middleware::{cookies, Middleware, Next};
 use crate::router::{Router, Selection};
 use crate::utils::BoxFuture;

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use super::serve_dir::ServeDir;
 use crate::endpoint::MiddlewareEndpoint;
+use crate::log;
 use crate::utils::BoxFuture;
 use crate::{router::Router, Endpoint, Middleware, Response};
 

--- a/src/server/serve_dir.rs
+++ b/src/server/serve_dir.rs
@@ -2,6 +2,7 @@ use async_std::fs::File;
 use async_std::io::BufReader;
 use http_types::{Body, StatusCode};
 
+use crate::log;
 use crate::{Endpoint, Request, Response, Result};
 
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
Adds a new log submodule. Being able to introspect programs tends to be crucial for fixing problems, and as a framework we can guide people to do so. This patch introduces the `log` submodule, which allows users to log using key-value pairs.

In the future we should consider adding an actual logger to Tide as well, with examples showing how to start logging. That way we'll be able to match frameworks such as [fastify](https://github.com/fastify/fastify) and [rocket](https://docs.rs/rocket/0.4.4/rocket/) on initial UX. Thanks!

## Screenshot

![Screenshot_2020-04-22 tide log - Rust](https://user-images.githubusercontent.com/2467194/79973289-97354400-8497-11ea-8598-6d8773a67479.png)

