### PR TITLE
Add CORS headers to error responses

### DIFF
--- a/src/security/cors.rs
+++ b/src/security/cors.rs
@@ -379,4 +379,20 @@ mod test {
 
         assert_eq!(res[http_types::headers::SET_COOKIE][0], "foo=bar");
     }
+
+    #[async_std::test]
+    async fn set_cors_headers_to_error_responses() {
+        let mut app = crate::Server::new();
+        app.at(ENDPOINT).get(|_| async {
+            Err::<&str, _>(crate::Error::from_str(
+                StatusCode::BadRequest,
+                "bad request",
+            ))
+        });
+        app.middleware(CorsMiddleware::new().allow_origin(Origin::from(ALLOW_ORIGIN)));
+
+        let res: crate::http::Response = app.respond(request()).await.unwrap();
+        assert_eq!(res.status(), 400);
+        assert_eq!(res[headers::ACCESS_CONTROL_ALLOW_ORIGIN], ALLOW_ORIGIN);
+    }
 }


### PR DESCRIPTION
Browsers are currently unable to read responses the originate from `tide::Error`s when the `CORS` middleware is used. This PR makes sure to add CORS headers to error responses as well.

I guess we want to implement parts of the PR differently (I'll highlight the line I am talking about via a code comment), but I still wanted to open a PR to start the discussion and maybe at least provide a unit test another implementation could reuse.

Refs #525