### PR TITLE
impl `Response::redirect_see_other`

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -95,6 +95,30 @@ impl Response {
             .set_header("location".parse().unwrap(), location)
     }
 
+    /// Creates a response that represents a see other redirect to `location`.
+    ///
+    /// GET methods are unchanged.
+    /// Other methods are changed to GET and their body lost.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use tide::{Response, Request, StatusCode};
+    /// # fn next_product() -> Option<String> { None }
+    /// # #[allow(dead_code)]
+    /// async fn route_handler(request: Request<()>) -> tide::Result {
+    ///     if let Some(product_url) = next_product() {
+    ///         Ok(Response::redirect_see_other(product_url))
+    ///     } else {
+    ///         //...
+    /// #       Ok(Response::new(StatusCode::Ok)) //...
+    ///     }
+    /// }
+    /// ```
+    pub fn redirect_see_other(location: impl AsRef<str>) -> Self {
+        Response::new(StatusCode::SeeOther).set_header("location".parse().unwrap(), location)
+    }
+
     /// Returns the statuscode.
     pub fn status(&self) -> crate::StatusCode {
         self.res.status()


### PR DESCRIPTION
I just felt that this seemed to be missing.

`307` `Temporary Redirect` and `308`  `Permanent Redirect` result in undesired behaviour when you  want to simply display another page after processing a `post` request as `post` requests remain `post`s on the new URL.

`303` `See Other` Does not have this issue as it converts everything to `get`.
