### PR TITLE
add a no-dev-deps check to ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,13 @@ jobs:
         command: check
         args: --all --bins --examples
 
+    - name: check avoid-dev-deps
+      uses: actions-rs/cargo@v1
+      if: matrix.rust == 'nightly'
+      with:
+        command: check
+        args: --all -Z avoid-dev-deps
+
     - name: check unstable
       uses: actions-rs/cargo@v1
       with:


### PR DESCRIPTION
the build failure is the purpose of this pr, as master is broken until #511 is merged. this change will catch this sort of (rare) problem in the future