### PR TITLE
Add Server::respond

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -304,12 +304,12 @@ impl<State: Send + Sync + 'static> Server<State> {
     /// #
     /// use tide::http::{Url, Method, Request, Response};
     ///
-    /// // Initialize the application with state.
     /// let mut app = tide::new();
     /// app.at("/").get(|_| async move { Ok("hello world") });
     ///
     /// let req = Request::new(Method::Get, Url::parse("https://example.com")?);
     /// let res: Response = app.respond(req).await?;
+    ///
     /// assert_eq!(res.status(), 200);
     /// #
     /// # Ok(()) }


### PR DESCRIPTION
This adds `Server::respond`, replacing most of the functionality provided by the `http-service` trait. This allows passing arbitrary requests into the server, and always get responses back out. The goal is that we remove the `http-service` functionality in a future PR entirely, and replace it with this method instead.

What this enables us to do is to construct requests using `Surf`, and then pass them into `Tide` without a problem:

```rust
let mut app = tide::new();
app.at("/").get(|_| async move { Ok("hello world") });

let req = surf::get("https://business.soup");
let res: surf::Response = app.respond(req).await?;

assert_eq!(res.status(), 200);
```

## Screenshots

![Screenshot_2020-05-15 tide Server - Rust](https://user-images.githubusercontent.com/2467194/81994218-a26b3200-9647-11ea-90a5-471723db7c27.png)
