### PR TITLE
Fix crate version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ and **not ready for production yet**.
 Add two dependencies to your project's `Cargo.toml` file: `tide` itself, and `async-std` with the feature `attributes` enabled:
 ```toml
 # Example, use the version numbers you need
-tide = "0.7.0"
+tide = "0.8.0"
 async-std = { version = "1.5.0", features = ["attributes"] }
 ```
 


### PR DESCRIPTION
Examples won't work with `0.7.0`.