### PR TITLE
Update Request to latest http-types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ async-h1 = { version = "2.0.0", optional = true }
 async-sse = "2.1.0"
 async-std = { version = "1.6.0", features = ["unstable"] }
 femme = "2.0.1"
-http-types = "2.0.0"
+http-types = "2.0.1"
 kv-log-macro = "1.0.4"
 mime = "0.3.14"
 mime_guess = "2.0.3"

--- a/src/cookies/middleware.rs
+++ b/src/cookies/middleware.rs
@@ -45,7 +45,7 @@ impl<State: Send + Sync + 'static> Middleware<State> for CookiesMiddleware {
                 let cookie_data = CookieData::from_request(&ctx);
                 // no cookie data in ext context, so we try to create it
                 let content = cookie_data.content.clone();
-                ctx = ctx.set_ext(cookie_data);
+                ctx.set_ext(cookie_data);
                 content
             };
 

--- a/src/fs/serve_dir.rs
+++ b/src/fs/serve_dir.rs
@@ -22,7 +22,7 @@ impl ServeDir {
 
 impl<State> Endpoint<State> for ServeDir {
     fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, Result> {
-        let path = req.uri().path();
+        let path = req.url().path();
         let path = path.trim_start_matches(&self.prefix);
         let path = path.trim_start_matches('/');
         let mut file_path = self.dir.clone();

--- a/src/log/middleware.rs
+++ b/src/log/middleware.rs
@@ -30,7 +30,7 @@ impl LogMiddleware {
         ctx: Request<State>,
         next: Next<'a, State>,
     ) -> crate::Result {
-        let path = ctx.uri().path().to_owned();
+        let path = ctx.url().path().to_owned();
         let method = ctx.method().to_string();
         log::info!("<-- Request received", {
             method: method,

--- a/src/request.rs
+++ b/src/request.rs
@@ -235,7 +235,7 @@ impl<State> Request<State> {
     }
 
     /// Set a request extension value.
-    pub fn set_ext<T: Send + Sync + 'static>(mut self, val: T) {
+    pub fn set_ext<T: Send + Sync + 'static>(&mut self, val: T) -> Option<T> {
         self.req.ext_mut().insert(val)
     }
 
@@ -272,7 +272,15 @@ impl<State> Request<State> {
 
     /// Get the URL querystring.
     pub fn query<T: serde::de::DeserializeOwned>(&self) -> crate::Result<T> {
-        self.req.query()
+        // Default to an empty query string if no query parameter has been specified.
+        // This allows successful deserialisation of structs where all fields are optional
+        // when none of those fields has actually been passed by the caller.
+        let query = self.url().query().unwrap_or("");
+        serde_qs::from_str(query).map_err(|e| {
+            // Return the displayable version of the deserialisation error to the caller
+            // for easier debugging.
+            crate::Error::from_str(StatusCode::BadRequest, format!("{}", e))
+        })
     }
 
     /// Reads the entire request body into a byte buffer.

--- a/src/request.rs
+++ b/src/request.rs
@@ -29,6 +29,7 @@ pub struct Request<State> {
 }
 
 impl<State> Request<State> {
+    /// Create a new `Request`.
     pub(crate) fn new(
         state: Arc<State>,
         req: http_types::Request,
@@ -77,7 +78,7 @@ impl<State> Request<State> {
     ///
     /// let mut app = tide::new();
     /// app.at("/").get(|req: Request<()>| async move {
-    ///     assert_eq!(req.uri(), &"/".parse::<tide::http::Url>().unwrap());
+    ///     assert_eq!(req.url(), &"/".parse::<tide::http::Url>().unwrap());
     ///     Ok("")
     /// });
     /// app.listen("127.0.0.1:8080").await?;
@@ -85,7 +86,7 @@ impl<State> Request<State> {
     /// # Ok(()) })}
     /// ```
     #[must_use]
-    pub fn uri(&self) -> &Url {
+    pub fn url(&self) -> &Url {
         self.req.url()
     }
 
@@ -269,7 +270,7 @@ impl<State> Request<State> {
         // Default to an empty query string if no query parameter has been specified.
         // This allows successful deserialisation of structs where all fields are optional
         // when none of those fields has actually been passed by the caller.
-        let query = self.uri().query().unwrap_or("");
+        let query = self.url().query().unwrap_or("");
         serde_qs::from_str(query).map_err(|e| {
             // Return the displayable version of the deserialisation error to the caller
             // for easier debugging.

--- a/src/request.rs
+++ b/src/request.rs
@@ -24,19 +24,19 @@ use crate::Response;
 #[derive(Debug)]
 pub struct Request<State> {
     pub(crate) state: Arc<State>,
-    pub(crate) request: http::Request,
+    pub(crate) req: http::Request,
     pub(crate) route_params: Vec<Params>,
 }
 
 impl<State> Request<State> {
     pub(crate) fn new(
         state: Arc<State>,
-        request: http_types::Request,
+        req: http_types::Request,
         route_params: Vec<Params>,
     ) -> Self {
         Self {
             state,
-            request,
+            req,
             route_params,
         }
     }
@@ -62,7 +62,7 @@ impl<State> Request<State> {
     /// ```
     #[must_use]
     pub fn method(&self) -> Method {
-        self.request.method()
+        self.req.method()
     }
 
     /// Access the request's full URI method.
@@ -86,7 +86,7 @@ impl<State> Request<State> {
     /// ```
     #[must_use]
     pub fn uri(&self) -> &Url {
-        self.request.url()
+        self.req.url()
     }
 
     /// Access the request's HTTP version.
@@ -110,7 +110,7 @@ impl<State> Request<State> {
     /// ```
     #[must_use]
     pub fn version(&self) -> Option<Version> {
-        self.request.version()
+        self.req.version()
     }
 
     /// Get an HTTP header.
@@ -137,18 +137,18 @@ impl<State> Request<State> {
         &self,
         key: impl Into<http_types::headers::HeaderName>,
     ) -> Option<&http_types::headers::HeaderValues> {
-        self.request.header(key)
+        self.req.header(key)
     }
 
     /// Get a request extension value.
     #[must_use]
     pub fn ext<T: Send + Sync + 'static>(&self) -> Option<&T> {
-        self.request.ext().get()
+        self.req.ext().get()
     }
 
     /// Set a request extension value.
     pub fn set_ext<T: Send + Sync + 'static>(mut self, val: T) -> Self {
-        self.request.ext_mut().insert(val);
+        self.req.ext_mut().insert(val);
         self
     }
 
@@ -212,7 +212,7 @@ impl<State> Request<State> {
     /// ```
     pub async fn body_bytes(&mut self) -> std::io::Result<Vec<u8>> {
         let mut buf = Vec::with_capacity(1024);
-        self.request.read_to_end(&mut buf).await?;
+        self.req.read_to_end(&mut buf).await?;
         Ok(buf)
     }
 
@@ -302,36 +302,36 @@ impl<State> Request<State> {
     /// Get the length of the body.
     #[must_use]
     pub fn len(&self) -> Option<usize> {
-        self.request.len()
+        self.req.len()
     }
     /// Checks if the body is empty.
     #[must_use]
     pub fn is_empty(&self) -> Option<bool> {
-        Some(self.request.len()? == 0)
+        Some(self.req.len()? == 0)
     }
 
     /// Peer address of the underlying transport
     #[must_use]
     pub fn peer_addr(&self) -> Option<&str> {
-        self.request.peer_addr()
+        self.req.peer_addr()
     }
 
     /// Local address of the underlying transport
     #[must_use]
     pub fn local_addr(&self) -> Option<&str> {
-        self.request.local_addr()
+        self.req.local_addr()
     }
 }
 
 impl<State> AsMut<http::Request> for Request<State> {
     fn as_mut(&mut self) -> &mut http::Request {
-        &mut self.request
+        &mut self.req
     }
 }
 
 impl<State> AsRef<http::Request> for Request<State> {
     fn as_ref(&self) -> &http::Request {
-        &self.request
+        &self.req
     }
 }
 
@@ -341,13 +341,13 @@ impl<State> Read for Request<State> {
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
-        Pin::new(&mut self.request).poll_read(cx, buf)
+        Pin::new(&mut self.req).poll_read(cx, buf)
     }
 }
 
 impl<State> Into<http::Request> for Request<State> {
     fn into(self) -> http::Request {
-        self.request
+        self.req
     }
 }
 
@@ -366,7 +366,7 @@ impl<State> IntoIterator for Request<State> {
     /// Returns a iterator of references over the remaining items.
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        self.request.into_iter()
+        self.req.into_iter()
     }
 }
 
@@ -376,7 +376,7 @@ impl<'a, State> IntoIterator for &'a Request<State> {
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        self.request.iter()
+        self.req.iter()
     }
 }
 
@@ -386,7 +386,7 @@ impl<'a, State> IntoIterator for &'a mut Request<State> {
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
-        self.request.iter_mut()
+        self.req.iter_mut()
     }
 }
 
@@ -400,7 +400,7 @@ impl<State> Index<HeaderName> for Request<State> {
     /// Panics if the name is not present in `Request`.
     #[inline]
     fn index(&self, name: HeaderName) -> &HeaderValues {
-        &self.request[name]
+        &self.req[name]
     }
 }
 
@@ -414,7 +414,7 @@ impl<State> Index<&str> for Request<State> {
     /// Panics if the name is not present in `Request`.
     #[inline]
     fn index(&self, name: &str) -> &HeaderValues {
-        &self.request[name]
+        &self.req[name]
     }
 }
 

--- a/src/route.rs
+++ b/src/route.rs
@@ -278,16 +278,16 @@ impl<State, E: Endpoint<State>> Endpoint<State> for StripPrefixEndpoint<E> {
     fn call<'a>(&'a self, req: crate::Request<State>) -> BoxFuture<'a, crate::Result> {
         let crate::Request {
             state,
-            mut request,
+            mut req,
             route_params,
         } = req;
 
         let rest = crate::request::rest(&route_params).unwrap_or_else(|| "");
-        request.url_mut().set_path(&rest);
+        req.url_mut().set_path(&rest);
 
         self.0.call(crate::Request {
             state,
-            request,
+            req,
             route_params,
         })
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -398,7 +398,7 @@ impl<State: Sync + Send + 'static, InnerState: Sync + Send + 'static> Endpoint<S
 {
     fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, crate::Result> {
         let Request {
-            request: req,
+            req,
             mut route_params,
             ..
         } = req;

--- a/tests/cookies.rs
+++ b/tests/cookies.rs
@@ -91,7 +91,7 @@ async fn successfully_remove_cookie() {
     assert_eq!(cookie.name(), COOKIE_NAME);
     assert_eq!(cookie.value(), "");
     assert_eq!(cookie.http_only(), None);
-    assert_eq!(cookie.max_age().unwrap().num_nanoseconds(), Some(0));
+    assert_eq!(cookie.max_age().unwrap().whole_nanoseconds(), 0);
 }
 
 #[async_std::test]

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -34,7 +34,7 @@ async fn nested() {
 
 #[async_std::test]
 async fn nested_middleware() {
-    let echo_path = |req: tide::Request<()>| async move { Ok(req.uri().path().to_string()) };
+    let echo_path = |req: tide::Request<()>| async move { Ok(req.url().path().to_string()) };
 
     #[derive(Debug, Clone, Default)]
     pub struct TestMiddleware;

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -19,7 +19,7 @@ async fn nested() {
         Method::Get,
         Url::parse("http://example.com/foo/foo").unwrap(),
     );
-    let res: Response = outer.respond(req).await.unwrap();
+    let mut res: Response = outer.respond(req).await.unwrap();
     assert_eq!(res.status(), 200);
     assert_eq!(res.body_string().await.unwrap(), "foo");
 
@@ -27,7 +27,7 @@ async fn nested() {
         Method::Get,
         Url::parse("http://example.com/foo/bar").unwrap(),
     );
-    let res: Response = outer.respond(req).await.unwrap();
+    let mut res: Response = outer.respond(req).await.unwrap();
     assert_eq!(res.status(), 200);
     assert_eq!(res.body_string().await.unwrap(), "bar");
 }
@@ -76,7 +76,7 @@ async fn nested_middleware() {
         Method::Get,
         Url::parse("http://example.com/foo/echo").unwrap(),
     );
-    let res: Response = app.respond(req).await.unwrap();
+    let mut res: Response = app.respond(req).await.unwrap();
     assert_eq!(res["X-Tide-Test"], "1");
     assert_eq!(res.status(), 200);
     assert_eq!(res.body_string().await.unwrap(), "/echo");
@@ -85,13 +85,13 @@ async fn nested_middleware() {
         Method::Get,
         Url::parse("http://example.com/foo/x/bar").unwrap(),
     );
-    let res: Response = app.respond(req).await.unwrap();
+    let mut res: Response = app.respond(req).await.unwrap();
     assert_eq!(res["X-Tide-Test"], "1");
     assert_eq!(res.status(), 200);
     assert_eq!(res.body_string().await.unwrap(), "/");
 
     let req = Request::new(Method::Get, Url::parse("http://example.com/bar").unwrap());
-    let res: Response = app.respond(req).await.unwrap();
+    let mut res: Response = app.respond(req).await.unwrap();
     assert!(res.header("X-Tide-Test").is_none());
     assert_eq!(res.status(), 200);
     assert_eq!(res.body_string().await.unwrap(), "/bar");
@@ -109,12 +109,12 @@ async fn nested_with_different_state() {
     outer.at("/foo").nest(inner);
 
     let req = Request::new(Method::Get, Url::parse("http://example.com/foo").unwrap());
-    let res: Response = outer.respond(req).await.unwrap();
+    let mut res: Response = outer.respond(req).await.unwrap();
     assert_eq!(res.status(), 200);
     assert_eq!(res.body_string().await.unwrap(), "the number is 42");
 
     let req = Request::new(Method::Get, Url::parse("http://example.com/").unwrap());
-    let res: Response = outer.respond(req).await.unwrap();
+    let mut res: Response = outer.respond(req).await.unwrap();
     assert_eq!(res.status(), 200);
     assert_eq!(res.body_string().await.unwrap(), "Hello, world!");
 }

--- a/tests/querystring.rs
+++ b/tests/querystring.rs
@@ -57,7 +57,7 @@ async fn unsuccessfully_deserialize_query() {
     let app = get_server();
     let req = http_types::Request::new(Method::Get, Url::parse("http://example.com/").unwrap());
     let mut res: http::Response = app.respond(req).await.unwrap();
-    assert_eq!(res.status(), 400);
+    assert_eq!(res.status(), 400_u16);
 
     let mut body = String::new();
     res.read_to_string(&mut body).await.unwrap();

--- a/tests/route_middleware.rs
+++ b/tests/route_middleware.rs
@@ -30,7 +30,7 @@ impl<State: Send + Sync + 'static> Middleware<State> for TestMiddleware {
 }
 
 async fn echo_path<State>(req: tide::Request<State>) -> tide::Result<String> {
-    Ok(req.uri().path().to_string())
+    Ok(req.url().path().to_string())
 }
 
 #[async_std::test]


### PR DESCRIPTION
Exposes more methods, removed `Self` from chaining returns, and renamed methods. Also updates to http-types v2.0.1. We should do Response next. Thanks!