### PR TITLE
Remove default middlewares from server creation

### DIFF
--- a/src/security/cors.rs
+++ b/src/security/cors.rs
@@ -367,7 +367,7 @@ mod test {
 
     #[async_std::test]
     async fn retain_cookies() {
-        let mut app = crate::Server::new();
+        let mut app = crate::Server::new().with_cookies();
         app.middleware(CorsMiddleware::new().allow_origin(ALLOW_ORIGIN));
         app.at(ENDPOINT).get(|_| async {
             let mut res = crate::Response::new(http_types::StatusCode::Ok);

--- a/src/server.rs
+++ b/src/server.rs
@@ -199,14 +199,31 @@ impl<State: Send + Sync + 'static> Server<State> {
     /// # Ok(()) }) }
     /// ```
     pub fn with_state(state: State) -> Self {
-        let mut server = Self {
+        Self {
             router: Arc::new(Router::new()),
             middleware: Arc::new(vec![]),
             state: Arc::new(state),
-        };
-        server.middleware(cookies::CookiesMiddleware::new());
-        server.middleware(log::LogMiddleware::new());
-        server
+        }
+    }
+
+    /// Add the logging middleware to an application.
+    ///
+    /// ```rust,no_run
+    /// # let app = tide::Server::new().with_logging();
+    /// ```
+    pub fn with_logging(mut self) -> Self {
+        self.middleware(log::LogMiddleware::new());
+        self
+    }
+
+    /// Add the cookies middleware to an application.
+    ///
+    /// ```rust,no_run
+    /// # let app = tide::Server::new().with_cookies();
+    /// ```
+    pub fn with_cookies(mut self) -> Self {
+        self.middleware(cookies::CookiesMiddleware::new());
+        self
     }
 
     /// Add a new route at the given `path`, relative to root.

--- a/tests/cookies.rs
+++ b/tests/cookies.rs
@@ -34,7 +34,7 @@ async fn set_multiple_cookie(_req: Request<()>) -> tide::Result {
 }
 
 fn app() -> crate::Server<()> {
-    let mut app = tide::new();
+    let mut app = tide::new().with_cookies();
 
     app.at("/get").get(retrieve_cookie);
     app.at("/set").get(insert_cookie);


### PR DESCRIPTION
Fixes #396 #476 #551 in that it removes the default logging and cookies middlewares from `Server::with_state()` and allows users to use their own middlewares, or use the default ones from the framework by calling `with_cookies()` and/or `with_logging()` on the server instance.