### PR TITLE
Remove Ok(()) with .await as end statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ async-std = { version = "1.5.0", features = ["attributes"] }
 async fn main() -> Result<(), std::io::Error> {
     let mut app = tide::new();
     app.at("/").get(|_| async { Ok("Hello, world!") });
-    app.listen("127.0.0.1:8080").await?;
-    Ok(())
+    app.listen("127.0.0.1:8080").await
 }
 ```
 

--- a/examples/chunked.rs
+++ b/examples/chunked.rs
@@ -11,7 +11,6 @@ fn main() -> Result<(), std::io::Error> {
             let res = Response::new(StatusCode::Ok).body(BufReader::new(file));
             Ok(res)
         });
-        app.listen("127.0.0.1:8080").await?;
-        Ok(())
+        app.listen("127.0.0.1:8080").await
     })
 }

--- a/examples/cookies.rs
+++ b/examples/cookies.rs
@@ -27,8 +27,6 @@ fn main() -> Result<(), std::io::Error> {
         app.at("/").get(retrieve_cookie);
         app.at("/set").get(set_cookie);
         app.at("/remove").get(remove_cookie);
-        app.listen("127.0.0.1:8080").await?;
-
-        Ok(())
+        app.listen("127.0.0.1:8080").await
     })
 }

--- a/examples/fib.rs
+++ b/examples/fib.rs
@@ -25,6 +25,7 @@ async fn fibsum(req: Request<()>) -> tide::Result<String> {
     );
     Ok(res)
 }
+
 // Example: HTTP GET to http://localhost:8080/fib/42
 // $ curl "http://localhost:8080/fib/42"
 // The fib of 42 is 267914296.
@@ -33,7 +34,6 @@ fn main() -> Result<(), std::io::Error> {
     task::block_on(async {
         let mut app = tide::new();
         app.at("/fib/:n").get(fibsum);
-        app.listen("0.0.0.0:8080").await?;
-        Ok(())
+        app.listen("0.0.0.0:8080").await
     })
 }

--- a/examples/graphql.rs
+++ b/examples/graphql.rs
@@ -107,7 +107,6 @@ fn main() -> std::io::Result<()> {
         app.at("/").get(redirect::permanent("/graphiql"));
         app.at("/graphql").post(handle_graphql);
         app.at("/graphiql").get(handle_graphiql);
-        app.listen("0.0.0.0:8080").await?;
-        Ok(())
+        app.listen("0.0.0.0:8080").await
     })
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -4,7 +4,6 @@ fn main() -> Result<(), std::io::Error> {
     task::block_on(async {
         let mut app = tide::new();
         app.at("/").get(|_| async move { Ok("Hello, world!") });
-        app.listen("127.0.0.1:8080").await?;
-        Ok(())
+        app.listen("127.0.0.1:8080").await
     })
 }

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -23,7 +23,6 @@ fn main() -> io::Result<()> {
             Ok(Response::new(StatusCode::Ok).body_json(&cat)?)
         });
 
-        app.listen("127.0.0.1:8080").await?;
-        Ok(())
+        app.listen("127.0.0.1:8080").await
     })
 }

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -9,6 +9,5 @@ async fn main() -> Result<(), std::io::Error> {
             .get(|_| async move { Ok("Goodbye, world") });
         api
     });
-    app.listen("127.0.0.1:8080").await?;
-    Ok(())
+    app.listen("127.0.0.1:8080").await
 }

--- a/examples/sse.rs
+++ b/examples/sse.rs
@@ -8,6 +8,5 @@ async fn main() -> Result<(), std::io::Error> {
         sender.send("fruit", "apple", None).await;
         Ok(())
     }));
-    app.listen("localhost:8080").await?;
-    Ok(())
+    app.listen("localhost:8080").await
 }

--- a/examples/static_file.rs
+++ b/examples/static_file.rs
@@ -7,7 +7,6 @@ fn main() -> Result<(), std::io::Error> {
         let mut app = tide::new();
         app.at("/").get(|_| async move { Ok("visit /src/*") });
         app.at("/src").serve_dir("src/")?;
-        app.listen("127.0.0.1:8080").await?;
-        Ok(())
+        app.listen("127.0.0.1:8080").await
     })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,9 +30,9 @@
 //! #
 //! let mut app = tide::new();
 //! app.at("/").get(|_| async move { Ok("Hello, world!") });
-//! app.listen("127.0.0.1:8080").await?;
+//! app.listen("127.0.0.1:8080").await
 //! #
-//! # Ok(()) }) }
+//! # }) }
 //! ```
 //!
 //! __echo server__
