### PR TITLE
femme is not just a dev dep anymore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,10 +42,10 @@ route-recognizer = "0.1.13"
 serde = "1.0.102"
 serde_json = "1.0.41"
 serde_qs = "0.5.0"
+femme = "1.3.0"
 
 [dev-dependencies]
 async-std = { version = "1.4.0", features = ["unstable", "attributes"] }
-femme = "1.3.0"
 juniper = "0.14.1"
 portpicker = "0.1.0"
 serde = { version = "1.0.102", features = ["derive"] }


### PR DESCRIPTION
master is currently broken in the following way:

although `cargo test` and `cargo build` work just fine, a project created like

```sh
cargo new tide-example --bin
cd tide-example
cargo add tide --git=https://github.com/http-rs/tide.git
cargo build
```

results in this compile error

```
 error[E0277]: the trait bound `std::string::String: log::kv::value::ToValue` is not satisfied
   --> /Users/jbr/.cargo/git/checkouts/tide-ea61fd839c4268c0/f575a12/src/server.rs:302:21
    |
302 |                     log::error!("async-h1 error", { error: err.to_string() });
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `log::kv::value::ToValue` is not implemented for `std::string::String`
    |
    = note: required for the cast to the object type `dyn log::kv::value::ToValue`
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to previous error

For more information about this error, try `rustc --explain E0277`.
error: could not compile `tide`.

To learn more, run the command again with --verbose.
```

Adding this change to tide's dependencies fixes the issue. As of https://github.com/http-rs/tide/commit/ee5f05e35085711a1cef7087031ae52a5fabbdf6#diff-4ce93534efc34e923ce01e975eb7ed80R302 tide seems to need femme to compile.
