### PR TITLE
export http_types::{Body, StatusCode}

### DIFF
--- a/backup/examples/staticfile.rs
+++ b/backup/examples/staticfile.rs
@@ -5,8 +5,7 @@ use http::{
     header::{self, HeaderMap},
     StatusCode,
 };
-use http_service::Body;
-use tide::{Request, Response, Result, Server};
+use tide::{Body, Request, Response, Result, Server};
 
 use std::path::{Component, Path, PathBuf};
 use std::{fs, io};

--- a/examples/chunked.rs
+++ b/examples/chunked.rs
@@ -1,8 +1,7 @@
 use async_std::fs;
 use async_std::io::BufReader;
 use async_std::task;
-use http_types::StatusCode;
-use tide::Response;
+use tide::{Response, StatusCode};
 
 fn main() -> Result<(), std::io::Error> {
     task::block_on(async {

--- a/examples/cookies.rs
+++ b/examples/cookies.rs
@@ -1,7 +1,6 @@
 use async_std::task;
 use cookie::Cookie;
-use http_types::StatusCode;
-use tide::{Request, Response};
+use tide::{Request, Response, StatusCode};
 
 /// Tide will use the the `Cookies`'s `Extract` implementation to build this parameter.
 ///

--- a/examples/graphql.rs
+++ b/examples/graphql.rs
@@ -1,8 +1,7 @@
 use async_std::task;
-use http_types::StatusCode;
 use juniper::RootNode;
 use std::sync::RwLock;
-use tide::{redirect, Request, Response, Server};
+use tide::{redirect, Request, Response, Server, StatusCode};
 
 #[derive(Clone)]
 struct User {

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -1,7 +1,7 @@
 use async_std::io;
 use async_std::task;
-use http_types::StatusCode;
 use serde::{Deserialize, Serialize};
+use tide::{Request, Response, StatusCode};
 
 #[derive(Deserialize, Serialize)]
 struct Cat {
@@ -12,17 +12,16 @@ fn main() -> io::Result<()> {
     task::block_on(async {
         let mut app = tide::new();
 
-        app.at("/submit")
-            .post(|mut req: tide::Request<()>| async move {
-                let cat: Cat = req.body_json().await?;
-                println!("cat name: {}", cat.name);
+        app.at("/submit").post(|mut req: Request<()>| async move {
+            let cat: Cat = req.body_json().await?;
+            println!("cat name: {}", cat.name);
 
-                let cat = Cat {
-                    name: "chashu".into(),
-                };
+            let cat = Cat {
+                name: "chashu".into(),
+            };
 
-                Ok(tide::Response::new(StatusCode::Ok).body_json(&cat)?)
-            });
+            Ok(Response::new(StatusCode::Ok).body_json(&cat)?)
+        });
 
         app.listen("127.0.0.1:8080").await?;
         Ok(())

--- a/src/cookies/middleware.rs
+++ b/src/cookies/middleware.rs
@@ -13,10 +13,11 @@ use std::sync::{Arc, RwLock};
 /// # Examples
 ///
 /// ```
+/// # use tide::{Request, Response, StatusCode};
 /// let mut app = tide::Server::new();
-/// app.at("/get").get(|cx: tide::Request<()>| async move { Ok(cx.cookie("testCookie").unwrap().value().to_string()) });
+/// app.at("/get").get(|cx: Request<()>| async move { Ok(cx.cookie("testCookie").unwrap().value().to_string()) });
 /// app.at("/set").get(|_| async {
-///     let mut res = tide::Response::new(http_types::StatusCode::Ok);
+///     let mut res = Response::new(StatusCode::Ok);
 ///     res.set_cookie(cookie::Cookie::new("testCookie", "NewCookieValue"));
 ///     Ok(res)
 /// });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,7 @@ pub use request::Request;
 pub mod sse;
 
 #[doc(inline)]
-pub use http_types::{Error, Result, Status, StatusCode};
+pub use http_types::{Body, Error, Result, Status, StatusCode};
 
 #[doc(inline)]
 pub use middleware::{Middleware, Next};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,7 @@ pub use request::Request;
 pub mod sse;
 
 #[doc(inline)]
-pub use http_types::{Error, Result, Status};
+pub use http_types::{Error, Result, Status, StatusCode};
 
 #[doc(inline)]
 pub use middleware::{Middleware, Next};

--- a/src/response/into_response.rs
+++ b/src/response/into_response.rs
@@ -1,6 +1,6 @@
+use crate::StatusCode;
 use crate::{Request, Response};
 use async_std::io::BufReader;
-use http_types::StatusCode;
 
 /// Conversion into a `Response`.
 pub trait IntoResponse: Send + Sized {
@@ -14,7 +14,7 @@ pub trait IntoResponse: Send + Sized {
     /// let resp = "Hello, 404!".with_status(http_types::StatusCode::NotFound).into_response();
     /// assert_eq!(resp.status(), http_types::StatusCode::NotFound);
     /// ```
-    fn with_status(self, status: http_types::StatusCode) -> WithStatus<Self> {
+    fn with_status(self, status: StatusCode) -> WithStatus<Self> {
         WithStatus {
             inner: self,
             status,

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -43,7 +43,7 @@ impl Response {
     where
         R: BufRead + Unpin + Send + Sync + 'static,
     {
-        let status = http_types::StatusCode::try_from(status).expect("invalid status code");
+        let status = crate::StatusCode::try_from(status).expect("invalid status code");
         let mut res = http_types::Response::new(status);
         res.set_body(Body::from_reader(reader, None));
 
@@ -59,7 +59,7 @@ impl Response {
     /// # Example
     ///
     /// ```
-    /// # use tide::{Response, Request};
+    /// # use tide::{Response, Request, StatusCode};
     /// # fn canonicalize(uri: &url::Url) -> Option<&url::Url> { None }
     /// # #[allow(dead_code)]
     /// async fn route_handler(request: Request<()>) -> tide::Result<Response> {
@@ -67,7 +67,7 @@ impl Response {
     ///         Ok(Response::redirect_permanent(canonical_redirect))
     ///     } else {
     ///          //...
-    /// #        Ok(Response::new(http_types::StatusCode::Ok)) // ...
+    /// #        Ok(Response::new(StatusCode::Ok)) // ...
     ///     }
     /// }
     /// ```
@@ -82,7 +82,7 @@ impl Response {
     /// # Example
     ///
     /// ```
-    /// # use tide::{Response, Request};
+    /// # use tide::{Response, Request, StatusCode};
     /// # fn special_sale_today() -> Option<String> { None }
     /// # #[allow(dead_code)]
     /// async fn route_handler(request: Request<()>) -> tide::Result<Response> {
@@ -90,7 +90,7 @@ impl Response {
     ///         Ok(Response::redirect_temporary(sale_url))
     ///     } else {
     ///         //...
-    /// #       Ok(Response::new(http_types::StatusCode::Ok)) //...
+    /// #       Ok(Response::new(StatusCode::Ok)) //...
     ///     }
     /// }
     /// ```
@@ -100,12 +100,12 @@ impl Response {
     }
 
     /// Returns the statuscode.
-    pub fn status(&self) -> http_types::StatusCode {
+    pub fn status(&self) -> crate::StatusCode {
         self.res.status()
     }
 
     /// Set the statuscode.
-    pub fn set_status(mut self, status: http_types::StatusCode) -> Self {
+    pub fn set_status(mut self, status: crate::StatusCode) -> Self {
         self.res.set_status(status);
         self
     }

--- a/src/router.rs
+++ b/src/router.rs
@@ -88,13 +88,9 @@ impl<State: 'static> Router<State> {
 }
 
 fn not_found_endpoint<State>(_cx: Request<State>) -> BoxFuture<'static, Result<Response>> {
-    Box::pin(async move { Ok(Response::new(http_types::StatusCode::NotFound.into())) })
+    Box::pin(async move { Ok(Response::new(crate::StatusCode::NotFound.into())) })
 }
 
 fn method_not_allowed<State>(_cx: Request<State>) -> BoxFuture<'static, Result<Response>> {
-    Box::pin(async move {
-        Ok(Response::new(
-            http_types::StatusCode::MethodNotAllowed.into(),
-        ))
-    })
+    Box::pin(async move { Ok(Response::new(crate::StatusCode::MethodNotAllowed.into())) })
 }

--- a/src/server/serve_dir.rs
+++ b/src/server/serve_dir.rs
@@ -1,9 +1,8 @@
+use crate::log;
+use crate::{Body, Endpoint, Request, Response, Result, StatusCode};
+
 use async_std::fs::File;
 use async_std::io::BufReader;
-use http_types::{Body, StatusCode};
-
-use crate::log;
-use crate::{Endpoint, Request, Response, Result};
 
 use std::path::{Path, PathBuf};
 

--- a/tests/cookies.rs
+++ b/tests/cookies.rs
@@ -2,9 +2,8 @@ use cookie::Cookie;
 use futures::executor::block_on;
 use futures::AsyncReadExt;
 use http_service_mock::make_server;
-use http_types::StatusCode;
 
-use tide::{Request, Response, Server};
+use tide::{Request, Response, Server, StatusCode};
 
 static COOKIE_NAME: &str = "testCookie";
 

--- a/tests/querystring.rs
+++ b/tests/querystring.rs
@@ -1,9 +1,8 @@
 use async_std::prelude::*;
 use futures::executor::block_on;
 use http_service_mock::{make_server, TestBackend};
-use http_types::StatusCode;
 use serde::Deserialize;
-use tide::{IntoResponse, Request, Response, Server};
+use tide::{IntoResponse, Request, Response, Server, StatusCode};
 
 #[derive(Deserialize)]
 struct Params {

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,18 +1,18 @@
 use async_std::prelude::*;
 use async_std::task;
-use http_types::StatusCode;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
+use tide::{Request, Response, StatusCode};
 
 #[test]
 fn hello_world() -> Result<(), http_types::Error> {
     task::block_on(async {
         let server = task::spawn(async {
             let mut app = tide::new();
-            app.at("/").get(|mut req: tide::Request<()>| async move {
+            app.at("/").get(|mut req: Request<()>| async move {
                 assert_eq!(req.body_string().await.unwrap(), "nori".to_string());
-                let res = tide::Response::new(StatusCode::Ok).body_string("says hello".to_string());
+                let res = Response::new(StatusCode::Ok).body_string("says hello".to_string());
                 Ok(res)
             });
             app.listen("localhost:8080").await?;
@@ -68,11 +68,11 @@ fn json() -> Result<(), http_types::Error> {
     task::block_on(async {
         let server = task::spawn(async {
             let mut app = tide::new();
-            app.at("/").get(|mut req: tide::Request<()>| async move {
+            app.at("/").get(|mut req: Request<()>| async move {
                 let mut counter: Counter = req.body_json().await.unwrap();
                 assert_eq!(counter.count, 0);
                 counter.count = 1;
-                let res = tide::Response::new(StatusCode::Ok).body_json(&counter)?;
+                let res = Response::new(StatusCode::Ok).body_json(&counter)?;
                 Ok(res)
             });
             app.listen("localhost:8082").await?;


### PR DESCRIPTION
Each response requires a StatusCode. Because this is so common throughout Tide we should export this from the top-level. This allows us to simplify the imports in many examples as well. Thanks!