### PR TITLE
Add Response::from_res

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -247,10 +247,23 @@ impl Response {
         self.res.local_mut().insert(val);
         self
     }
+
+    /// Create a `tide::Response` from a type that can be converted into an
+    /// `http_types::Response`.
+    pub fn from_res<T>(value: T) -> Self
+    where
+        T: Into<http_types::Response>,
+    {
+        let res: http_types::Response = value.into();
+        Self {
+            res,
+            cookie_events: vec![],
+        }
+    }
 }
 
 impl Into<http::Response> for Response {
-    fn into(self) -> http::Response {
+    fn into(self) -> http_types::Response {
         self.res
     }
 }


### PR DESCRIPTION
This adds `Response::from_res` which enables us to bridge with `Surf` for  authoring proxies conveniently. We couldn't add this as a generic `From` bound because it would conflict with existing implementations.

This was in response to this [this example](https://gist.github.com/jbr/d5c4fec7368eae5a372b6ae403b9c67f) which proxies from surf -> tide, which would allow us to rewrite the core logic from ~10 lines to 2 lines.

```rust
let res = surf::get(...).await?;
Ok(Response::from_res(res))
```