### PR TITLE
Small docstring fix for Response::body_json()

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -189,7 +189,7 @@ impl Response {
             .set_mime(mime::APPLICATION_WWW_FORM_URLENCODED))
     }
 
-    /// Encode a struct as a form and set as the response body.
+    /// Encode a struct as JSON and set as the response body.
     ///
     /// # Mime
     ///


### PR DESCRIPTION
I assume the "as a form" is copy-paste from body_form() above.