### PR TITLE
http-types and async-h1 2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,12 +32,11 @@ unstable = []
 __internal__bench = []
 
 [dependencies]
-async-h1 = { version = "1.1.2", optional = true }
+async-h1 = { version = "2.0.0", optional = true }
 async-sse = "2.1.0"
-async-std = { version = "1.4.0", features = ["unstable"] }
-cookie = { version = "0.12.0", features = ["percent-encode"]}
+async-std = { version = "1.6.0", features = ["unstable"] }
 femme = "2.0.1"
-http-types = "1.0.1"
+http-types = "2.0.0"
 kv-log-macro = "1.0.4"
 mime = "0.3.14"
 mime_guess = "2.0.3"
@@ -47,12 +46,12 @@ serde_json = "1.0.41"
 serde_qs = "0.5.0"
 
 [dev-dependencies]
-async-std = { version = "1.4.0", features = ["unstable", "attributes"] }
+async-std = { version = "1.6.0", features = ["unstable", "attributes"] }
 juniper = "0.14.1"
 portpicker = "0.1.0"
 serde = { version = "1.0.102", features = ["derive"] }
-surf = "2.0.0-alpha.1"
 criterion = "0.3.1"
+surf = { version = "2.0.0-alpha.2", default-features = false, features = ["h1-client"] }
 
 [[test]]
 name = "nested"

