### PR TITLE
init default logger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ async-h1 = { version = "1.1.2", optional = true }
 async-sse = "2.1.0"
 async-std = { version = "1.4.0", features = ["unstable"] }
 cookie = { version = "0.12.0", features = ["percent-encode"]}
+femme = "2.0.1"
 http-types = "1.0.1"
 kv-log-macro = "1.0.4"
 mime = "0.3.14"
@@ -42,7 +43,6 @@ route-recognizer = "0.1.13"
 serde = "1.0.102"
 serde_json = "1.0.41"
 serde_qs = "0.5.0"
-femme = { path = "../../femme" }
 
 [dev-dependencies]
 async-std = { version = "1.4.0", features = ["unstable", "attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ route-recognizer = "0.1.13"
 serde = "1.0.102"
 serde_json = "1.0.41"
 serde_qs = "0.5.0"
-femme = "1.3.0"
+femme = { path = "../../femme" }
 
 [dev-dependencies]
 async-std = { version = "1.4.0", features = ["unstable", "attributes"] }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,10 +1,8 @@
-use async_std::task;
-
-fn main() -> Result<(), std::io::Error> {
-    task::block_on(async {
-        let mut app = tide::new();
-        app.at("/").get(|_| async move { Ok("Hello, world!") });
-        app.listen("127.0.0.1:8080").await?;
-        Ok(())
-    })
+#[async_std::main]
+async fn main() -> Result<(), std::io::Error> {
+    tide::log::start();
+    let mut app = tide::new();
+    app.at("/").get(|_| async move { Ok("Hello, world!") });
+    app.listen("127.0.0.1:8080").await?;
+    Ok(())
 }

--- a/examples/static_file.rs
+++ b/examples/static_file.rs
@@ -1,13 +1,9 @@
-use async_std::task;
-use tide::log;
-
-fn main() -> Result<(), std::io::Error> {
-    femme::start(log::Level::Info.to_level_filter()).unwrap();
-    task::block_on(async {
-        let mut app = tide::new();
-        app.at("/").get(|_| async move { Ok("visit /src/*") });
-        app.at("/src").serve_dir("src/")?;
-        app.listen("127.0.0.1:8080").await?;
-        Ok(())
-    })
+#[async_std::main]
+async fn main() -> Result<(), std::io::Error> {
+    tide::log::start();
+    let mut app = tide::new();
+    app.at("/").get(|_| async move { Ok("visit /src/*") });
+    app.at("/src").serve_dir("src/")?;
+    app.listen("127.0.0.1:8080").await?;
+    Ok(())
 }

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -5,9 +5,7 @@
 //! ```no_run
 //! use tide::log;
 //!
-//! // `tide::log` requires starting a third-party logger such as `femme`. We may
-//! // ship such a logger as part of Tide in the future.
-//! femme::start(log::Level::Info.to_level_filter()).unwrap();
+//! log::start();
 //!
 //! log::info!("Hello cats");
 //! log::debug!("{} wants tuna", "Nori");

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -23,4 +23,17 @@ pub use kv_log_macro::{max_level, Level};
 
 mod middleware;
 
+pub use femme::LevelFilter;
 pub use middleware::LogMiddleware;
+
+/// Start logging.
+pub fn start() {
+    femme::start();
+    crate::log::info!("Logger started", { level: "Info" });
+}
+
+/// Start logging with a log level.
+pub fn with_level(level: LevelFilter) {
+    femme::with_level(level);
+    crate::log::info!("Logger started", { level: format!("{}", level) });
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -283,9 +283,15 @@ impl<State: Send + Sync + 'static> Server<State> {
         let listener = async_std::net::TcpListener::bind(addr).await?;
 
         let addr = format!("http://{}", listener.local_addr()?);
-        log::info!("Server is listening on: {}", addr);
-        let mut incoming = listener.incoming();
+        let tls = false;
+        let target = if cfg!(debug_assertions) {
+            "dev"
+        } else {
+            "release"
+        };
+        log::info!("Server listening", { address: addr, target: target, tls: tls });
 
+        let mut incoming = listener.incoming();
         while let Some(stream) = incoming.next().await {
             let stream = stream?;
             let addr = addr.clone();


### PR DESCRIPTION
Relies on https://github.com/lrlna/femme/pull/9. Adds a default logger that supports `log`'s key-value API. A base "hello world" example now looks like this:

```rust
#[async_std::main]
async fn main() -> Result<(), std::io::Error> {
    tide::log::start();
    let mut app = tide::new();
    app.at("/").get(|_| async move { Ok("Hello, world!") });
    app.listen("127.0.0.1:8080").await?;
    Ok(())
}
```

---

There's a bit of a design question whether we should expose this as a separate function, or integrate it directly into the framework. I think logging is kind of on the fringe here since it not only captures things going on *inside* the framework; it captures things going on outside of it as well.

I feel that making it a single line to enable logging strikes a good balance between the two -- we make it easy to get a good setup going with minimal work, but we don't enable things that have global implications for the program without consulting the user.

# Screenshots
<img src ="https://user-images.githubusercontent.com/2467194/81590260-d5e55c80-93ba-11ea-90c5-28cc6c4144c5.png" width = 400px />
