### PR TITLE
Update docs from Request.local to Request.ext

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,10 +104,14 @@
 //!
 //! ## State
 //!
-//! Middleware often needs to share values with the endpoint. This is done through "local state".
-//! Local state is built using a typemap that's available through [`Request::local`].
+//! Middleware often needs to share values with the endpoint. This is done through "request scoped
+//! state".  Request scoped state is built using a typemap that's available through
+//! [`Request::ext`].
 //!
-//! Global state is used when a complete application needs access to a particular
+//! If the endpoint needs to share values with middleware, response scoped state can be set via
+//! [`Response::set_ext`] and is available through [`Response::ext`].
+//!
+//! Application scoped state is used when a complete application needs access to a particular
 //! value. Examples of this include: database connections, websocket connections, or
 //! network-enabled config. Every `Request<State>` has an inner value that must
 //! implement `Send + Sync + Clone`, and can thus freely be shared between requests.
@@ -117,7 +121,7 @@
 //!
 //! ## Extension Traits
 //!
-//! Sometimes having global and local context can require a bit of setup. There are
+//! Sometimes having application and request scoped context can require a bit of setup. There are
 //! cases where it'd be nice if things were a little easier. This is why Tide
 //! encourages people to write _extension traits_.
 //!
@@ -236,9 +240,9 @@ pub fn new() -> server::Server<()> {
     Server::new()
 }
 
-/// Create a new Tide server with shared global state.
+/// Create a new Tide server with shared application scoped state.
 ///
-/// Global state is useful for storing items
+/// Application scoped state is useful for storing items
 ///
 /// # Examples
 ///

--- a/src/request.rs
+++ b/src/request.rs
@@ -240,7 +240,7 @@ impl<State> Request<State> {
     }
 
     #[must_use]
-    ///  Access app-global state.
+    ///  Access application scoped state.
     pub fn state(&self) -> &State {
         &self.state
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -238,13 +238,13 @@ impl Response {
         self.cookie_events.push(CookieEvent::Removed(cookie));
     }
 
-    /// Get a response extension value.
+    /// Get a response scoped extension value.
     #[must_use]
     pub fn ext<T: Send + Sync + 'static>(&self) -> Option<&T> {
         self.res.ext().get()
     }
 
-    /// Set a local value.
+    /// Set a response scoped extension value.
     pub fn set_ext<T: Send + Sync + 'static>(mut self, val: T) -> Self {
         self.res.ext_mut().insert(val);
         self

--- a/src/server.rs
+++ b/src/server.rs
@@ -163,9 +163,9 @@ impl Default for Server<()> {
 }
 
 impl<State: Send + Sync + 'static> Server<State> {
-    /// Create a new Tide server with shared global state.
+    /// Create a new Tide server with shared application scoped state.
     ///
-    /// Global state is useful for storing items
+    /// Application scoped state is useful for storing items
     ///
     /// # Examples
     ///
@@ -259,14 +259,13 @@ impl<State: Send + Sync + 'static> Server<State> {
 
     /// Add middleware to an application.
     ///
-    /// Middleware provides application-global customization of the
-    /// request/response cycle, such as compression, logging, or header
-    /// modification. Middleware is invoked when processing a request, and can
-    /// either continue processing (possibly modifying the response) or
-    /// immediately return a response. See the [`Middleware`] trait for details.
+    /// Middleware provides customization of the request/response cycle, such as compression,
+    /// logging, or header modification. Middleware is invoked when processing a request, and can
+    /// either continue processing (possibly modifying the response) or immediately return a
+    /// response. See the [`Middleware`] trait for details.
     ///
-    /// Middleware can only be added at the "top level" of an application,
-    /// and is processed in the order in which it is applied.
+    /// Middleware can only be added at the "top level" of an application, and is processed in the
+    /// order in which it is applied.
     pub fn middleware<M>(&mut self, middleware: M) -> &mut Self
     where
         M: Middleware<State> + Debug,


### PR DESCRIPTION
The method was renamed in Tide 0.9.

Just 2 cents, it was a bit confusing to me to use "local state" and "global state" as the names because IMHO those terms are normally associated with entire programs. Other frameworks call "local state" as "per request state" or "request scoped state". The "global state" is sometimes referred to as "application scoped state" as well. I'm not familiar with the design and terminology of this framework, but my suggestion would be to clarify/rename those concepts.