--- a/examples/graphql.rs
+++ b/examples/graphql.rs
@@ -95,7 +95,7 @@ async fn handle_graphql(mut cx: Request<State>) -> tide::Result {
 async fn handle_graphiql(_: Request<State>) -> tide::Result {
     let res = Response::new(StatusCode::Ok)
         .body_string(juniper::http::graphiql::graphiql_source("/graphql"))
-        .set_header("content-type".parse().unwrap(), "text/html;charset=utf-8");
+        .set_mime(mime::TEXT_HTML_UTF_8);
     Ok(res)
 }
 

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -16,6 +16,7 @@
 //! # Ok(()) }) }
 //! ```
 
+use crate::http::headers::LOCATION;
 use crate::utils::BoxFuture;
 use crate::StatusCode;
 use crate::{Endpoint, Request, Response};
@@ -103,6 +104,6 @@ impl<T: AsRef<str>> Into<Response> for Redirect<T> {
 
 impl<T: AsRef<str>> Into<Response> for &Redirect<T> {
     fn into(self) -> Response {
-        Response::new(self.status).set_header("location".parse().unwrap(), &self.location)
+        Response::new(self.status).set_header(LOCATION, self.location.as_ref())
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -124,7 +124,7 @@ impl<State> Request<State> {
     ///
     /// let mut app = tide::new();
     /// app.at("/").get(|req: Request<()>| async move {
-    ///     assert_eq!(req.header("X-Forwarded-For").unwrap().last().as_str(), "127.0.0.1");
+    ///     assert_eq!(req.header("X-Forwarded-For").unwrap(), "127.0.0.1");
     ///     Ok("")
     /// });
     /// app.listen("127.0.0.1:8080").await?;

--- a/src/request.rs
+++ b/src/request.rs
@@ -294,11 +294,8 @@ impl<State> Request<State> {
     /// returns a `Cookie` by name of the cookie.
     #[must_use]
     pub fn cookie(&self, name: &str) -> Option<Cookie<'static>> {
-        if let Some(cookie_data) = self.local::<CookieData>() {
-            cookie_data.content.read().unwrap().get(name).cloned()
-        } else {
-            None
-        }
+        self.ext::<CookieData>()
+            .and_then(|cookie_data| cookie_data.content.read().unwrap().get(name).cloned())
     }
 
     /// Get the length of the body.

--- a/src/route.rs
+++ b/src/route.rs
@@ -153,7 +153,7 @@ impl<'a, State: 'static> Route<'a, State> {
                     ));
                     (ep.clone(), ep)
                 };
-            self.router.add(&self.path, method.clone(), ep1);
+            self.router.add(&self.path, method, ep1);
             let wildcard = self.at("*--tide-path-rest");
             wildcard.router.add(&wildcard.path, method, ep2);
         } else {

--- a/src/security/cors.rs
+++ b/src/security/cors.rs
@@ -282,27 +282,12 @@ mod test {
 
         assert_eq!(res.status(), 200);
 
-        assert_eq!(
-            res[headers::ACCESS_CONTROL_ALLOW_ORIGIN][0].as_str(),
-            ALLOW_ORIGIN
-        );
-        assert_eq!(
-            res[headers::ACCESS_CONTROL_ALLOW_METHODS][0].as_str(),
-            ALLOW_METHODS
-        );
-        assert_eq!(
-            res[headers::ACCESS_CONTROL_ALLOW_HEADERS][0].as_str(),
-            WILDCARD
-        );
-        assert_eq!(
-            res[headers::ACCESS_CONTROL_MAX_AGE][0].as_str(),
-            DEFAULT_MAX_AGE
-        );
+        assert_eq!(res[headers::ACCESS_CONTROL_ALLOW_ORIGIN], ALLOW_ORIGIN);
+        assert_eq!(res[headers::ACCESS_CONTROL_ALLOW_METHODS], ALLOW_METHODS);
+        assert_eq!(res[headers::ACCESS_CONTROL_ALLOW_HEADERS], WILDCARD);
+        assert_eq!(res[headers::ACCESS_CONTROL_MAX_AGE], DEFAULT_MAX_AGE);
 
-        assert_eq!(
-            res[headers::ACCESS_CONTROL_ALLOW_CREDENTIALS][0].as_str(),
-            "true"
-        );
+        assert_eq!(res[headers::ACCESS_CONTROL_ALLOW_CREDENTIALS], "true");
     }
     #[async_std::test]
     async fn default_cors_middleware() {
@@ -311,8 +296,7 @@ mod test {
         let res: crate::http::Response = app.respond(request()).await.unwrap();
 
         assert_eq!(res.status(), 200);
-
-        assert_eq!(res[headers::ACCESS_CONTROL_ALLOW_ORIGIN][0].as_str(), "*");
+        assert_eq!(res[headers::ACCESS_CONTROL_ALLOW_ORIGIN], "*");
     }
 
     #[async_std::test]
@@ -328,10 +312,7 @@ mod test {
         let res: crate::http::Response = app.respond(request()).await.unwrap();
 
         assert_eq!(res.status(), 200);
-        assert_eq!(
-            res[headers::ACCESS_CONTROL_ALLOW_ORIGIN][0].as_str(),
-            ALLOW_ORIGIN
-        );
+        assert_eq!(res[headers::ACCESS_CONTROL_ALLOW_ORIGIN], ALLOW_ORIGIN);
     }
 
     #[async_std::test]
@@ -341,12 +322,7 @@ mod test {
         let res: crate::http::Response = app.respond(request()).await.unwrap();
 
         assert_eq!(res.status(), 200);
-        assert_eq!(
-            res[headers::ACCESS_CONTROL_ALLOW_CREDENTIALS]
-                .last()
-                .as_str(),
-            "true"
-        );
+        assert_eq!(res[headers::ACCESS_CONTROL_ALLOW_CREDENTIALS], "true");
     }
 
     #[async_std::test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -295,10 +295,9 @@ impl<State: Send + Sync + 'static> Server<State> {
         let mut incoming = listener.incoming();
         while let Some(stream) = incoming.next().await {
             let stream = stream?;
-            let addr = addr.clone();
             let this = self.clone();
             task::spawn(async move {
-                let res = async_h1::accept(&addr, stream, |req| async {
+                let res = async_h1::accept(stream, |req| async {
                     let res = this.respond(req).await;
                     let res = res.map_err(|_| io::Error::from(io::ErrorKind::Other))?;
                     Ok(res)

--- a/tests/chunked-encode-small.rs
+++ b/tests/chunked-encode-small.rs
@@ -2,7 +2,7 @@ mod test_utils;
 use async_std::io::Cursor;
 use async_std::prelude::*;
 use async_std::task;
-use http_types::{headers, StatusCode};
+use http_types::StatusCode;
 use std::time::Duration;
 
 use tide::Response;
@@ -20,11 +20,11 @@ async fn chunked_large() -> Result<(), http_types::Error> {
     let port = test_utils::find_port().await;
     let server = task::spawn(async move {
         let mut app = tide::new();
-        app.at("/").get(|mut _req: tide::Request<()>| async move {
+        app.at("/").get(|_| async move {
             let body = Cursor::new(TEXT.to_owned());
             let res = Response::new(StatusCode::Ok)
                 .body(body)
-                .set_header(headers::CONTENT_TYPE, "text/plain; charset=utf-8");
+                .set_mime(mime::TEXT_PLAIN_UTF_8);
             Ok(res)
         });
         app.listen(("localhost", port)).await?;
@@ -33,17 +33,21 @@ async fn chunked_large() -> Result<(), http_types::Error> {
 
     let client = task::spawn(async move {
         task::sleep(Duration::from_millis(100)).await;
-        let mut res = surf::get(format!("http://localhost:{}", port)).await?;
+        let mut res = surf::get(format!("http://localhost:{}", port))
+            .await
+            .unwrap();
         assert_eq!(res.status(), 200);
         assert_eq!(
-            res.header(&"transfer-encoding".parse().unwrap()),
-            Some(&vec![http_types::headers::HeaderValue::from_ascii(
-                b"chunked"
-            )
-            .unwrap()])
+            // this is awkward and should be revisited when surf is on newer http-types
+            res.header(&"transfer-encoding".parse().unwrap())
+                .unwrap()
+                .last()
+                .unwrap()
+                .as_str(),
+            "chunked"
         );
         assert_eq!(res.header(&"content-length".parse().unwrap()), None);
-        let string = res.body_string().await?;
+        let string = res.body_string().await.unwrap();
         assert_eq!(string, TEXT.to_string());
         Ok(())
     });

--- a/tests/cookies.rs
+++ b/tests/cookies.rs
@@ -1,5 +1,6 @@
 use async_std::prelude::*;
 use tide::http::cookies::Cookie;
+use tide::http::headers::{COOKIE, SET_COOKIE};
 
 use tide::{Request, Response, Server, StatusCode};
 
@@ -46,13 +47,16 @@ async fn make_request(endpoint: &str) -> http_types::Response {
     let app = app();
     let mut req = http_types::Request::new(
         http_types::Method::Get,
-        format!("http://example.com{}", endpoint).parse().unwrap(),
+        http_types::url::Url::parse("http://example.com")
+            .unwrap()
+            .join(endpoint)
+            .unwrap(),
     );
+
     req.insert_header(
-        http_types::headers::COOKIE,
+        COOKIE,
         "testCookie=RequestCookieValue; secondTestCookie=Other%3BCookie%20Value",
-    )
-    .unwrap();
+    );
 
     let res: tide::http::Response = app.respond(req).await.unwrap();
     res
@@ -74,15 +78,14 @@ async fn successfully_retrieve_request_cookie() {
 async fn successfully_set_cookie() {
     let res = make_request("/set").await;
     assert_eq!(res.status(), StatusCode::Ok);
-    let test_cookie_header = res.header(&http_types::headers::SET_COOKIE).unwrap()[0].as_str();
-    assert_eq!(test_cookie_header, "testCookie=NewCookieValue");
+    assert_eq!(res[SET_COOKIE], "testCookie=NewCookieValue");
 }
 
 #[async_std::test]
 async fn successfully_remove_cookie() {
     let res = make_request("/remove").await;
     assert_eq!(res.status(), StatusCode::Ok);
-    let test_cookie_header = res.header(&http_types::headers::SET_COOKIE).unwrap()[0].as_str();
+    let test_cookie_header = res[SET_COOKIE].last().as_str();
     assert!(test_cookie_header.starts_with("testCookie=;"));
     let cookie = Cookie::parse_encoded(test_cookie_header).unwrap();
     assert_eq!(cookie.name(), COOKIE_NAME);
@@ -95,8 +98,8 @@ async fn successfully_remove_cookie() {
 async fn successfully_set_multiple_cookies() {
     let res = make_request("/multi").await;
     assert_eq!(res.status(), StatusCode::Ok);
-    let cookie_header = res.header(&http_types::headers::SET_COOKIE);
-    let cookies = cookie_header.unwrap().iter().collect::<Vec<_>>();
+    let cookie_header = res[SET_COOKIE].clone();
+    let cookies = cookie_header.iter().collect::<Vec<_>>();
     assert_eq!(cookies.len(), 2, "{:?}", &cookies);
     let cookie1 = cookies[0].as_str();
     let cookie2 = cookies[1].as_str();

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -1,6 +1,5 @@
-use http_types::headers::{HeaderName, HeaderValue};
+use http_types::headers::HeaderName;
 use http_types::{Method, Request, Response, Url};
-use std::str::FromStr;
 use test_utils::BoxFuture;
 use tide::{Middleware, Next};
 
@@ -78,7 +77,7 @@ async fn nested_middleware() {
         Url::parse("http://example.com/foo/echo").unwrap(),
     );
     let res: Response = app.respond(req).await.unwrap();
-    assert_header(&res, "X-Tide-Test", Some("1"));
+    assert_eq!(res["X-Tide-Test"], "1");
     assert_eq!(res.status(), 200);
     assert_eq!(res.body_string().await.unwrap(), "/echo");
 
@@ -87,13 +86,13 @@ async fn nested_middleware() {
         Url::parse("http://example.com/foo/x/bar").unwrap(),
     );
     let res: Response = app.respond(req).await.unwrap();
-    assert_header(&res, "X-Tide-Test", Some("1"));
+    assert_eq!(res["X-Tide-Test"], "1");
     assert_eq!(res.status(), 200);
     assert_eq!(res.body_string().await.unwrap(), "/");
 
     let req = Request::new(Method::Get, Url::parse("http://example.com/bar").unwrap());
     let res: Response = app.respond(req).await.unwrap();
-    assert_header(&res, "X-Tide-Test", None);
+    assert!(res.header("X-Tide-Test").is_none());
     assert_eq!(res.status(), 200);
     assert_eq!(res.body_string().await.unwrap(), "/bar");
 }
@@ -118,28 +117,4 @@ async fn nested_with_different_state() {
     let res: Response = outer.respond(req).await.unwrap();
     assert_eq!(res.status(), 200);
     assert_eq!(res.body_string().await.unwrap(), "Hello, world!");
-}
-
-// See https://github.com/http-rs/http-types/issues/89 for a proposed fix to this boilerplate.
-fn assert_header(headers: impl AsRef<http_types::Headers>, lhs: &str, rhs: Option<&str>) {
-    match rhs {
-        Some(s) => {
-            let header = headers
-                .as_ref()
-                .get(
-                    &http_types::headers::HeaderName::from_ascii(lhs.to_owned().into_bytes())
-                        .unwrap(),
-                )
-                .unwrap()
-                .iter()
-                .next();
-            assert_eq!(header, Some(&HeaderValue::from_str(s).unwrap()));
-        }
-        None => {
-            let header = headers.as_ref().get(
-                &http_types::headers::HeaderName::from_ascii(lhs.to_owned().into_bytes()).unwrap(),
-            );
-            assert_eq!(header, None);
-        }
-    }
 }

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -54,7 +54,7 @@ async fn nested_middleware() {
             Box::pin(async move {
                 let res = next.run(req).await?;
                 let res = res.set_header(
-                    HeaderName::from_ascii("X-Tide-Test".to_owned().into_bytes()).unwrap(),
+                    HeaderName::from_bytes("X-Tide-Test".to_owned().into_bytes()).unwrap(),
                     "1",
                 );
                 Ok(res)

--- a/tests/querystring.rs
+++ b/tests/querystring.rs
@@ -1,5 +1,4 @@
 use async_std::prelude::*;
-use async_std::task::block_on;
 use http_types::{url::Url, Method};
 use serde::Deserialize;
 use tide::{http, Request, Response, Server, StatusCode};

--- a/tests/querystring.rs
+++ b/tests/querystring.rs
@@ -1,4 +1,6 @@
 use async_std::prelude::*;
+use async_std::task::block_on;
+use http_types::{url::Url, Method};
 use serde::Deserialize;
 use tide::{http, Request, Response, Server, StatusCode};
 
@@ -40,8 +42,8 @@ fn get_server() -> Server<()> {
 async fn successfully_deserialize_query() {
     let app = get_server();
     let req = http_types::Request::new(
-        http_types::Method::Get,
-        "http://example.com/?msg=Hello".parse().unwrap(),
+        Method::Get,
+        Url::parse("http://example.com/?msg=Hello").unwrap(),
     );
 
     let mut res: http::Response = app.respond(req).await.unwrap();
@@ -54,10 +56,7 @@ async fn successfully_deserialize_query() {
 #[async_std::test]
 async fn unsuccessfully_deserialize_query() {
     let app = get_server();
-    let req = http_types::Request::new(
-        http_types::Method::Get,
-        "http://example.com/".parse().unwrap(),
-    );
+    let req = http_types::Request::new(Method::Get, Url::parse("http://example.com/").unwrap());
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), 400);
 
@@ -70,8 +69,8 @@ async fn unsuccessfully_deserialize_query() {
 async fn malformatted_query() {
     let app = get_server();
     let req = http_types::Request::new(
-        http_types::Method::Get,
-        "http://example.com/?error=should_fail".parse().unwrap(),
+        Method::Get,
+        Url::parse("http://example.com/?error=should_fail").unwrap(),
     );
     let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), 400);
@@ -85,8 +84,8 @@ async fn malformatted_query() {
 async fn empty_query_string_for_struct_with_no_required_fields() {
     let app = get_server();
     let req = http_types::Request::new(
-        http_types::Method::Get,
-        "http://example.com/optional".parse().unwrap(),
+        Method::Get,
+        Url::parse("http://example.com/optional").unwrap(),
     );
     let res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -26,7 +26,8 @@ fn hello_world() -> Result<(), http_types::Error> {
             let string = surf::get(format!("http://localhost:{}", port))
                 .body_string("nori".to_string())
                 .recv_string()
-                .await?;
+                .await
+                .unwrap();
             assert_eq!(string, "says hello".to_string());
             Ok(())
         });
@@ -52,7 +53,8 @@ fn echo_server() -> Result<(), http_types::Error> {
             let string = surf::get(format!("http://localhost:{}", port))
                 .body_string("chashu".to_string())
                 .recv_string()
-                .await?;
+                .await
+                .unwrap();
             assert_eq!(string, "chashu".to_string());
             Ok(())
         });
@@ -88,7 +90,8 @@ fn json() -> Result<(), http_types::Error> {
             let counter: Counter = surf::get(format!("http://localhost:{}", &port))
                 .body_json(&Counter { count: 0 })?
                 .recv_json()
-                .await?;
+                .await
+                .unwrap();
             assert_eq!(counter.count, 1);
             Ok(())
         });


### PR DESCRIPTION
A few notes on this mostly-find-and-replace PR:

* This is building against http-rs/async-h1#105 and http-types master, as there are not yet releases for those

* This PR revealed an issue with surf's native client when talking to a server that understands 100-continue. instead of attempting to resolve that, this pr switches to surf's async-h1 client for testing. http-rs/surf#177 represents further work required to address this

* ~~Interacting with a single header value is still a little awkward and this PR is inconsistent about using [0] vs `HeaderValues::last()`~~

* It's surprising that `Response::append_header` panics if the ToHeaderValues cannot be converted but `Response::set_header` does not

* Tests that rely on surf are still a little awkward because of incompatible http-types

* An unexpected side effect of accepting TryInto<url::Url> for http_types::Request is that they can no longer be constructed with an implicit `url::Url` as in `"str".parse().unwrap()`, but instead need to be explicitly parsed as `url::Url::parse("str").unwrap()`. I was surprised to discover that Url isn't `TryFrom<&str>`.


