### PR TITLE
Restore default params in tide::Result

### DIFF
--- a/examples/cookies.rs
+++ b/examples/cookies.rs
@@ -1,6 +1,6 @@
 use async_std::task;
-use cookie::Cookie;
-use tide::{Request, Response, StatusCode};
+use tide::http::Cookie;
+use tide::{Request, StatusCode};
 
 /// Tide will use the the `Cookies`'s `Extract` implementation to build this parameter.
 ///
@@ -8,13 +8,13 @@ async fn retrieve_cookie(cx: Request<()>) -> tide::Result<String> {
     Ok(format!("hello cookies: {:?}", cx.cookie("hello").unwrap()))
 }
 
-async fn set_cookie(_req: Request<()>) -> tide::Result<Response> {
+async fn set_cookie(_req: Request<()>) -> tide::Result {
     let mut res = tide::Response::new(StatusCode::Ok);
     res.set_cookie(Cookie::new("hello", "world"));
     Ok(res)
 }
 
-async fn remove_cookie(_req: Request<()>) -> tide::Result<Response> {
+async fn remove_cookie(_req: Request<()>) -> tide::Result {
     let mut res = tide::Response::new(StatusCode::Ok);
     res.remove_cookie(Cookie::named("hello"));
     Ok(res)

--- a/examples/graphql.rs
+++ b/examples/graphql.rs
@@ -72,7 +72,7 @@ fn create_schema() -> Schema {
     Schema::new(QueryRoot {}, MutationRoot {})
 }
 
-async fn handle_graphql(mut cx: Request<State>) -> tide::Result<Response> {
+async fn handle_graphql(mut cx: Request<State>) -> tide::Result {
     let query: juniper::http::GraphQLRequest = cx
         .body_json()
         .await
@@ -92,7 +92,7 @@ async fn handle_graphql(mut cx: Request<State>) -> tide::Result<Response> {
     Ok(res)
 }
 
-async fn handle_graphiql(_: Request<State>) -> tide::Result<Response> {
+async fn handle_graphiql(_: Request<State>) -> tide::Result {
     let res = Response::new(StatusCode::Ok)
         .body_string(juniper::http::graphiql::graphiql_source("/graphql"))
         .set_header("content-type".parse().unwrap(), "text/html;charset=utf-8");

--- a/src/cookies/middleware.rs
+++ b/src/cookies/middleware.rs
@@ -1,7 +1,6 @@
 use crate::response::CookieEvent;
 use crate::utils::BoxFuture;
-use crate::{Middleware, Next};
-use crate::{Request, Response, Result};
+use crate::{Middleware, Next, Request};
 
 use cookie::CookieJar;
 use http_types::headers;
@@ -37,7 +36,7 @@ impl<State: Send + Sync + 'static> Middleware<State> for CookiesMiddleware {
         &'a self,
         mut ctx: Request<State>,
         next: Next<'a, State>,
-    ) -> BoxFuture<'a, Result<Response>> {
+    ) -> BoxFuture<'a, crate::Result> {
         Box::pin(async move {
             let cookie_jar = if let Some(cookie_data) = ctx.local::<CookieData>() {
                 cookie_data.content.clone()

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -5,7 +5,7 @@ use http_types::Result;
 
 use crate::middleware::Next;
 use crate::utils::BoxFuture;
-use crate::{Middleware, Request, Response};
+use crate::{Middleware, Request};
 
 /// An HTTP request handler.
 ///
@@ -51,7 +51,7 @@ use crate::{Middleware, Request, Response};
 /// Tide routes will also accept endpoints with `Fn` signatures of this form, but using the `async` keyword has better ergonomics.
 pub trait Endpoint<State>: Send + Sync + 'static {
     /// Invoke the endpoint within the given context
-    fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, Result<Response>>;
+    fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, crate::Result>;
 }
 
 pub(crate) type DynEndpoint<State> = dyn Endpoint<State>;
@@ -62,7 +62,7 @@ where
     Fut: Future<Output = Result<Res>> + Send + 'static,
     Res: IntoResponse,
 {
-    fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, Result<Response>> {
+    fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, crate::Result> {
         let fut = (self)(req);
         Box::pin(async move {
             let res = fut.await?;
@@ -111,7 +111,7 @@ impl<E, State: 'static> Endpoint<State> for MiddlewareEndpoint<E, State>
 where
     E: Endpoint<State>,
 {
-    fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, Result<Response>> {
+    fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, crate::Result> {
         let next = Next {
             endpoint: &self.endpoint,
             next_middleware: &self.middleware,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@
 //! it's incredibly efficient.
 //!
 //! ```txt
-//! async fn endpoint(req: Request) -> Result<Response>;
+//! async fn endpoint(req: Request) -> Result;
 //! ```
 //!
 //! ## Middleware
@@ -88,7 +88,7 @@
 //! like a stack. A simplified example of the logger middleware is something like this:
 //!
 //! ```ignore
-//! async fn log(req: Request, next: Next) -> Result<Response> {
+//! async fn log(req: Request, next: Next) -> tide::Result {
 //!     println!("Incoming request from {} on url {}", req.peer_addr(), req.url());
 //!     let res = next().await?;
 //!     println!("Outgoing response with status {}", res.status());
@@ -204,7 +204,7 @@ pub use request::Request;
 pub mod sse;
 
 #[doc(inline)]
-pub use http_types::{Body, Error, Result, Status, StatusCode};
+pub use http_types::{Body, Error, Status, StatusCode};
 
 #[doc(inline)]
 pub use middleware::{Middleware, Next};
@@ -271,3 +271,6 @@ where
 {
     Server::with_state(state)
 }
+
+/// A specialized Result type for Tide.
+pub type Result<T = Response> = std::result::Result<T, Error>;

--- a/src/log/middleware.rs
+++ b/src/log/middleware.rs
@@ -1,6 +1,6 @@
 use crate::log;
-use crate::{Middleware, Next, Request, Response};
-use futures_core::future::BoxFuture;
+use crate::utils::BoxFuture;
+use crate::{Middleware, Next, Request};
 
 /// Log all incoming requests and responses.
 ///
@@ -28,7 +28,7 @@ impl LogMiddleware {
         &'a self,
         ctx: Request<State>,
         next: Next<'a, State>,
-    ) -> crate::Result<Response> {
+    ) -> crate::Result {
         let path = ctx.uri().path().to_owned();
         let method = ctx.method().to_string();
         log::trace!("IN => {} {}", method, path);
@@ -65,7 +65,7 @@ impl<State: Send + Sync + 'static> Middleware<State> for LogMiddleware {
         &'a self,
         ctx: Request<State>,
         next: Next<'a, State>,
-    ) -> BoxFuture<'a, crate::Result<Response>> {
+    ) -> BoxFuture<'a, crate::Result> {
         Box::pin(async move { self.log(ctx, next).await })
     }
 }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -4,11 +4,10 @@ use std::sync::Arc;
 
 #[doc(inline)]
 pub use http_service::HttpService;
-use http_types::Result;
 
 use crate::endpoint::DynEndpoint;
 use crate::utils::BoxFuture;
-use crate::{Request, Response};
+use crate::Request;
 
 // mod compression;
 // mod default_headers;
@@ -23,7 +22,7 @@ pub trait Middleware<State>: 'static + Send + Sync {
         &'a self,
         cx: Request<State>,
         next: Next<'a, State>,
-    ) -> BoxFuture<'a, Result<Response>>;
+    ) -> BoxFuture<'a, crate::Result>;
 }
 
 impl<State, F> Middleware<State> for F
@@ -31,13 +30,13 @@ where
     F: Send
         + Sync
         + 'static
-        + for<'a> Fn(Request<State>, Next<'a, State>) -> BoxFuture<'a, crate::Result<Response>>,
+        + for<'a> Fn(Request<State>, Next<'a, State>) -> BoxFuture<'a, crate::Result>,
 {
     fn handle<'a>(
         &'a self,
         req: Request<State>,
         next: Next<'a, State>,
-    ) -> BoxFuture<'a, crate::Result<Response>> {
+    ) -> BoxFuture<'a, crate::Result> {
         (self)(req, next)
     }
 }
@@ -51,7 +50,7 @@ pub struct Next<'a, State> {
 
 impl<'a, State: 'static> Next<'a, State> {
     /// Asynchronously execute the remaining middleware chain.
-    pub fn run(mut self, req: Request<State>) -> BoxFuture<'a, Result<Response>> {
+    pub fn run(mut self, req: Request<State>) -> BoxFuture<'a, crate::Result> {
         if let Some((current, next)) = self.next_middleware.split_first() {
             self.next_middleware = next;
             current.handle(req, self)

--- a/src/redirect/temporary.rs
+++ b/src/redirect/temporary.rs
@@ -32,7 +32,7 @@ pub struct TemporaryRedirect {
 }
 
 impl<State> Endpoint<State> for TemporaryRedirect {
-    fn call<'a>(&'a self, _req: Request<State>) -> BoxFuture<'a, crate::Result<Response>> {
+    fn call<'a>(&'a self, _req: Request<State>) -> BoxFuture<'a, crate::Result> {
         let res = Response::redirect_temporary(&self.location);
         Box::pin(async move { Ok(res) })
     }

--- a/src/response/mod.rs
+++ b/src/response/mod.rs
@@ -62,7 +62,7 @@ impl Response {
     /// # use tide::{Response, Request, StatusCode};
     /// # fn canonicalize(uri: &url::Url) -> Option<&url::Url> { None }
     /// # #[allow(dead_code)]
-    /// async fn route_handler(request: Request<()>) -> tide::Result<Response> {
+    /// async fn route_handler(request: Request<()>) -> tide::Result {
     ///     if let Some(canonical_redirect) = canonicalize(request.uri()) {
     ///         Ok(Response::redirect_permanent(canonical_redirect))
     ///     } else {
@@ -85,7 +85,7 @@ impl Response {
     /// # use tide::{Response, Request, StatusCode};
     /// # fn special_sale_today() -> Option<String> { None }
     /// # #[allow(dead_code)]
-    /// async fn route_handler(request: Request<()>) -> tide::Result<Response> {
+    /// async fn route_handler(request: Request<()>) -> tide::Result {
     ///     if let Some(sale_url) = special_sale_today() {
     ///         Ok(Response::redirect_temporary(sale_url))
     ///     } else {

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,10 +1,9 @@
-use http_types::Result;
 use route_recognizer::{Match, Params, Router as MethodRouter};
 use std::collections::HashMap;
 
 use crate::endpoint::DynEndpoint;
 use crate::utils::BoxFuture;
-use crate::{Request, Response};
+use crate::{Request, Response, StatusCode};
 
 /// The routing table used by `Server`
 ///
@@ -87,10 +86,10 @@ impl<State: 'static> Router<State> {
     }
 }
 
-fn not_found_endpoint<State>(_cx: Request<State>) -> BoxFuture<'static, Result<Response>> {
-    Box::pin(async move { Ok(Response::new(crate::StatusCode::NotFound.into())) })
+fn not_found_endpoint<State>(_cx: Request<State>) -> BoxFuture<'static, crate::Result> {
+    Box::pin(async move { Ok(Response::new(StatusCode::NotFound)) })
 }
 
-fn method_not_allowed<State>(_cx: Request<State>) -> BoxFuture<'static, Result<Response>> {
-    Box::pin(async move { Ok(Response::new(crate::StatusCode::MethodNotAllowed.into())) })
+fn method_not_allowed<State>(_cx: Request<State>) -> BoxFuture<'static, crate::Result> {
+    Box::pin(async move { Ok(Response::new(StatusCode::MethodNotAllowed)) })
 }

--- a/src/security/cors.rs
+++ b/src/security/cors.rs
@@ -3,7 +3,7 @@ use http_types::headers::HeaderValue;
 use http_types::{headers, Method, StatusCode};
 
 use crate::middleware::{Middleware, Next};
-use crate::{Request, Response, Result};
+use crate::{Request, Result};
 
 /// Middleware for CORS
 ///
@@ -145,11 +145,7 @@ impl CorsMiddleware {
 }
 
 impl<State: Send + Sync + 'static> Middleware<State> for CorsMiddleware {
-    fn handle<'a>(
-        &'a self,
-        req: Request<State>,
-        next: Next<'a, State>,
-    ) -> BoxFuture<'a, Result<Response>> {
+    fn handle<'a>(&'a self, req: Request<State>, next: Next<'a, State>) -> BoxFuture<'a, Result> {
         Box::pin(async move {
             let origins = req.header(&headers::ORIGIN).cloned().unwrap_or_default();
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -15,7 +15,7 @@ use crate::log;
 use crate::middleware::{Middleware, Next};
 use crate::router::{Router, Selection};
 use crate::utils::BoxFuture;
-use crate::{Endpoint, Request, Response};
+use crate::{Endpoint, Request};
 
 mod route;
 mod serve_dir;
@@ -360,7 +360,7 @@ impl<State: Sync + Send + 'static> HttpService for Server<State> {
 impl<State: Sync + Send + 'static, InnerState: Sync + Send + 'static> Endpoint<State>
     for Server<InnerState>
 {
-    fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, crate::Result<Response>> {
+    fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, crate::Result> {
         let Request {
             request: req,
             mut route_params,

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -7,7 +7,7 @@ use super::serve_dir::ServeDir;
 use crate::endpoint::MiddlewareEndpoint;
 use crate::log;
 use crate::utils::BoxFuture;
-use crate::{router::Router, Endpoint, Middleware, Response};
+use crate::{router::Router, Endpoint, Middleware};
 
 /// A handle to a route.
 ///
@@ -274,10 +274,7 @@ impl<E> Clone for StripPrefixEndpoint<E> {
 }
 
 impl<State, E: Endpoint<State>> Endpoint<State> for StripPrefixEndpoint<E> {
-    fn call<'a>(
-        &'a self,
-        mut req: crate::Request<State>,
-    ) -> BoxFuture<'a, crate::Result<Response>> {
+    fn call<'a>(&'a self, mut req: crate::Request<State>) -> BoxFuture<'a, crate::Result> {
         let rest = req.rest().unwrap_or("");
         let uri = req.uri();
         let mut new_uri = uri.clone();

--- a/src/server/serve_dir.rs
+++ b/src/server/serve_dir.rs
@@ -20,7 +20,7 @@ impl ServeDir {
 }
 
 impl<State> Endpoint<State> for ServeDir {
-    fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, Result<Response>> {
+    fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, Result> {
         let path = req.uri().path();
         let path = path.replacen(&self.prefix, "", 1);
         let path = path.trim_start_matches('/');

--- a/tests/cookies.rs
+++ b/tests/cookies.rs
@@ -11,19 +11,19 @@ async fn retrieve_cookie(cx: Request<()>) -> tide::Result<String> {
     Ok(cx.cookie(COOKIE_NAME).unwrap().value().to_string())
 }
 
-async fn set_cookie(_req: Request<()>) -> tide::Result<Response> {
+async fn set_cookie(_req: Request<()>) -> tide::Result {
     let mut res = Response::new(StatusCode::Ok);
     res.set_cookie(Cookie::new(COOKIE_NAME, "NewCookieValue"));
     Ok(res)
 }
 
-async fn remove_cookie(_req: Request<()>) -> tide::Result<Response> {
+async fn remove_cookie(_req: Request<()>) -> tide::Result {
     let mut res = Response::new(StatusCode::Ok);
     res.remove_cookie(Cookie::named(COOKIE_NAME));
     Ok(res)
 }
 
-async fn set_multiple_cookie(_req: Request<()>) -> tide::Result<Response> {
+async fn set_multiple_cookie(_req: Request<()>) -> tide::Result {
     let mut res = Response::new(StatusCode::Ok);
     res.set_cookie(Cookie::new("C1", "V1"));
     res.set_cookie(Cookie::new("C2", "V2"));

--- a/tests/querystring.rs
+++ b/tests/querystring.rs
@@ -15,7 +15,7 @@ struct OptionalParams {
     _time: Option<u64>,
 }
 
-async fn handler(cx: Request<()>) -> tide::Result<Response> {
+async fn handler(cx: Request<()>) -> tide::Result {
     let p = cx.query::<Params>();
     match p {
         Ok(params) => Ok(params.msg.into_response()),
@@ -23,7 +23,7 @@ async fn handler(cx: Request<()>) -> tide::Result<Response> {
     }
 }
 
-async fn optional_handler(cx: Request<()>) -> tide::Result<Response> {
+async fn optional_handler(cx: Request<()>) -> tide::Result {
     let p = cx.query::<OptionalParams>();
     match p {
         Ok(_) => Ok(Response::new(StatusCode::Ok)),


### PR DESCRIPTION
This means we no long have to define Result<Response> in every single location, which is the way our type alias used to work before #438. Thanks!