### PR TITLE
Adds logos for docs.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,6 +182,8 @@
 #![warn(missing_debug_implementations, rust_2018_idioms)]
 #![doc(test(attr(deny(rust_2018_idioms, warnings))))]
 #![doc(test(attr(allow(unused_extern_crates, unused_variables))))]
+#![doc(html_favicon_url = "https://yoshuawuyts.com/assets/http-rs/favicon.ico")]
+#![doc(html_logo_url = "https://yoshuawuyts.com/assets/http-rs/logo-rounded.png")]
 
 mod cookies;
 mod endpoint;


### PR DESCRIPTION
Adds logos and favicons to our docs.rs renderings. Because we don't have a custom domain for http-rs I'm hosting it from my own domain for the time being. Thanks!

## Screenshots

![Screenshot_2020-04-23 tide - Rust](https://user-images.githubusercontent.com/2467194/80120968-0c824100-858c-11ea-90ca-a0b3fcb5b420.png)
