### PR TITLE
Add AsRef/AsMut<Headers> for Request/Response

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -399,15 +399,27 @@ impl<State> Request<State> {
     }
 }
 
+impl<State> AsRef<http::Request> for Request<State> {
+    fn as_ref(&self) -> &http::Request {
+        &self.req
+    }
+}
+
 impl<State> AsMut<http::Request> for Request<State> {
     fn as_mut(&mut self) -> &mut http::Request {
         &mut self.req
     }
 }
 
-impl<State> AsRef<http::Request> for Request<State> {
-    fn as_ref(&self) -> &http::Request {
-        &self.req
+impl<State> AsRef<http::Headers> for Request<State> {
+    fn as_ref(&self) -> &http::Headers {
+        self.req.as_ref()
+    }
+}
+
+impl<State> AsMut<http::Headers> for Request<State> {
+    fn as_mut(&mut self) -> &mut http::Headers {
+        self.req.as_mut()
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -264,15 +264,27 @@ impl Response {
     }
 }
 
+impl AsRef<http::Response> for Response {
+    fn as_ref(&self) -> &http::Response {
+        &self.res
+    }
+}
+
 impl AsMut<http::Response> for Response {
     fn as_mut(&mut self) -> &mut http::Response {
         &mut self.res
     }
 }
 
-impl AsRef<http::Response> for Response {
-    fn as_ref(&self) -> &http::Response {
-        &self.res
+impl AsRef<http::Headers> for Response {
+    fn as_ref(&self) -> &http::Headers {
+        self.res.as_ref()
+    }
+}
+
+impl AsMut<http::Headers> for Response {
+    fn as_mut(&mut self) -> &mut http::Headers {
+        self.res.as_mut()
     }
 }
 


### PR DESCRIPTION
Adds `{AsRef,AsMut}<Headers>` impls for `Request` and `Response`. This is useful for generic functions that want to operate on `http_types::Headers`. With this Tide's req/res types can be passed directly to functions that operate on `http-types`'s types:
```rust
fn set_custom(headers: impl AsMut<http_types::Headers>) {
    headers.insert("x-custom", "meow");
}

set_custom(&mut req);
set_custom(&mut res);
```