### PR TITLE
Request+Response AsRef and Into impls for inner context access

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -308,6 +308,18 @@ impl<State> Request<State> {
     }
 }
 
+impl<State> AsMut<http::Request> for Request<State> {
+    fn as_mut(&mut self) -> &mut http::Request {
+        &mut self.request
+    }
+}
+
+impl<State> AsRef<http::Request> for Request<State> {
+    fn as_ref(&self) -> &http::Request {
+        &self.request
+    }
+}
+
 impl<State> Read for Request<State> {
     fn poll_read(
         mut self: Pin<&mut Self>,
@@ -315,6 +327,12 @@ impl<State> Read for Request<State> {
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
         Pin::new(&mut self.request).poll_read(cx, buf)
+    }
+}
+
+impl<State> Into<http::Request> for Request<State> {
+    fn into(self) -> http::Request {
+        self.request
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -262,6 +262,18 @@ impl Response {
     }
 }
 
+impl AsMut<http::Response> for Response {
+    fn as_mut(&mut self) -> &mut http::Response {
+        &mut self.res
+    }
+}
+
+impl AsRef<http::Response> for Response {
+    fn as_ref(&self) -> &http::Response {
+        &self.res
+    }
+}
+
 impl Into<http::Response> for Response {
     fn into(self) -> http_types::Response {
         self.res


### PR DESCRIPTION
Part of https://github.com/http-rs/tide/issues/465