### PR TITLE
Remove http service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ structopt = "0.3.3"
 surf = "2.0.0-alpha.1"
 futures = "0.3.1"
 femme = "1.3.0"
+portpicker = "0.1.0"
 
 [[test]]
 name = "nested"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,15 +24,14 @@ rustdoc-args = ["--cfg", "feature=\"docs\""]
 
 [features]
 default = ["h1-server"]
-h1-server = ["http-service-h1"]
+h1-server = ["async-h1"]
 docs = ["unstable"]
 unstable = []
 
 [dependencies]
 async-sse = "2.1.0"
 http-types = "1.0.1"
-http-service = "0.5.0"
-http-service-h1 = { version = "0.1.0", optional = true }
+async-h1 = { version = "1.1.2", optional = true }
 route-recognizer = "0.1.13"
 serde = "1.0.102"
 serde_json = "1.0.41"
@@ -54,7 +53,6 @@ basic-cookies = "0.1.3"
 bytes = "0.4.12"
 futures-fs = "0.0.5"
 futures-util = { version = "0.3.0", features = ["compat"] }
-http-service-mock = "0.5.0"
 juniper = "0.14.1"
 mime = "0.3.14"
 mime_guess = "2.0.1"

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -2,9 +2,6 @@
 
 use std::sync::Arc;
 
-#[doc(inline)]
-pub use http_service::HttpService;
-
 use crate::endpoint::DynEndpoint;
 use crate::utils::BoxFuture;
 use crate::Request;

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,8 +1,4 @@
 use cookie::Cookie;
-use http_types::{
-    headers::{HeaderName, HeaderValue},
-    Method, StatusCode, Url, Version,
-};
 use route_recognizer::Params;
 use serde::Deserialize;
 
@@ -13,6 +9,8 @@ use std::pin::Pin;
 use std::{str::FromStr, sync::Arc};
 
 use crate::cookies::CookieData;
+use crate::http::headers::{HeaderName, HeaderValue};
+use crate::http::{self, Method, StatusCode, Url, Version};
 use crate::Response;
 
 /// An HTTP request.
