### PR TITLE
Fix tests/wildcard

### DIFF
--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -49,18 +49,16 @@ async fn wildcard() {
     assert_eq!(body.as_bytes(), b"-6");
 }
 
-// #[test]
-// fn invalid_segment_error() {
-//     let mut app = tide::Server::new();
-//     app.at("/add_one/:num").get(add_one);
-//     let mut server = make_server(app.into_http_service()).unwrap();
+#[async_std::test]
+async fn invalid_segment_error() {
+    let mut app = tide::new();
+    app.at("/add_one/:num").get(add_one);
 
-//     let req = http::Request::get("/add_one/a")
-//         .body(Body::empty())
-//         .unwrap();
-//     let res = server.simulate(req).unwrap();
-//     assert_eq!(res.status(), 400);
-// }
+    let mut req = http::Request::new(Method::Get, "http://localhost/add_one/a".parse().unwrap());
+    req.set_body(Body::empty());
+    let res: http::Response = app.respond(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::BadRequest);
+}
 
 // #[test]
 // fn not_found_error() {

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -9,8 +9,12 @@ async fn add_one(cx: Request<()>) -> Result<String, tide::Error> {
 }
 
 async fn add_two(cx: Request<()>) -> Result<String, tide::Error> {
-    let one= cx.param::<i64>("one").map_err(|err| tide::Error::new(StatusCode::BadRequest, err))?;
-    let two= cx.param::<i64>("two").map_err(|err| tide::Error::new(StatusCode::BadRequest, err))?;
+    let one = cx
+        .param::<i64>("one")
+        .map_err(|err| tide::Error::new(StatusCode::BadRequest, err))?;
+    let two = cx
+        .param::<i64>("two")
+        .map_err(|err| tide::Error::new(StatusCode::BadRequest, err))?;
     Ok((one + two).to_string())
 }
 

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -33,7 +33,6 @@ async fn wildcard() {
     app.at("/add_one/:num").get(add_one);
 
     let mut req = http::Request::new(Method::Get, "http://localhost/add_one/3".parse().unwrap());
-    req.set_body(Body::empty());
 
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
@@ -41,7 +40,6 @@ async fn wildcard() {
     assert_eq!(body.as_bytes(), b"4");
 
     let mut req = http::Request::new(Method::Get, "http://localhost/add_one/-7".parse().unwrap());
-    req.set_body(Body::empty());
 
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
@@ -55,7 +53,7 @@ async fn invalid_segment_error() {
     app.at("/add_one/:num").get(add_one);
 
     let mut req = http::Request::new(Method::Get, "http://localhost/add_one/a".parse().unwrap());
-    req.set_body(Body::empty());
+
     let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::BadRequest);
 }

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -31,15 +31,13 @@ async fn wildcard() {
     let mut app = tide::Server::new();
     app.at("/add_one/:num").get(add_one);
 
-    let mut req = http::Request::new(Method::Get, "http://localhost/add_one/3".parse().unwrap());
-
+    let req = http::Request::new(Method::Get, "http://localhost/add_one/3".parse().unwrap());
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
     let body = res.take_body().into_string().await.unwrap();
     assert_eq!(body.as_bytes(), b"4");
 
-    let mut req = http::Request::new(Method::Get, "http://localhost/add_one/-7".parse().unwrap());
-
+    let req = http::Request::new(Method::Get, "http://localhost/add_one/-7".parse().unwrap());
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
     let body = res.take_body().into_string().await.unwrap();
@@ -51,8 +49,7 @@ async fn invalid_segment_error() {
     let mut app = tide::new();
     app.at("/add_one/:num").get(add_one);
 
-    let mut req = http::Request::new(Method::Get, "http://localhost/add_one/a".parse().unwrap());
-
+    let req = http::Request::new(Method::Get, "http://localhost/add_one/a".parse().unwrap());
     let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::BadRequest);
 }

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -2,10 +2,10 @@ use http_types::{Method, StatusCode, Url};
 use tide::{http, Request};
 
 async fn add_one(cx: Request<()>) -> Result<String, tide::Error> {
-    return match cx.param::<i64>("num") {
+    match cx.param::<i64>("num") {
         Ok(num) => Ok((num + 1).to_string()),
         Err(err) => Err(tide::Error::new(StatusCode::BadRequest, err)),
-    };
+    }
 }
 
 async fn add_two(cx: Request<()>) -> Result<String, tide::Error> {
@@ -23,17 +23,17 @@ async fn add_two(cx: Request<()>) -> Result<String, tide::Error> {
 }
 
 async fn echo_path(cx: Request<()>) -> Result<String, tide::Error> {
-    return match cx.param::<String>("path") {
+    match cx.param::<String>("path") {
         Ok(path) => Ok(path),
         Err(err) => Err(tide::Error::new(StatusCode::BadRequest, err)),
-    };
+    }
 }
 
 async fn echo_empty(cx: Request<()>) -> Result<String, tide::Error> {
-    return match cx.param::<String>("") {
+    match cx.param::<String>("") {
         Ok(path) => Ok(path),
         Err(err) => Err(tide::Error::new(StatusCode::BadRequest, err)),
-    };
+    }
 }
 
 #[async_std::test]

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -160,32 +160,27 @@ async fn nameless_wildcard() {
     assert_eq!(res.status(), StatusCode::Ok);
 }
 
-// #[test]
-// fn nameless_internal_wildcard() {
-//     let mut app = tide::Server::new();
-//     app.at("/echo/:/:path").get(echo_path);
-//     let mut server = make_server(app.into_http_service()).unwrap();
+#[async_std::test]
+async fn nameless_internal_wildcard() {
+    let mut app = tide::new();
+    app.at("/echo/:/:path").get(echo_path);
 
-//     let req = http::Request::get("/echo/one").body(Body::empty()).unwrap();
-//     let res = server.simulate(req).unwrap();
-//     assert_eq!(res.status(), 404);
+    let req = http::Request::new(Method::Get, "http://localhost/echo/one".parse().unwrap());
+    let res: http::Response = app.respond(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::NotFound);
 
-//     let req = http::Request::get("/echo/one/two")
-//         .body(Body::empty())
-//         .unwrap();
-//     let res = server.simulate(req).unwrap();
-//     assert_eq!(res.status(), 200);
-//     let body = block_on(res.into_body().into_vec()).unwrap();
-//     assert_eq!(&*body, &*b"two");
+    let req = http::Request::new(Method::Get, "http://localhost/echo/one/two".parse().unwrap());
+    let mut res: http::Response = app.respond(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::Ok);
+    let body: String = res.take_body().into_string().await.unwrap();
+    assert_eq!(body.as_bytes(), b"two");
 
-//     let req = http::Request::get("/echo/one/two")
-//         .body(Body::empty())
-//         .unwrap();
-//     let res = server.simulate(req).unwrap();
-//     assert_eq!(res.status(), 200);
-//     let body = block_on(res.into_body().into_vec()).unwrap();
-//     assert_eq!(&*body, &*b"two");
-// }
+    let req = http::Request::new(Method::Get, "http://localhost/echo/one/two".parse().unwrap());
+    let mut res: http::Response = app.respond(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::Ok);
+    let body: String = res.take_body().into_string().await.unwrap();
+    assert_eq!(body.as_bytes(), b"two");
+}
 
 // #[test]
 // fn nameless_internal_wildcard2() {

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -1,5 +1,5 @@
 use http_types::{Body, Method, StatusCode};
-use tide::{http, Request, Response};
+use tide::{http, Request};
 
 async fn add_one(cx: Request<()>) -> Result<String, tide::Error> {
     return match cx.param::<i64>("num"){
@@ -118,28 +118,23 @@ async fn multi_wildcard() {
     assert_eq!(res.status(), StatusCode::NotFound);
 }
 
-// #[test]
-// fn wild_last_segment() {
-//     let mut app = tide::Server::new();
-//     app.at("/echo/:path/*").get(echo_path);
-//     let mut server = make_server(app.into_http_service()).unwrap();
+#[async_std::test]
+async fn wild_last_segment() {
+    let mut app = tide::new();
+    app.at("/echo/:path/*").get(echo_path);
 
-//     let req = http::Request::get("/echo/one/two")
-//         .body(Body::empty())
-//         .unwrap();
-//     let res = server.simulate(req).unwrap();
-//     assert_eq!(res.status(), 200);
-//     let body = block_on(res.into_body().into_vec()).unwrap();
-//     assert_eq!(&*body, &*b"one");
+    let req = http::Request::new(Method::Get, "http://localhost/echo/one/two".parse().unwrap());
+    let mut res: http::Response = app.respond(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::Ok);
+    let body: String = res.take_body().into_string().await.unwrap();
+    assert_eq!(body.as_bytes(), b"one");
 
-//     let req = http::Request::get("/echo/one/two/three/four")
-//         .body(Body::empty())
-//         .unwrap();
-//     let res = server.simulate(req).unwrap();
-//     assert_eq!(res.status(), 200);
-//     let body = block_on(res.into_body().into_vec()).unwrap();
-//     assert_eq!(&*body, &*b"one");
-// }
+    let req = http::Request::new(Method::Get, "http://localhost/echo/one/two/three/four".parse().unwrap());
+    let mut res: http::Response = app.respond(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::Ok);
+    let body: String = res.take_body().into_string().await.unwrap();
+    assert_eq!(body.as_bytes(), b"one");
+}
 
 // #[test]
 // fn invalid_wildcard() {

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -9,16 +9,8 @@ async fn add_one(cx: Request<()>) -> Result<String, tide::Error> {
 }
 
 async fn add_two(cx: Request<()>) -> Result<String, tide::Error> {
-    let one;
-    match cx.param::<i64>("one") {
-        Ok(num) => one = num,
-        Err(err) => return Err(tide::Error::new(StatusCode::BadRequest, err)),
-    };
-    let two;
-    match cx.param::<i64>("two") {
-        Ok(num) => two = num,
-        Err(err) => return Err(tide::Error::new(StatusCode::BadRequest, err)),
-    };
+    let one= cx.param::<i64>("one").map_err(|err| tide::Error::new(StatusCode::BadRequest, err))?;
+    let two= cx.param::<i64>("two").map_err(|err| tide::Error::new(StatusCode::BadRequest, err))?;
     Ok((one + two).to_string())
 }
 

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -37,19 +37,17 @@ async fn wildcard() {
         Method::Get,
         Url::parse("http://localhost/add_one/3").unwrap(),
     );
-    let mut res: http::Response = app.respond(req).await.unwrap();
+    let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
-    let body = res.take_body().into_string().await.unwrap();
-    assert_eq!(body.as_bytes(), b"4");
+    assert_eq!(&res.body_string().await.unwrap(), "4");
 
     let req = http::Request::new(
         Method::Get,
         Url::parse("http://localhost/add_one/-7").unwrap(),
     );
-    let mut res: http::Response = app.respond(req).await.unwrap();
+    let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
-    let body = res.take_body().into_string().await.unwrap();
-    assert_eq!(body.as_bytes(), b"-6");
+    assert_eq!(&res.body_string().await.unwrap(), "-6");
 }
 
 #[async_std::test]
@@ -87,25 +85,22 @@ async fn wild_path() {
         Method::Get,
         Url::parse("http://localhost/echo/some_path").unwrap(),
     );
-    let mut res: http::Response = app.respond(req).await.unwrap();
+    let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
-    let body: String = res.take_body().into_string().await.unwrap();
-    assert_eq!(body.as_bytes(), b"some_path");
+    assert_eq!(&res.body_string().await.unwrap(), "some_path");
 
     let req = http::Request::new(
         Method::Get,
         Url::parse("http://localhost/echo/multi/segment/path").unwrap(),
     );
-    let mut res: http::Response = app.respond(req).await.unwrap();
+    let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
-    let body: String = res.take_body().into_string().await.unwrap();
-    assert_eq!(body.as_bytes(), b"multi/segment/path");
+    assert_eq!(&res.body_string().await.unwrap(), "multi/segment/path");
 
     let req = http::Request::new(Method::Get, Url::parse("http://localhost/echo/").unwrap());
-    let mut res: http::Response = app.respond(req).await.unwrap();
+    let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::NotFound);
-    let body: String = res.take_body().into_string().await.unwrap();
-    assert_eq!(body.as_bytes(), b"");
+    assert_eq!(&res.body_string().await.unwrap(), "");
 }
 
 #[async_std::test]
@@ -117,19 +112,17 @@ async fn multi_wildcard() {
         Method::Get,
         Url::parse("http://localhost/add_two/1/2/").unwrap(),
     );
-    let mut res: http::Response = app.respond(req).await.unwrap();
+    let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
-    let body: String = res.take_body().into_string().await.unwrap();
-    assert_eq!(body.as_bytes(), b"3");
+    assert_eq!(&res.body_string().await.unwrap(), "3");
 
     let req = http::Request::new(
         Method::Get,
         Url::parse("http://localhost/add_two/-1/2/").unwrap(),
     );
-    let mut res: http::Response = app.respond(req).await.unwrap();
+    let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), 200);
-    let body: String = res.take_body().into_string().await.unwrap();
-    assert_eq!(body.as_bytes(), b"1");
+    assert_eq!(&res.body_string().await.unwrap(), "1");
 
     let req = http::Request::new(
         Method::Get,
@@ -148,19 +141,17 @@ async fn wild_last_segment() {
         Method::Get,
         Url::parse("http://localhost/echo/one/two").unwrap(),
     );
-    let mut res: http::Response = app.respond(req).await.unwrap();
+    let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
-    let body: String = res.take_body().into_string().await.unwrap();
-    assert_eq!(body.as_bytes(), b"one");
+    assert_eq!(&res.body_string().await.unwrap(), "one");
 
     let req = http::Request::new(
         Method::Get,
         Url::parse("http://localhost/echo/one/two/three/four").unwrap(),
     );
-    let mut res: http::Response = app.respond(req).await.unwrap();
+    let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
-    let body: String = res.take_body().into_string().await.unwrap();
-    assert_eq!(body.as_bytes(), b"one");
+    assert_eq!(&res.body_string().await.unwrap(), "one");
 }
 
 #[async_std::test]