@@ -42,9 +42,9 @@
 //! #
 //! let mut app = tide::new();
 //! app.at("/").get(|req| async move { Ok(req) });
-//! app.listen("127.0.0.1:8080").await?;
+//! app.listen("127.0.0.1:8080").await
 //! #
-//! # Ok(()) }) }
+//! # }) }
 //! ````
 //!
 //! __send and receive json__
@@ -63,9 +63,9 @@
 //!    counter.count += 1;
 //!    Ok(Response::new(tide::http::StatusCode::Ok).body_json(&counter)?)
 //! });
-//! app.listen("127.0.0.1:8080").await?;
+//! app.listen("127.0.0.1:8080").await
 //! #
-//! # Ok(()) }) }
+//! # }) }
 //! ```
 //!
 //! # Concepts
@@ -226,9 +226,9 @@ pub use http_types as http;
 /// #
 /// let mut app = tide::new();
 /// app.at("/").get(|_| async move { Ok("Hello, world!") });
-/// app.listen("127.0.0.1:8080").await?;
+/// app.listen("127.0.0.1:8080").await
 /// #
-/// # Ok(()) }) }
+/// # }) }
 /// ```
 pub fn new() -> server::Server<()> {
     Server::new()
@@ -261,9 +261,9 @@ pub fn new() -> server::Server<()> {
 /// app.at("/").get(|req: Request<State>| async move {
 ///     Ok(format!("Hello, {}!", &req.state().name))
 /// });
-/// app.listen("127.0.0.1:8080").await?;
+/// app.listen("127.0.0.1:8080").await
 /// #
-/// # Ok(()) }) }
+/// # }) }
 /// ```
 pub fn with_state<State>(state: State) -> server::Server<State>
 where

--- a/src/redirect/mod.rs
+++ b/src/redirect/mod.rs
@@ -11,9 +11,9 @@
 //! let mut app = tide::new();
 //! app.at("/").get(|_| async move { Ok("meow") });
 //! app.at("/nori").get(redirect::temporary("/"));
-//! app.listen("127.0.0.1:8080").await?;
+//! app.listen("127.0.0.1:8080").await
 //! #
-//! # Ok(()) }) }
+//! # }) }
 //! ```
 mod permanent;
 mod temporary;

--- a/src/redirect/permanent.rs
+++ b/src/redirect/permanent.rs
@@ -16,9 +16,9 @@ use crate::{Endpoint, Request, Response};
 /// let mut app = tide::new();
 /// app.at("/").get(|_| async move { Ok("meow") });
 /// app.at("/nori").get(redirect::permanent("/"));
-/// app.listen("127.0.0.1:8080").await?;
+/// app.listen("127.0.0.1:8080").await
 /// #
-/// # Ok(()) }) }
+/// # }) }
 /// ```
 pub fn permanent(location: impl AsRef<str>) -> PermanentRedirect {
     let location = location.as_ref().to_owned();

--- a/src/redirect/temporary.rs
+++ b/src/redirect/temporary.rs
@@ -16,9 +16,9 @@ use crate::{Endpoint, Request, Response};
 /// let mut app = tide::new();
 /// app.at("/").get(|_| async move { Ok("meow") });
 /// app.at("/nori").get(redirect::temporary("/"));
-/// app.listen("127.0.0.1:8080").await?;
+/// app.listen("127.0.0.1:8080").await
 /// #
-/// # Ok(()) }) }
+/// # }) }
 /// ```
 pub fn temporary(location: impl AsRef<str>) -> TemporaryRedirect {
     let location = location.as_ref().to_owned();

--- a/src/request.rs
+++ b/src/request.rs
@@ -57,9 +57,9 @@ impl<State> Request<State> {
     ///     assert_eq!(req.method(), http_types::Method::Get);
     ///     Ok("")
     /// });
-    /// app.listen("127.0.0.1:8080").await?;
+    /// app.listen("127.0.0.1:8080").await
     /// #
-    /// # Ok(()) })}
+    /// # })}
     /// ```
     pub fn method(&self) -> Method {
         self.request.method()
@@ -80,9 +80,9 @@ impl<State> Request<State> {
     ///     assert_eq!(req.uri(), &"/".parse::<tide::http::Url>().unwrap());
     ///     Ok("")
     /// });
-    /// app.listen("127.0.0.1:8080").await?;
+    /// app.listen("127.0.0.1:8080").await
     /// #
-    /// # Ok(()) })}
+    /// # })}
     /// ```
     pub fn uri(&self) -> &Url {
         self.request.url()
@@ -103,9 +103,9 @@ impl<State> Request<State> {
     ///     assert_eq!(req.version(), Some(http_types::Version::Http1_1));
     ///     Ok("")
     /// });
-    /// app.listen("127.0.0.1:8080").await?;
+    /// app.listen("127.0.0.1:8080").await
     /// #
-    /// # Ok(()) })}
+    /// # })}
     /// ```
     pub fn version(&self) -> Option<Version> {
         self.request.version()
@@ -126,9 +126,9 @@ impl<State> Request<State> {
     ///     assert_eq!(req.header(&"X-Forwarded-For".parse().unwrap()), Some(&vec!["127.0.0.1".parse().unwrap()]));
     ///     Ok("")
     /// });
-    /// app.listen("127.0.0.1:8080").await?;
+    /// app.listen("127.0.0.1:8080").await
     /// #
-    /// # Ok(()) })}
+    /// # })}
     /// ```
     pub fn header(
         &self,
@@ -208,9 +208,9 @@ impl<State> Request<State> {
     ///     let _body: Vec<u8> = req.body_bytes().await.unwrap();
     ///     Ok("")
     /// });
-    /// app.listen("127.0.0.1:8080").await?;
+    /// app.listen("127.0.0.1:8080").await
     /// #
-    /// # Ok(()) })}
+    /// # })}
     /// ```
     pub async fn body_bytes(&mut self) -> std::io::Result<Vec<u8>> {
         let mut buf = Vec::with_capacity(1024);
@@ -243,9 +243,9 @@ impl<State> Request<State> {
     ///     let _body: String = req.body_string().await.unwrap();
     ///     Ok("")
     /// });
-    /// app.listen("127.0.0.1:8080").await?;
+    /// app.listen("127.0.0.1:8080").await
     /// #
-    /// # Ok(()) })}
+    /// # })}
     /// ```
     pub async fn body_string(&mut self) -> std::io::Result<String> {
         let body_bytes = self.body_bytes().await?;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -153,9 +153,9 @@ impl Server<()> {
     /// #
     /// let mut app = tide::new();
     /// app.at("/").get(|_| async move { Ok("Hello, world!") });
-    /// app.listen("127.0.0.1:8080").await?;
+    /// app.listen("127.0.0.1:8080").await
     /// #
-    /// # Ok(()) }) }
+    /// # }) }
     /// ```
     pub fn new() -> Server<()> {
         Self::with_state(())
@@ -196,9 +196,9 @@ impl<State: Send + Sync + 'static> Server<State> {
     /// app.at("/").get(|req: Request<State>| async move {
     ///     Ok(format!("Hello, {}!", &req.state().name))
     /// });
-    /// app.listen("127.0.0.1:8080").await?;
+    /// app.listen("127.0.0.1:8080").await
     /// #
-    /// # Ok(()) }) }
+    /// # }) }
     /// ```
     pub fn with_state(state: State) -> Server<State> {
         let mut server = Server {

--- a/src/server/route.rs
+++ b/src/server/route.rs
@@ -125,8 +125,7 @@ impl<'a, State: 'static> Route<'a, State> {
     /// async fn main() -> Result<(), std::io::Error> {
     ///     let mut app = tide::new();
     ///     app.at("/public/images").serve_dir("images/")?;
-    ///     app.listen("127.0.0.1:8080").await?;
-    ///     Ok(())
+    ///     app.listen("127.0.0.1:8080").await
     /// }
     /// ```
     pub fn serve_dir(&mut self, dir: impl AsRef<Path>) -> io::Result<()> {

--- a/src/sse/mod.rs
+++ b/src/sse/mod.rs
@@ -22,8 +22,8 @@
 //!     sender.send("fruit", "apple", None).await;
 //!     Ok(())
 //! }));
-//! app.listen("localhost:8080").await?;
-//! # Ok(()) }) }
+//! app.listen("localhost:8080").await
+//! # }) }
 //! ```
 
 mod endpoint;


### PR DESCRIPTION
Make `app.listen` more ergonomic.

Before

```rust
#[async_std::main]
async fn main() -> Result<(), std::io::Error> {
    let mut app = tide::new();
    app.at("/").get(|_| async { Ok("Hello, world!") });
    app.listen("127.0.0.1:8080").await?;
    Ok(())
}
```

After

```rust
#[async_std::main]
async fn main() -> Result<(), std::io::Error> {
    let mut app = tide::new();
    app.at("/").get(|_| async { Ok("Hello, world!") });
    app.listen("127.0.0.1:8080").await
}
```