@@ -25,7 +23,7 @@ use crate::Response;
 #[derive(Debug)]
 pub struct Request<State> {
     pub(crate) state: Arc<State>,
-    pub(crate) request: http_service::Request,
+    pub(crate) request: http::Request,
     pub(crate) route_params: Vec<Params>,
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -2,13 +2,11 @@ use async_std::io::prelude::*;
 use std::convert::TryFrom;
 
 use cookie::Cookie;
-use http_service::Body;
-use http_types::{
-    headers::{HeaderName, HeaderValue},
-    StatusCode,
-};
 use mime::Mime;
 use serde::Serialize;
+
+use crate::http::headers::{HeaderName, HeaderValue};
+use crate::http::{self, Body, StatusCode};
 
 #[derive(Debug)]
 pub(crate) enum CookieEvent {
@@ -19,7 +17,7 @@ pub(crate) enum CookieEvent {
 /// An HTTP response
 #[derive(Debug)]
 pub struct Response {
-    pub(crate) res: http_service::Response,
+    pub(crate) res: http::Response,
     // tracking here
     pub(crate) cookie_events: Vec<CookieEvent>,
 }
@@ -246,14 +244,14 @@ impl Response {
     }
 }
 
-impl Into<http_service::Response> for Response {
-    fn into(self) -> http_service::Response {
+impl Into<http::Response> for Response {
+    fn into(self) -> http::Response {
         self.res
     }
 }
 
-impl From<http_service::Response> for Response {
-    fn from(res: http_service::Response) -> Self {
+impl From<http::Response> for Response {
+    fn from(res: http::Response) -> Self {
         Self {
             res,
             cookie_events: vec![],

--- a/src/security/cors.rs
+++ b/src/security/cors.rs
@@ -2,6 +2,7 @@ use crate::utils::BoxFuture;
 use http_types::headers::HeaderValue;
 use http_types::{headers, Method, StatusCode};
 
+use crate::http;
 use crate::middleware::{Middleware, Next};
 use crate::{Request, Result};
 
@@ -167,7 +168,7 @@ impl<State: Send + Sync + 'static> Middleware<State> for CorsMiddleware {
                 return Ok(self.build_preflight_response(&origins).into());
             }
 
-            let mut response: http_service::Response = next.run(req).await?.into();
+            let mut response: http::Response = next.run(req).await?.into();
             response
                 .insert_header(
                     headers::ACCESS_CONTROL_ALLOW_ORIGIN,

--- a/src/server.rs
+++ b/src/server.rs
@@ -335,8 +335,8 @@ impl<State: Send + Sync + 'static> Server<State> {
     {
         let req = Request::new(self.state.clone(), req.into(), Vec::new());
         match self.call(req).await {
-            Ok(value) => {
-                let res: http_types::Response = value.into();
+            Ok(res) => {
+                let res: http_types::Response = res.into();
                 // We assume that if an error was manually cast to a
                 // Response that we actually want to send the body to the
                 // client. At this point we don't scrub the message.

--- a/src/server.rs
+++ b/src/server.rs
@@ -304,12 +304,12 @@ impl<State: Send + Sync + 'static> Server<State> {
     /// #
     /// use tide::http::{Url, Method, Request, Response};
     ///
-    /// // Initialize the application with state.
     /// let mut app = tide::new();
     /// app.at("/").get(|_| async move { Ok("hello world") });
     ///
     /// let req = Request::new(Method::Get, Url::parse("https://example.com")?);
     /// let res: Response = app.respond(req).await?;
+    ///
     /// assert_eq!(res.status(), 200);
     /// #
     /// # Ok(()) }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,14 +1,12 @@
 //! An HTTP server
 
-use async_std::future::Future;
 use async_std::io;
 use async_std::net::ToSocketAddrs;
+use async_std::prelude::*;
 use async_std::sync::Arc;
-use async_std::task::{Context, Poll};
-use http_service::HttpService;
+use async_std::task;
 
 use std::fmt::Debug;
-use std::pin::Pin;
 
 use crate::cookies;
 use crate::log;
@@ -281,14 +279,31 @@ impl<State: Send + Sync + 'static> Server<State> {
 
     /// Asynchronously serve the app at the given address.
     #[cfg(feature = "h1-server")]
-    pub async fn listen(self, addr: impl ToSocketAddrs) -> std::io::Result<()> {
+    pub async fn listen(self, addr: impl ToSocketAddrs) -> io::Result<()> {
         let listener = async_std::net::TcpListener::bind(addr).await?;
 
         let addr = format!("http://{}", listener.local_addr()?);
         log::info!("Server is listening on: {}", addr);
-        let mut server = http_service_h1::Server::new(addr, listener.incoming(), self);
+        let mut incoming = listener.incoming();
 
-        server.run().await
+        while let Some(stream) = incoming.next().await {
+            let stream = stream?;
+            let addr = addr.clone();
+            let this = self.clone();
+            task::spawn(async move {
+                let res = async_h1::accept(&addr, stream, |req| async {
+                    let res = this.respond(req).await;
+                    let res = res.map_err(|_| io::Error::from(io::ErrorKind::Other))?;
+                    Ok(res)
+                })
+                .await;
+
+                if let Err(err) = res {
+                    log::error!("async-h1 error", { error: err.to_string() });
+                }
+            });
+        }
+        Ok(())
     }
 
     /// Respond to a `Request` with a `Response`.
@@ -349,56 +364,6 @@ impl<State> Clone for Server<State> {
             state: self.state.clone(),
             middleware: self.middleware.clone(),
         }
-    }
-}
-
-#[derive(Debug)]
-pub struct ReadyFuture;
-
-impl Future for ReadyFuture {
-    type Output = io::Result<()>;
-
-    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
-        Poll::Ready(Ok(()))
-    }
-}
-
-impl<State: Sync + Send + 'static> HttpService for Server<State> {
-    type Connection = ();
-    type ConnectionFuture = ReadyFuture;
-    type ConnectionError = io::Error;
-    type ResponseFuture = BoxFuture<'static, Result<http_service::Response, http_types::Error>>;
-    type ResponseError = http_types::Error;
-
-    fn connect(&self) -> Self::ConnectionFuture {
-        ReadyFuture {}
-    }
-
-    fn respond(&self, _conn: (), req: http_service::Request) -> Self::ResponseFuture {
-        let req = Request::new(self.state.clone(), req, Vec::new());
-        let service = self.clone();
-        Box::pin(async move {
-            match service.call(req).await {
-                Ok(value) => {
-                    let res = value.into();
-                    // We assume that if an error was manually cast to a
-                    // Response that we actually want to send the body to the
-                    // client. At this point we don't scrub the message.
-                    Ok(res)
-                }
-                Err(err) => {
-                    let mut res = http_types::Response::new(err.status());
-                    res.set_content_type(http_types::mime::PLAIN);
-                    // Only send the message if it is a non-500 range error. All
-                    // errors default to 500 by default, so sending the error
-                    // body is opt-in at the call site.
-                    if !res.status().is_server_error() {
-                        res.set_body(err.to_string());
-                    }
-                    Ok(res)
-                }
-            }
-        })
     }
 }
 

--- a/tests/chunked-encode-large.rs
+++ b/tests/chunked-encode-large.rs
@@ -68,7 +68,7 @@ const TEXT: &'static str = concat![
 
 #[async_std::test]
 async fn chunked_large() -> Result<(), http_types::Error> {
-    let bind = test_utils::find_port().await;
+    let port = test_utils::find_port().await;
     let server = task::spawn(async move {
         let mut app = tide::new();
         app.at("/").get(|mut _req: tide::Request<()>| async {
@@ -78,13 +78,13 @@ async fn chunked_large() -> Result<(), http_types::Error> {
                 .set_header(headers::CONTENT_TYPE, "text/plain; charset=utf-8");
             Ok(res)
         });
-        app.listen(&bind).await?;
+        app.listen(("localhost", port)).await?;
         Result::<(), http_types::Error>::Ok(())
     });
 
     let client = task::spawn(async move {
         task::sleep(Duration::from_millis(100)).await;
-        let mut res = surf::get(format!("http://{}", bind)).await?;
+        let mut res = surf::get(format!("http://localhost:{}", port)).await?;
         assert_eq!(res.status(), 200);
         assert_eq!(
             res.header(&"transfer-encoding".parse().unwrap()),

--- a/tests/chunked-encode-small.rs
+++ b/tests/chunked-encode-small.rs
@@ -27,13 +27,13 @@ async fn chunked_large() -> Result<(), http_types::Error> {
                 .set_header(headers::CONTENT_TYPE, "text/plain; charset=utf-8");
             Ok(res)
         });
-        app.listen(&port).await?;
+        app.listen(("localhost", port)).await?;
         Result::<(), http_types::Error>::Ok(())
     });
 
     let client = task::spawn(async move {
         task::sleep(Duration::from_millis(100)).await;
-        let mut res = surf::get(format!("http://{}", port)).await?;
+        let mut res = surf::get(format!("http://localhost:{}", port)).await?;
         assert_eq!(res.status(), 200);
         assert_eq!(
             res.header(&"transfer-encoding".parse().unwrap()),

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -17,13 +17,13 @@ fn hello_world() -> Result<(), http_types::Error> {
                 let res = Response::new(StatusCode::Ok).body_string("says hello".to_string());
                 Ok(res)
             });
-            app.listen(&port).await?;
+            app.listen(("localhost", port)).await?;
             Result::<(), http_types::Error>::Ok(())
         });
 
         let client = task::spawn(async move {
             task::sleep(Duration::from_millis(100)).await;
-            let string = surf::get(format!("http://{}", port))
+            let string = surf::get(format!("http://localhost:{}", port))
                 .body_string("nori".to_string())
                 .recv_string()
                 .await?;
@@ -43,13 +43,13 @@ fn echo_server() -> Result<(), http_types::Error> {
             let mut app = tide::new();
             app.at("/").get(|req| async move { Ok(req) });
 
-            app.listen(&port).await?;
+            app.listen(("localhost", port)).await?;
             Result::<(), http_types::Error>::Ok(())
         });
 
         let client = task::spawn(async move {
             task::sleep(Duration::from_millis(100)).await;
-            let string = surf::get(format!("http://{}", port))
+            let string = surf::get(format!("http://localhost:{}", port))
                 .body_string("chashu".to_string())
                 .recv_string()
                 .await?;
@@ -79,13 +79,13 @@ fn json() -> Result<(), http_types::Error> {
                 let res = Response::new(StatusCode::Ok).body_json(&counter)?;
                 Ok(res)
             });
-            app.listen(&port).await?;
+            app.listen(("localhost", port)).await?;
             Result::<(), http_types::Error>::Ok(())
         });
 
         let client = task::spawn(async move {
             task::sleep(Duration::from_millis(100)).await;
-            let counter: Counter = surf::get(format!("http://{}", &port))
+            let counter: Counter = surf::get(format!("http://localhost:{}", &port))
                 .body_json(&Counter { count: 0 })?
                 .recv_json()
                 .await?;

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -1,7 +1,5 @@
-pub async fn find_port() -> async_std::net::SocketAddr {
-    async_std::net::TcpListener::bind("localhost:0")
-        .await
-        .unwrap()
-        .local_addr()
-        .unwrap()
+use portpicker::pick_unused_port;
+
+pub async fn find_port() -> u16 {
+    pick_unused_port().expect("No ports free")
 }


### PR DESCRIPTION
Depends on #501. Removes all of our use of `http-service`, simplifying our tests significantly. This sets us up to use Surf for our request instantiation in the future as well. Thanks!