@@ -212,19 +203,17 @@ async fn nameless_internal_wildcard() {
         Method::Get,
         Url::parse("http://localhost/echo/one/two").unwrap(),
     );
-    let mut res: http::Response = app.respond(req).await.unwrap();
+    let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
-    let body: String = res.take_body().into_string().await.unwrap();
-    assert_eq!(body.as_bytes(), b"two");
+    assert_eq!(&res.body_string().await.unwrap(), "two");
 
     let req = http::Request::new(
         Method::Get,
         Url::parse("http://localhost/echo/one/two").unwrap(),
     );
-    let mut res: http::Response = app.respond(req).await.unwrap();
+    let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
-    let body: String = res.take_body().into_string().await.unwrap();
-    assert_eq!(body.as_bytes(), b"two");
+    assert_eq!(&res.body_string().await.unwrap(), "two");
 }
 
 #[async_std::test]
@@ -236,8 +225,7 @@ async fn nameless_internal_wildcard2() {
         Method::Get,
         Url::parse("http://localhost/echo/one/two").unwrap(),
     );
-    let mut res: http::Response = app.respond(req).await.unwrap();
+    let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
-    let body: String = res.take_body().into_string().await.unwrap();
-    assert_eq!(body.as_bytes(), b"one");
+    assert_eq!(&res.body_string().await.unwrap(), "one");
 }

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -1,4 +1,4 @@
-use http_types::{Method, StatusCode};
+use http_types::{Method, StatusCode, Url};
 use tide::{http, Request};
 
 async fn add_one(cx: Request<()>) -> Result<String, tide::Error> {
@@ -41,13 +41,19 @@ async fn wildcard() {
     let mut app = tide::Server::new();
     app.at("/add_one/:num").get(add_one);
 
-    let req = http::Request::new(Method::Get, "http://localhost/add_one/3".parse().unwrap());
+    let req = http::Request::new(
+        Method::Get,
+        Url::parse("http://localhost/add_one/3").unwrap(),
+    );
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
     let body = res.take_body().into_string().await.unwrap();
     assert_eq!(body.as_bytes(), b"4");
 
-    let req = http::Request::new(Method::Get, "http://localhost/add_one/-7".parse().unwrap());
+    let req = http::Request::new(
+        Method::Get,
+        Url::parse("http://localhost/add_one/-7").unwrap(),
+    );
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
     let body = res.take_body().into_string().await.unwrap();
@@ -59,7 +65,10 @@ async fn invalid_segment_error() {
     let mut app = tide::new();
     app.at("/add_one/:num").get(add_one);
 
-    let req = http::Request::new(Method::Get, "http://localhost/add_one/a".parse().unwrap());
+    let req = http::Request::new(
+        Method::Get,
+        Url::parse("http://localhost/add_one/a").unwrap(),
+    );
     let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::BadRequest);
 }
@@ -69,7 +78,10 @@ async fn not_found_error() {
     let mut app = tide::new();
     app.at("/add_one/:num").get(add_one);
 
-    let req = http::Request::new(Method::Get, "http://localhost/add_one/".parse().unwrap());
+    let req = http::Request::new(
+        Method::Get,
+        Url::parse("http://localhost/add_one/").unwrap(),
+    );
     let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::NotFound);
 }
