### PR TITLE
fix tests on master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ unstable = []
 __internal__bench = []
 
 [dependencies]
-async-h1 = { version = "2.0.0", optional = true }
+async-h1 = { version = "2.0.1", optional = true }
 async-sse = "3.0.0"
 async-std = { version = "1.6.0", features = ["unstable"] }
 femme = "2.0.1"
@@ -47,9 +47,9 @@ serde_qs = "0.5.0"
 async-std = { version = "1.6.0", features = ["unstable", "attributes"] }
 juniper = "0.14.1"
 portpicker = "0.1.0"
+surf = { version = "2.0.0-alpha.3", default-features = false, features = ["h1-client"] }
 serde = { version = "1.0.102", features = ["derive"] }
 criterion = "0.3.1"
-surf = { version = "2.0.0-alpha.2", default-features = false, features = ["h1-client"] }
 tempdir = "0.3.7"
 
 [[test]]

--- a/tests/chunked-encode-large.rs
+++ b/tests/chunked-encode-large.rs
@@ -88,16 +88,8 @@ async fn chunked_large() -> Result<(), http_types::Error> {
             .await
             .unwrap();
         assert_eq!(res.status(), 200);
-        assert_eq!(
-            // this is awkward and should be revisited when surf is on newer http-types
-            res.header(&"transfer-encoding".parse().unwrap())
-                .unwrap()
-                .last()
-                .unwrap()
-                .as_str(),
-            "chunked"
-        );
-        assert_eq!(res.header(&"content-length".parse().unwrap()), None);
+        assert_eq!(res.header("transfer-encoding").unwrap(), "chunked");
+        assert!(res.header("content-length").is_none());
         let string = res.body_string().await.unwrap();
         assert_eq!(string, TEXT.to_string());
         Ok(())

--- a/tests/chunked-encode-small.rs
+++ b/tests/chunked-encode-small.rs
@@ -38,16 +38,8 @@ async fn chunked_large() -> Result<(), http_types::Error> {
             .await
             .unwrap();
         assert_eq!(res.status(), 200);
-        assert_eq!(
-            // this is awkward and should be revisited when surf is on newer http-types
-            res.header(&"transfer-encoding".parse().unwrap())
-                .unwrap()
-                .last()
-                .unwrap()
-                .as_str(),
-            "chunked"
-        );
-        assert_eq!(res.header(&"content-length".parse().unwrap()), None);
+        assert_eq!(res.header("transfer-encoding").unwrap(), "chunked");
+        assert!(res.header("content-length").is_none());
         let string = res.body_string().await.unwrap();
         assert_eq!(string, TEXT.to_string());
         Ok(())

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -41,7 +41,7 @@ async fn wildcard() {
         Method::Get,
         Url::parse("http://localhost/add_one/3").unwrap(),
     );
-    let res: http::Response = app.respond(req).await.unwrap();
+    let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
     assert_eq!(&res.body_string().await.unwrap(), "4");
 
@@ -49,7 +49,7 @@ async fn wildcard() {
         Method::Get,
         Url::parse("http://localhost/add_one/-7").unwrap(),
     );
-    let res: http::Response = app.respond(req).await.unwrap();
+    let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
     assert_eq!(&res.body_string().await.unwrap(), "-6");
 }
@@ -89,7 +89,7 @@ async fn wild_path() {
         Method::Get,
         Url::parse("http://localhost/echo/some_path").unwrap(),
     );
-    let res: http::Response = app.respond(req).await.unwrap();
+    let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
     assert_eq!(&res.body_string().await.unwrap(), "some_path");
 
@@ -97,12 +97,12 @@ async fn wild_path() {
         Method::Get,
         Url::parse("http://localhost/echo/multi/segment/path").unwrap(),
     );
-    let res: http::Response = app.respond(req).await.unwrap();
+    let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
     assert_eq!(&res.body_string().await.unwrap(), "multi/segment/path");
 
     let req = http::Request::new(Method::Get, Url::parse("http://localhost/echo/").unwrap());
-    let res: http::Response = app.respond(req).await.unwrap();
+    let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::NotFound);
     assert_eq!(&res.body_string().await.unwrap(), "");
 }
@@ -116,7 +116,7 @@ async fn multi_wildcard() {
         Method::Get,
         Url::parse("http://localhost/add_two/1/2/").unwrap(),
     );
-    let res: http::Response = app.respond(req).await.unwrap();
+    let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
     assert_eq!(&res.body_string().await.unwrap(), "3");
 
@@ -124,7 +124,7 @@ async fn multi_wildcard() {
         Method::Get,
         Url::parse("http://localhost/add_two/-1/2/").unwrap(),
     );
-    let res: http::Response = app.respond(req).await.unwrap();
+    let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), 200);
     assert_eq!(&res.body_string().await.unwrap(), "1");
 
@@ -145,7 +145,7 @@ async fn wild_last_segment() {
         Method::Get,
         Url::parse("http://localhost/echo/one/two").unwrap(),
     );
-    let res: http::Response = app.respond(req).await.unwrap();
+    let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
     assert_eq!(&res.body_string().await.unwrap(), "one");
 
@@ -153,7 +153,7 @@ async fn wild_last_segment() {
         Method::Get,
         Url::parse("http://localhost/echo/one/two/three/four").unwrap(),
     );
-    let res: http::Response = app.respond(req).await.unwrap();
+    let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
     assert_eq!(&res.body_string().await.unwrap(), "one");
 }
@@ -207,7 +207,7 @@ async fn nameless_internal_wildcard() {
         Method::Get,
         Url::parse("http://localhost/echo/one/two").unwrap(),
     );
-    let res: http::Response = app.respond(req).await.unwrap();
+    let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
     assert_eq!(&res.body_string().await.unwrap(), "two");
 
@@ -215,7 +215,7 @@ async fn nameless_internal_wildcard() {
         Method::Get,
         Url::parse("http://localhost/echo/one/two").unwrap(),
     );
-    let res: http::Response = app.respond(req).await.unwrap();
+    let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
     assert_eq!(&res.body_string().await.unwrap(), "two");
 }
@@ -229,7 +229,7 @@ async fn nameless_internal_wildcard2() {
         Method::Get,
         Url::parse("http://localhost/echo/one/two").unwrap(),
     );
-    let res: http::Response = app.respond(req).await.unwrap();
+    let mut res: http::Response = app.respond(req).await.unwrap();
     assert_eq!(res.status(), StatusCode::Ok);
     assert_eq!(&res.body_string().await.unwrap(), "one");
 }


### PR DESCRIPTION
this became necessary because the surf change was not Major but had breaking changes from the previous alpha.

this also explicitly updates surf and async-h1 deps