### PR TITLE
Response: expose `header()` from internal response

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -109,6 +109,11 @@ impl Response {
         self.res.len()
     }
 
+    /// Get an HTTP header.
+    pub fn header(&self, name: &HeaderName) -> Option<&Vec<HeaderValue>> {
+        self.res.header(name)
+    }
+
     /// Remove a header.
     pub fn remove_header(&mut self, name: &HeaderName) -> Option<Vec<HeaderValue>> {
         self.res.remove_header(name)


### PR DESCRIPTION
Some middleware may want to check headers on the response in order to decide what to do.