@@ -81,7 +93,7 @@ async fn wild_path() {
 
     let req = http::Request::new(
         Method::Get,
-        "http://localhost/echo/some_path".parse().unwrap(),
+        Url::parse("http://localhost/echo/some_path").unwrap(),
     );
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
@@ -90,14 +102,14 @@ async fn wild_path() {
 
     let req = http::Request::new(
         Method::Get,
-        "http://localhost/echo/multi/segment/path".parse().unwrap(),
+        Url::parse("http://localhost/echo/multi/segment/path").unwrap(),
     );
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
     let body: String = res.take_body().into_string().await.unwrap();
     assert_eq!(body.as_bytes(), b"multi/segment/path");
 
-    let req = http::Request::new(Method::Get, "http://localhost/echo/".parse().unwrap());
+    let req = http::Request::new(Method::Get, Url::parse("http://localhost/echo/").unwrap());
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::NotFound);
     let body: String = res.take_body().into_string().await.unwrap();
@@ -111,7 +123,7 @@ async fn multi_wildcard() {
 
     let req = http::Request::new(
         Method::Get,
-        "http://localhost/add_two/1/2/".parse().unwrap(),
+        Url::parse("http://localhost/add_two/1/2/").unwrap(),
     );
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
@@ -120,14 +132,17 @@ async fn multi_wildcard() {
 
     let req = http::Request::new(
         Method::Get,
-        "http://localhost/add_two/-1/2/".parse().unwrap(),
+        Url::parse("http://localhost/add_two/-1/2/").unwrap(),
     );
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), 200);
     let body: String = res.take_body().into_string().await.unwrap();
     assert_eq!(body.as_bytes(), b"1");
 
-    let req = http::Request::new(Method::Get, "http://localhost/add_two/1".parse().unwrap());
+    let req = http::Request::new(
+        Method::Get,
+        Url::parse("http://localhost/add_two/1").unwrap(),
+    );
     let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::NotFound);
 }
