### PR TITLE
Use Debug format for std::time::Duration in LogMiddleware

### DIFF
--- a/src/log/middleware.rs
+++ b/src/log/middleware.rs
@@ -44,21 +44,21 @@ impl LogMiddleware {
                         method: method,
                         path: path,
                         status: status as u16,
-                        duration: format!("{}ms", start.elapsed().as_millis()),
+                        duration: format!("{:?}", start.elapsed()),
                     });
                 } else if status.is_client_error() {
                     log::warn!("--> Response sent", {
                         method: method,
                         path: path,
                         status: status as u16,
-                        duration: format!("{}ms", start.elapsed().as_millis()),
+                        duration: format!("{:?}", start.elapsed()),
                     });
                 } else {
                     log::info!("--> Response sent", {
                         method: method,
                         path: path,
                         status: status as u16,
-                        duration: format!("{}ms", start.elapsed().as_millis()),
+                        duration: format!("{:?}", start.elapsed()),
                     });
                 }
                 Ok(res)
@@ -68,7 +68,7 @@ impl LogMiddleware {
                     method: method,
                     path: path,
                     status: err.status() as u16,
-                    duration: format!("{}ms", start.elapsed().as_millis()),
+                    duration: format!("{:?}", start.elapsed()),
                 });
                 Err(err)
             }


### PR DESCRIPTION
`LogMiddleware` is currently logging the duration for the handler operation using `Duration.as_millis()`.

In case the request gets handled in less than `1ms`, this is what the logger prints:
```
tide::log::middleware --> Response sent
    method "GET"
    path "/"
    status 200
    duration "0ms"
```

However, [`std::time::Duration`](https://doc.rust-lang.org/std/time/struct.Duration.html) implements [`Debug` parsing correctly from seconds to nanoseconds](https://doc.rust-lang.org/src/core/time.rs.html#943-955).

With this PR, this is what the logger prints:
```
tide::log::middleware --> Response sent
    method "GET"
    path "/"
    status 200
    duration "685.45µs"
```

