### PR TITLE
introduce the ideas of Before and After middlewares

### DIFF
--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -98,7 +98,7 @@ async fn main() -> Result<()> {
     tide::log::start();
     let mut app = tide::with_state(UserDatabase::default());
 
-    app.middleware(After::new(|result: Result| async move {
+    app.middleware(After(|result: Result| async move {
         let response = result.unwrap_or_else(|e| Response::new(e.status()));
         match response.status() {
             StatusCode::NotFound => Ok(response
@@ -115,12 +115,10 @@ async fn main() -> Result<()> {
 
     app.middleware(user_loader);
     app.middleware(RequestCounterMiddleware::new(0));
-    app.middleware(Before::new(
-        |mut request: Request<UserDatabase>| async move {
-            request.set_ext(std::time::Instant::now());
-            request
-        },
-    ));
+    app.middleware(Before(|mut request: Request<UserDatabase>| async move {
+        request.set_ext(std::time::Instant::now());
+        request
+    }));
 
     app.at("/").get(|req: Request<_>| async move {
         let count: &RequestCount = req.ext().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,7 @@ pub mod security;
 pub mod sse;
 
 pub use endpoint::Endpoint;
-pub use middleware::{Middleware, Next};
+pub use middleware::{After, Before, Middleware, Next};
 pub use redirect::Redirect;
 pub use request::Request;
 pub use response::Response;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -27,6 +27,23 @@ pub trait Middleware<State>: 'static + Send + Sync {
     }
 }
 
+/// Define a middleware that operates on incoming requests.
+///
+/// This middleware is useful because it is not possible in Rust yet to use
+/// closures to define inline middleware.
+///
+/// # Examples
+///
+/// ```rust
+/// use tide::{Before, Request};
+/// use std::time::Instant;
+///
+/// let mut app = tide::new();
+/// app.middleware(Before(|mut request: Request<()>| async move {
+///     request.set_ext(Instant::now());
+///     request
+/// }));
+/// ```
 #[derive(Debug)]
 pub struct Before<F>(pub F);
 impl<State, F, Fut> Middleware<State> for Before<F>
@@ -47,6 +64,26 @@ where
     }
 }
 
+/// Define a middleware that operates on outgoing responses.
+///
+/// This middleware is useful because it is not possible in Rust yet to use
+/// closures to define inline middleware.
+///
+/// # Examples
+///
+/// ```rust
+/// use tide::{After, Response, http};
+///
+/// let mut app = tide::new();
+/// app.middleware(After(|res: tide::Result| async move {
+///     let res = res.unwrap_or_else(|e| Response::new(e.status()));
+///     match res.status() {
+///         http::StatusCode::NotFound => Ok("Page not found".into()),
+///         http::StatusCode::InternalServerError => Ok("Something went wrong".into()),
+///         _ => Ok(res),
+///     }
+/// }));
+/// ```
 #[derive(Debug)]
 pub struct After<F>(pub F);
 impl<State, F, Fut> Middleware<State> for After<F>

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -28,13 +28,7 @@ pub trait Middleware<State>: 'static + Send + Sync {
 }
 
 #[derive(Debug)]
-pub struct Before<F>(F);
-impl<F> Before<F> {
-    pub fn new(f: F) -> Self {
-        Self(f)
-    }
-}
-
+pub struct Before<F>(pub F);
 impl<State, F, Fut> Middleware<State> for Before<F>
 where
     State: Send + Sync + 'static,
@@ -54,13 +48,7 @@ where
 }
 
 #[derive(Debug)]
-pub struct After<F>(F);
-impl<F> After<F> {
-    pub fn new(f: F) -> Self {
-        Self(f)
-    }
-}
-
+pub struct After<F>(pub F);
 impl<State, F, Fut> Middleware<State> for After<F>
 where
     State: Send + Sync + 'static,


### PR DESCRIPTION
For discussion, a _functional_ sketch

### context
Due to the lack of AsyncFn types in rust currently, we cannot describe the bounds for an async function that has a lifetime in the arguments. As a result, there's no way to write
```rust
// this example is not possible
app.middleware(|req: Request<()>, next: Next<()>| async move {
  next.run(req).await
});
```

and instead function middlewares look like:
```rust
// current signature
fn minimal_middleware<'a>(
    request: Request<()>,
    next: Next<'a, ()>,
) -> Pin<Box<dyn Future<Output = Result> + Send + 'a>> {
    Box::pin(async { next.run(request).await })
}

//--snip--

app.middleware(minimal_middleware);
```

### proposed solution

Because the issue is that Next is not owned, it is possible to write simple async signatures for middlewares that exist on either side of the Next call.  This PR called them `Before` and `After` middlewares currently, but those names probably can be improved. This PR is predicated on an assumption that a meaningful percentage of app-written middlewares exist as transformations of the request OR the response. This enables the following code.

```rust
// possible with this pr
app.middleware(Before(|request: Request<()>| async move { request })));
app.middleware(After(|result: Result| async move { result })));
```





