### PR TITLE
use http_types::mime instead of the mime crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ async-std = { version = "1.6.0", features = ["unstable"] }
 femme = "2.0.1"
 http-types = "2.0.1"
 kv-log-macro = "1.0.4"
-mime_guess = "2.0.3"
 route-recognizer = "0.1.13"
 serde = "1.0.102"
 serde_json = "1.0.41"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ async-std = { version = "1.6.0", features = ["unstable"] }
 femme = "2.0.1"
 http-types = "2.0.1"
 kv-log-macro = "1.0.4"
-mime = "0.3.14"
 mime_guess = "2.0.3"
 route-recognizer = "0.1.13"
 serde = "1.0.102"

--- a/examples/graphql.rs
+++ b/examples/graphql.rs
@@ -95,7 +95,7 @@ async fn handle_graphql(mut cx: Request<State>) -> tide::Result {
 async fn handle_graphiql(_: Request<State>) -> tide::Result {
     let res = Response::new(StatusCode::Ok)
         .body_string(juniper::http::graphiql::graphiql_source("/graphql"))
-        .set_mime(mime::TEXT_HTML_UTF_8);
+        .set_mime(tide::http::mime::HTML);
     Ok(res)
 }
 

--- a/src/fs/serve_dir.rs
+++ b/src/fs/serve_dir.rs
@@ -1,6 +1,6 @@
+use crate::http::Mime;
 use crate::log;
 use crate::{Body, Endpoint, Request, Response, Result, StatusCode};
-use crate::http::Mime;
 
 use async_std::fs::File;
 use async_std::io::BufReader;

--- a/src/fs/serve_dir.rs
+++ b/src/fs/serve_dir.rs
@@ -1,5 +1,6 @@
 use crate::log;
 use crate::{Body, Endpoint, Request, Response, Result, StatusCode};
+use crate::http::Mime;
 
 use async_std::fs::File;
 use async_std::io::BufReader;
@@ -70,7 +71,7 @@ impl<State> Endpoint<State> for ServeDir {
             res.set_body(body);
 
             if let Some(content_type) = mime_guess::from_path(&file_path).first() {
-                res = res.set_mime(content_type.to_string().parse().unwrap());
+                res = res.set_mime(content_type.to_string().parse::<Mime>().unwrap());
             }
 
             Ok(res)

--- a/src/fs/serve_dir.rs
+++ b/src/fs/serve_dir.rs
@@ -70,7 +70,7 @@ impl<State> Endpoint<State> for ServeDir {
             res.set_body(body);
 
             if let Some(content_type) = mime_guess::from_path(&file_path).first() {
-                res = res.set_mime(content_type);
+                res = res.set_mime(content_type.to_string().parse().unwrap());
             }
 
             Ok(res)

--- a/src/fs/serve_dir.rs
+++ b/src/fs/serve_dir.rs
@@ -1,9 +1,5 @@
-use crate::http::Mime;
 use crate::log;
 use crate::{Body, Endpoint, Request, Response, Result, StatusCode};
-
-use async_std::fs::File;
-use async_std::io::BufReader;
 
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
@@ -44,36 +40,9 @@ impl<State> Endpoint<State> for ServeDir {
                 log::warn!("Unauthorized attempt to read: {:?}", file_path);
                 return Ok(Response::new(StatusCode::Forbidden));
             }
-
-            let file = match File::open(&file_path).await {
-                Err(error) => {
-                    return if error.kind() == async_std::io::ErrorKind::NotFound {
-                        log::warn!("File not found: {:?}", file_path);
-                        Ok(Response::new(StatusCode::NotFound))
-                    } else {
-                        log::warn!("Could not open {:?}", file_path);
-                        Ok(Response::new(StatusCode::InternalServerError))
-                    }
-                }
-                Ok(file) => file,
-            };
-
-            let len = if let Ok(metadata) = file.metadata().await {
-                metadata.len() as usize
-            } else {
-                log::warn!("Could not retrieve metadata");
-                return Ok(Response::new(StatusCode::InternalServerError));
-            };
-
-            let body = Body::from_reader(BufReader::new(file), Some(len));
-            // TODO: fix related bug where async-h1 crashes on large files
+            let body = Body::from_file(&file_path).await?;
             let mut res = Response::new(StatusCode::Ok);
             res.set_body(body);
-
-            if let Some(content_type) = mime_guess::from_path(&file_path).first() {
-                res = res.set_mime(content_type.to_string().parse::<Mime>().unwrap());
-            }
-
             Ok(res)
         })
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -171,9 +171,7 @@ impl Response {
     ) -> Result<Self, serde_qs::Error> {
         // TODO: think about how to handle errors
         self.res.set_body(serde_qs::to_string(&form)?.into_bytes());
-        Ok(self
-            .set_status(StatusCode::Ok)
-            .set_mime(mime::MULTIPART_FORM))
+        Ok(self.set_status(StatusCode::Ok).set_mime(mime::FORM))
     }
 
     /// Encode a struct as a form and set as the response body.

--- a/src/response.rs
+++ b/src/response.rs
@@ -4,10 +4,10 @@ use std::ops::Index;
 
 use serde::Serialize;
 
-use crate::http::{Mime, mime};
 use crate::http::cookies::Cookie;
 use crate::http::headers::{HeaderName, HeaderValues, ToHeaderValues};
 use crate::http::{self, Body, StatusCode};
+use crate::http::{mime, Mime};
 use crate::redirect::Redirect;
 
 #[derive(Debug)]

--- a/src/response.rs
+++ b/src/response.rs
@@ -2,9 +2,9 @@ use async_std::io::prelude::*;
 use std::convert::TryFrom;
 use std::ops::Index;
 
-use mime::Mime;
 use serde::Serialize;
 
+use crate::http::{Mime, mime};
 use crate::http::cookies::Cookie;
 use crate::http::headers::{HeaderName, HeaderValues, ToHeaderValues, CONTENT_TYPE};
 use crate::http::{self, Body, StatusCode};
@@ -137,7 +137,7 @@ impl Response {
     #[must_use]
     pub fn body_string(mut self, string: String) -> Self {
         self.res.set_body(string);
-        self.set_mime(mime::TEXT_PLAIN_UTF_8)
+        self.set_mime(mime::PLAIN)
     }
 
     /// Pass raw bytes as the request body.
@@ -151,7 +151,7 @@ impl Response {
     {
         self.res
             .set_body(http_types::Body::from_reader(reader, None));
-        self.set_mime(mime::APPLICATION_OCTET_STREAM)
+        self.set_mime(mime::BYTE_STREAM)
     }
 
     /// Set the body reader.
@@ -172,7 +172,7 @@ impl Response {
         self.res.set_body(serde_qs::to_string(&form)?.into_bytes());
         Ok(self
             .set_status(StatusCode::Ok)
-            .set_mime(mime::APPLICATION_WWW_FORM_URLENCODED))
+            .set_mime(mime::MULTIPART_FORM))
     }
 
     /// Encode a struct as a form and set as the response body.
@@ -182,7 +182,7 @@ impl Response {
     /// The encoding is set to `application/json`.
     pub fn body_json(mut self, json: &impl Serialize) -> serde_json::Result<Self> {
         self.res.set_body(serde_json::to_vec(json)?);
-        Ok(self.set_mime(mime::APPLICATION_JSON))
+        Ok(self.set_mime(mime::JSON))
     }
 
     // fn body_multipart(&mut self) -> BoxTryFuture<Multipart<Cursor<Vec<u8>>>> {

--- a/src/response.rs
+++ b/src/response.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 
 use crate::http::{Mime, mime};
 use crate::http::cookies::Cookie;
-use crate::http::headers::{HeaderName, HeaderValues, ToHeaderValues, CONTENT_TYPE};
+use crate::http::headers::{HeaderName, HeaderValues, ToHeaderValues};
 use crate::http::{self, Body, StatusCode};
 use crate::redirect::Redirect;
 
@@ -125,8 +125,9 @@ impl Response {
     ///
     /// [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types)
     #[must_use]
-    pub fn set_mime(self, mime: Mime) -> Self {
-        self.set_header(CONTENT_TYPE, mime.to_string())
+    pub fn set_mime(mut self, mime: impl Into<Mime>) -> Self {
+        self.res.set_content_type(mime.into());
+        self
     }
 
     /// Pass a string as the request body.

--- a/tests/chunked-encode-large.rs
+++ b/tests/chunked-encode-large.rs
@@ -2,9 +2,9 @@ mod test_utils;
 use async_std::io::Cursor;
 use async_std::prelude::*;
 use async_std::task;
+use http_types::mime;
 use http_types::StatusCode;
 use std::time::Duration;
-use http_types::mime;
 use tide::Response;
 
 const TEXT: &'static str = concat![

--- a/tests/chunked-encode-large.rs
+++ b/tests/chunked-encode-large.rs
@@ -4,7 +4,7 @@ use async_std::prelude::*;
 use async_std::task;
 use http_types::StatusCode;
 use std::time::Duration;
-
+use http_types::mime;
 use tide::Response;
 
 const TEXT: &'static str = concat![
@@ -75,7 +75,7 @@ async fn chunked_large() -> Result<(), http_types::Error> {
             let body = Cursor::new(TEXT.to_owned());
             let res = Response::new(StatusCode::Ok)
                 .body(body)
-                .set_mime(mime::TEXT_PLAIN_UTF_8);
+                .set_mime(mime::PLAIN);
             Ok(res)
         });
         app.listen(("localhost", port)).await?;

--- a/tests/chunked-encode-small.rs
+++ b/tests/chunked-encode-small.rs
@@ -4,6 +4,7 @@ use async_std::prelude::*;
 use async_std::task;
 use http_types::StatusCode;
 use std::time::Duration;
+use http_types::mime;
 
 use tide::Response;
 
@@ -24,7 +25,7 @@ async fn chunked_large() -> Result<(), http_types::Error> {
             let body = Cursor::new(TEXT.to_owned());
             let res = Response::new(StatusCode::Ok)
                 .body(body)
-                .set_mime(mime::TEXT_PLAIN_UTF_8);
+                .set_mime(mime::PLAIN);
             Ok(res)
         });
         app.listen(("localhost", port)).await?;

--- a/tests/chunked-encode-small.rs
+++ b/tests/chunked-encode-small.rs
@@ -2,9 +2,9 @@ mod test_utils;
 use async_std::io::Cursor;
 use async_std::prelude::*;
 use async_std::task;
+use http_types::mime;
 use http_types::StatusCode;
 use std::time::Duration;
-use http_types::mime;
 
 use tide::Response;
 


### PR DESCRIPTION
Fix the use of the mime crate in the graphql example (brought up by #534), which was a mistake. This pr removes dependence on the mime crate entirely, in preference to http_types::Mime

This pr also allows set_mime to accept an Into<Mime>, and calls through to the http_types::Response::set_content_type