### PR TITLE
🐞 add a minimal version of mime guessing to serve_dir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,13 +39,14 @@ serde_json = "1.0.41"
 serde_qs = "0.5.0"
 async-std = { version = "1.4.0", features = ["unstable"] }
 mime = "0.3.14"
-cookie = { version="0.12.0", features = ["percent-encode"]}
+cookie = { version = "0.12.0", features = ["percent-encode"]}
 futures-core = "0.3.1"
 futures = { version = "0.3.1", optional = true }
 http = { version = "0.2.0", optional = true }
 tokio = { version = "0.2.13", optional = true }
 url = "2.1.1"
 kv-log-macro = "1.0.4"
+mime_guess = "2.0.3"
 
 [dev-dependencies]
 async-std = { version = "1.4.0", features = ["unstable", "attributes"] }

--- a/src/server/serve_dir.rs
+++ b/src/server/serve_dir.rs
@@ -69,6 +69,11 @@ impl<State> Endpoint<State> for ServeDir {
             // TODO: fix related bug where async-h1 crashes on large files
             let mut res = Response::new(StatusCode::Ok);
             res.set_body(body);
+
+            if let Some(content_type) = mime_guess::from_path(&file_path).first() {
+                res = res.set_mime(content_type);
+            }
+
             Ok(res)
         })
     }


### PR DESCRIPTION
this is probably just a stopgap, but resolves the issue wherein browsers download text files served with a generic binary stream content type