@@ -139,7 +154,7 @@ async fn wild_last_segment() {
 
     let req = http::Request::new(
         Method::Get,
-        "http://localhost/echo/one/two".parse().unwrap(),
+        Url::parse("http://localhost/echo/one/two").unwrap(),
     );
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
@@ -148,7 +163,7 @@ async fn wild_last_segment() {
 
     let req = http::Request::new(
         Method::Get,
-        "http://localhost/echo/one/two/three/four".parse().unwrap(),
+        Url::parse("http://localhost/echo/one/two/three/four").unwrap(),
     );
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
@@ -163,7 +178,7 @@ async fn invalid_wildcard() {
 
     let req = http::Request::new(
         Method::Get,
-        "http://localhost/echo/one/two".parse().unwrap(),
+        Url::parse("http://localhost/echo/one/two").unwrap(),
     );
     let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::NotFound);
@@ -176,12 +191,15 @@ async fn nameless_wildcard() {
 
     let req = http::Request::new(
         Method::Get,
-        "http://localhost/echo/one/two".parse().unwrap(),
+        Url::parse("http://localhost/echo/one/two").unwrap(),
     );
     let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::NotFound);
 
-    let req = http::Request::new(Method::Get, "http://localhost/echo/one".parse().unwrap());
+    let req = http::Request::new(
+        Method::Get,
+        Url::parse("http://localhost/echo/one").unwrap(),
+    );
     let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
 }
@@ -191,13 +209,16 @@ async fn nameless_internal_wildcard() {
     let mut app = tide::new();
     app.at("/echo/:/:path").get(echo_path);
 
-    let req = http::Request::new(Method::Get, "http://localhost/echo/one".parse().unwrap());
+    let req = http::Request::new(
+        Method::Get,
+        Url::parse("http://localhost/echo/one").unwrap(),
+    );
     let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::NotFound);
 
     let req = http::Request::new(
         Method::Get,
-        "http://localhost/echo/one/two".parse().unwrap(),
+        Url::parse("http://localhost/echo/one/two").unwrap(),
     );
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
@@ -206,7 +227,7 @@ async fn nameless_internal_wildcard() {
 
     let req = http::Request::new(
         Method::Get,
-        "http://localhost/echo/one/two".parse().unwrap(),
+        Url::parse("http://localhost/echo/one/two").unwrap(),
     );
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
@@ -221,7 +242,7 @@ async fn nameless_internal_wildcard2() {
 
     let req = http::Request::new(
         Method::Get,
-        "http://localhost/echo/one/two".parse().unwrap(),
+        Url::parse("http://localhost/echo/one/two").unwrap(),
     );
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -146,23 +146,19 @@ async fn invalid_wildcard() {
     assert_eq!(res.status(), StatusCode::NotFound);
 }
 
-// #[test]
-// fn nameless_wildcard() {
-//     let mut app = tide::Server::new();
-//     app.at("/echo/:").get(|_| async move { "" });
+#[async_std::test]
+async fn nameless_wildcard() {
+    let mut app = tide::Server::new();
+    app.at("/echo/:").get(|_| async move { Ok("") });
 
-//     let mut server = make_server(app.into_http_service()).unwrap();
+    let req = http::Request::new(Method::Get, "http://localhost/echo/one/two".parse().unwrap());
+    let res: http::Response = app.respond(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::NotFound);
 
-//     let req = http::Request::get("/echo/one/two")
-//         .body(Body::empty())
-//         .unwrap();
-//     let res = server.simulate(req).unwrap();
-//     assert_eq!(res.status(), 404);
-
-//     let req = http::Request::get("/echo/one").body(Body::empty()).unwrap();
-//     let res = server.simulate(req).unwrap();
-//     assert_eq!(res.status(), 200);
-// }
+    let req = http::Request::new(Method::Get, "http://localhost/echo/one".parse().unwrap());
+    let res: http::Response = app.respond(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::Ok);
+}
 
 // #[test]
 // fn nameless_internal_wildcard() {

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -2,10 +2,10 @@ use http_types::{Method, StatusCode};
 use tide::{http, Request};
 
 async fn add_one(cx: Request<()>) -> Result<String, tide::Error> {
-    return match cx.param::<i64>("num"){
+    return match cx.param::<i64>("num") {
         Ok(num) => Ok((num + 1).to_string()),
-        Err(err) => Err(tide::Error::new(StatusCode::BadRequest, err))
-    }
+        Err(err) => Err(tide::Error::new(StatusCode::BadRequest, err)),
+    };
 }
 
 async fn add_two(cx: Request<()>) -> Result<String, tide::Error> {
@@ -23,17 +23,17 @@ async fn add_two(cx: Request<()>) -> Result<String, tide::Error> {
 }
 
 async fn echo_path(cx: Request<()>) -> Result<String, tide::Error> {
-    return match cx.param::<String>("path"){
+    return match cx.param::<String>("path") {
         Ok(path) => Ok(path),
-        Err(err) => Err(tide::Error::new(StatusCode::BadRequest, err))
-    }
+        Err(err) => Err(tide::Error::new(StatusCode::BadRequest, err)),
+    };
 }
 
 async fn echo_empty(cx: Request<()>) -> Result<String, tide::Error> {
-    return match cx.param::<String>(""){
+    return match cx.param::<String>("") {
         Ok(path) => Ok(path),
-        Err(err) => Err(tide::Error::new(StatusCode::BadRequest, err))
-    }
+        Err(err) => Err(tide::Error::new(StatusCode::BadRequest, err)),
+    };
 }
 
 #[async_std::test]
@@ -79,13 +79,19 @@ async fn wild_path() {
     let mut app = tide::new();
     app.at("/echo/*path").get(echo_path);
 
-    let req = http::Request::new(Method::Get, "http://localhost/echo/some_path".parse().unwrap());
+    let req = http::Request::new(
+        Method::Get,
+        "http://localhost/echo/some_path".parse().unwrap(),
+    );
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
     let body: String = res.take_body().into_string().await.unwrap();
     assert_eq!(body.as_bytes(), b"some_path");
 
-    let req = http::Request::new(Method::Get, "http://localhost/echo/multi/segment/path".parse().unwrap());
+    let req = http::Request::new(
+        Method::Get,
+        "http://localhost/echo/multi/segment/path".parse().unwrap(),
+    );
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
     let body: String = res.take_body().into_string().await.unwrap();
@@ -103,13 +109,19 @@ async fn multi_wildcard() {
     let mut app = tide::new();
     app.at("/add_two/:one/:two/").get(add_two);
 
-    let req = http::Request::new(Method::Get, "http://localhost/add_two/1/2/".parse().unwrap());
+    let req = http::Request::new(
+        Method::Get,
+        "http://localhost/add_two/1/2/".parse().unwrap(),
+    );
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
     let body: String = res.take_body().into_string().await.unwrap();
     assert_eq!(body.as_bytes(), b"3");
 
-    let req = http::Request::new(Method::Get, "http://localhost/add_two/-1/2/".parse().unwrap());
+    let req = http::Request::new(
+        Method::Get,
+        "http://localhost/add_two/-1/2/".parse().unwrap(),
+    );
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), 200);
     let body: String = res.take_body().into_string().await.unwrap();
@@ -125,13 +137,19 @@ async fn wild_last_segment() {
     let mut app = tide::new();
     app.at("/echo/:path/*").get(echo_path);
 
-    let req = http::Request::new(Method::Get, "http://localhost/echo/one/two".parse().unwrap());
+    let req = http::Request::new(
+        Method::Get,
+        "http://localhost/echo/one/two".parse().unwrap(),
+    );
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
     let body: String = res.take_body().into_string().await.unwrap();
     assert_eq!(body.as_bytes(), b"one");
 
-    let req = http::Request::new(Method::Get, "http://localhost/echo/one/two/three/four".parse().unwrap());
+    let req = http::Request::new(
+        Method::Get,
+        "http://localhost/echo/one/two/three/four".parse().unwrap(),
+    );
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
     let body: String = res.take_body().into_string().await.unwrap();
@@ -143,7 +161,10 @@ async fn invalid_wildcard() {
     let mut app = tide::new();
     app.at("/echo/*path/:one/").get(echo_path);
 
-    let req = http::Request::new(Method::Get, "http://localhost/echo/one/two".parse().unwrap());
+    let req = http::Request::new(
+        Method::Get,
+        "http://localhost/echo/one/two".parse().unwrap(),
+    );
     let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::NotFound);
 }
@@ -153,7 +174,10 @@ async fn nameless_wildcard() {
     let mut app = tide::Server::new();
     app.at("/echo/:").get(|_| async move { Ok("") });
 
-    let req = http::Request::new(Method::Get, "http://localhost/echo/one/two".parse().unwrap());
+    let req = http::Request::new(
+        Method::Get,
+        "http://localhost/echo/one/two".parse().unwrap(),
+    );
     let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::NotFound);
 
@@ -171,13 +195,19 @@ async fn nameless_internal_wildcard() {
     let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::NotFound);
 
-    let req = http::Request::new(Method::Get, "http://localhost/echo/one/two".parse().unwrap());
+    let req = http::Request::new(
+        Method::Get,
+        "http://localhost/echo/one/two".parse().unwrap(),
+    );
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
     let body: String = res.take_body().into_string().await.unwrap();
     assert_eq!(body.as_bytes(), b"two");
 
-    let req = http::Request::new(Method::Get, "http://localhost/echo/one/two".parse().unwrap());
+    let req = http::Request::new(
+        Method::Get,
+        "http://localhost/echo/one/two".parse().unwrap(),
+    );
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
     let body: String = res.take_body().into_string().await.unwrap();
@@ -189,7 +219,10 @@ async fn nameless_internal_wildcard2() {
     let mut app = tide::new();
     app.at("/echo/:/:path").get(echo_empty);
 
-    let req = http::Request::new(Method::Get, "http://localhost/echo/one/two".parse().unwrap());
+    let req = http::Request::new(
+        Method::Get,
+        "http://localhost/echo/one/two".parse().unwrap(),
+    );
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
     let body: String = res.take_body().into_string().await.unwrap();

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -60,16 +60,15 @@ async fn invalid_segment_error() {
     assert_eq!(res.status(), StatusCode::BadRequest);
 }
 
-// #[test]
-// fn not_found_error() {
-//     let mut app = tide::Server::new();
-//     app.at("/add_one/:num").get(add_one);
-//     let mut server = make_server(app.into_http_service()).unwrap();
+#[async_std::test]
+async fn not_found_error() {
+    let mut app = tide::new();
+    app.at("/add_one/:num").get(add_one);
 
-//     let req = http::Request::get("/add_one/").body(Body::empty()).unwrap();
-//     let res = server.simulate(req).unwrap();
-//     assert_eq!(res.status(), 404);
-// }
+    let req = http::Request::new(Method::Get, "http://localhost/add_one/".parse().unwrap());
+    let res: http::Response = app.respond(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::NotFound);
+}
 
 // #[test]
 // fn wildpath() {

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -1,4 +1,4 @@
-use http_types::{Body, Method, StatusCode};
+use http_types::{Method, StatusCode};
 use tide::{http, Request};
 
 async fn add_one(cx: Request<()>) -> Result<String, tide::Error> {
@@ -136,18 +136,15 @@ async fn wild_last_segment() {
     assert_eq!(body.as_bytes(), b"one");
 }
 
-// #[test]
-// fn invalid_wildcard() {
-//     let mut app = tide::Server::new();
-//     app.at("/echo/*path/:one/").get(echo_path);
-//     let mut server = make_server(app.into_http_service()).unwrap();
+#[async_std::test]
+async fn invalid_wildcard() {
+    let mut app = tide::new();
+    app.at("/echo/*path/:one/").get(echo_path);
 
-//     let req = http::Request::get("/echo/one/two")
-//         .body(Body::empty())
-//         .unwrap();
-//     let res = server.simulate(req).unwrap();
-//     assert_eq!(res.status(), 404);
-// }
+    let req = http::Request::new(Method::Get, "http://localhost/echo/one/two".parse().unwrap());
+    let res: http::Response = app.respond(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::NotFound);
+}
 
 // #[test]
 // fn nameless_wildcard() {


### PR DESCRIPTION
Fix test/wildcard.rs
This PR is related to #509

---

This file used Crate "http_service" and "http_service_mock".
But Cargo.toml does not contain them.
So, I use "Request::new(Method::Get, "http://localhost/*")" and "Server::respond(req)" instead of them.