### PR TITLE
Bring response in line with http-types

### DIFF
--- a/examples/chunked.rs
+++ b/examples/chunked.rs
@@ -1,14 +1,12 @@
-use async_std::fs;
-use async_std::io::BufReader;
 use async_std::task;
-use tide::{Response, StatusCode};
+use tide::{Body, Response, StatusCode};
 
 fn main() -> Result<(), std::io::Error> {
     task::block_on(async {
         let mut app = tide::new();
         app.at("/").get(|_| async move {
-            let file = fs::File::open(file!()).await.unwrap();
-            let res = Response::new(StatusCode::Ok).body(BufReader::new(file));
+            let mut res = Response::new(StatusCode::Ok);
+            res.set_body(Body::from_file(file!()).await.unwrap());
             Ok(res)
         });
         app.listen("127.0.0.1:8080").await?;

--- a/examples/cookies.rs
+++ b/examples/cookies.rs
@@ -8,9 +8,9 @@ async fn retrieve_cookie(cx: Request<()>) -> tide::Result<String> {
     Ok(format!("hello cookies: {:?}", cx.cookie("hello").unwrap()))
 }
 
-async fn append_cookie(_req: Request<()>) -> tide::Result {
+async fn insert_cookie(_req: Request<()>) -> tide::Result {
     let mut res = tide::Response::new(StatusCode::Ok);
-    res.append_cookie(Cookie::new("hello", "world"));
+    res.insert_cookie(Cookie::new("hello", "world"));
     Ok(res)
 }
 
@@ -25,7 +25,7 @@ fn main() -> Result<(), std::io::Error> {
         let mut app = tide::new();
 
         app.at("/").get(retrieve_cookie);
-        app.at("/set").get(append_cookie);
+        app.at("/set").get(insert_cookie);
         app.at("/remove").get(remove_cookie);
         app.listen("127.0.0.1:8080").await?;
 

--- a/examples/cookies.rs
+++ b/examples/cookies.rs
@@ -8,9 +8,9 @@ async fn retrieve_cookie(cx: Request<()>) -> tide::Result<String> {
     Ok(format!("hello cookies: {:?}", cx.cookie("hello").unwrap()))
 }
 
-async fn set_cookie(_req: Request<()>) -> tide::Result {
+async fn insert_cookie(_req: Request<()>) -> tide::Result {
     let mut res = tide::Response::new(StatusCode::Ok);
-    res.set_cookie(Cookie::new("hello", "world"));
+    res.insert_cookie(Cookie::new("hello", "world"));
     Ok(res)
 }
 
@@ -25,7 +25,7 @@ fn main() -> Result<(), std::io::Error> {
         let mut app = tide::new();
 
         app.at("/").get(retrieve_cookie);
-        app.at("/set").get(set_cookie);
+        app.at("/set").get(insert_cookie);
         app.at("/remove").get(remove_cookie);
         app.listen("127.0.0.1:8080").await?;
 

--- a/examples/cookies.rs
+++ b/examples/cookies.rs
@@ -8,9 +8,9 @@ async fn retrieve_cookie(cx: Request<()>) -> tide::Result<String> {
     Ok(format!("hello cookies: {:?}", cx.cookie("hello").unwrap()))
 }
 
-async fn insert_cookie(_req: Request<()>) -> tide::Result {
+async fn append_cookie(_req: Request<()>) -> tide::Result {
     let mut res = tide::Response::new(StatusCode::Ok);
-    res.insert_cookie(Cookie::new("hello", "world"));
+    res.append_cookie(Cookie::new("hello", "world"));
     Ok(res)
 }
 
@@ -25,7 +25,7 @@ fn main() -> Result<(), std::io::Error> {
         let mut app = tide::new();
 
         app.at("/").get(retrieve_cookie);
-        app.at("/set").get(insert_cookie);
+        app.at("/set").get(append_cookie);
         app.at("/remove").get(remove_cookie);
         app.listen("127.0.0.1:8080").await?;
 

--- a/examples/graphql.rs
+++ b/examples/graphql.rs
@@ -1,7 +1,7 @@
 use async_std::task;
 use juniper::RootNode;
 use std::sync::RwLock;
-use tide::{Redirect, Request, Response, Server, StatusCode};
+use tide::{Body, Redirect, Request, Response, Server, StatusCode};
 
 #[derive(Clone)]
 struct User {
@@ -86,16 +86,15 @@ async fn handle_graphql(mut cx: Request<State>) -> tide::Result {
         StatusCode::BadRequest
     };
 
-    let res = Response::new(status)
-        .body_json(&response)
-        .expect("be able to serialize the graphql response");
+    let mut res = Response::new(status);
+    res.set_body(Body::from_json(&response)?);
     Ok(res)
 }
 
 async fn handle_graphiql(_: Request<State>) -> tide::Result {
-    let res = Response::new(StatusCode::Ok)
-        .body_string(juniper::http::graphiql::graphiql_source("/graphql"))
-        .set_content_type(tide::http::mime::HTML);
+    let mut res = Response::new(StatusCode::Ok);
+    res.set_body(juniper::http::graphiql::graphiql_source("/graphql"));
+    res.set_content_type(tide::http::mime::HTML);
     Ok(res)
 }
 

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -1,7 +1,7 @@
 use async_std::task;
 use serde::{Deserialize, Serialize};
 use tide::prelude::*;
-use tide::{Request, Response, StatusCode};
+use tide::{Body, Request, Response};
 
 #[derive(Deserialize, Serialize)]
 struct Cat {
@@ -20,7 +20,9 @@ fn main() -> tide::Result<()> {
                 name: "chashu".into(),
             };
 
-            Ok(Response::new(StatusCode::Ok).body_json(&cat)?)
+            let mut res = Response::new(200);
+            res.set_body(Body::from_json(&cat)?);
+            Ok(res)
         });
 
         app.at("/animals").get(|_| async {

--- a/src/cookies/middleware.rs
+++ b/src/cookies/middleware.rs
@@ -18,7 +18,7 @@ use std::sync::{Arc, RwLock};
 /// app.at("/get").get(|cx: Request<()>| async move { Ok(cx.cookie("testCookie").unwrap().value().to_string()) });
 /// app.at("/set").get(|_| async {
 ///     let mut res = Response::new(StatusCode::Ok);
-///     res.insert_cookie(Cookie::new("testCookie", "NewCookieValue"));
+///     res.append_cookie(Cookie::new("testCookie", "NewCookieValue"));
 ///     Ok(res)
 /// });
 /// ```

--- a/src/cookies/middleware.rs
+++ b/src/cookies/middleware.rs
@@ -18,7 +18,7 @@ use std::sync::{Arc, RwLock};
 /// app.at("/get").get(|cx: Request<()>| async move { Ok(cx.cookie("testCookie").unwrap().value().to_string()) });
 /// app.at("/set").get(|_| async {
 ///     let mut res = Response::new(StatusCode::Ok);
-///     res.set_cookie(Cookie::new("testCookie", "NewCookieValue"));
+///     res.insert_cookie(Cookie::new("testCookie", "NewCookieValue"));
 ///     Ok(res)
 /// });
 /// ```
@@ -69,7 +69,7 @@ impl<State: Send + Sync + 'static> Middleware<State> for CookiesMiddleware {
             // iterate over added and removed cookies
             for cookie in jar.delta() {
                 let encoded_cookie = cookie.encoded().to_string();
-                res = res.append_header(headers::SET_COOKIE, encoded_cookie);
+                res.append_header(headers::SET_COOKIE, encoded_cookie);
             }
             Ok(res)
         })

--- a/src/cookies/middleware.rs
+++ b/src/cookies/middleware.rs
@@ -18,7 +18,7 @@ use std::sync::{Arc, RwLock};
 /// app.at("/get").get(|cx: Request<()>| async move { Ok(cx.cookie("testCookie").unwrap().value().to_string()) });
 /// app.at("/set").get(|_| async {
 ///     let mut res = Response::new(StatusCode::Ok);
-///     res.append_cookie(Cookie::new("testCookie", "NewCookieValue"));
+///     res.insert_cookie(Cookie::new("testCookie", "NewCookieValue"));
 ///     Ok(res)
 /// });
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //! ```no_run
 //! # use async_std::task::block_on;
 //! # fn main() -> Result<(), std::io::Error> { block_on(async {
-//! # use tide::{Request, Response};
+//! # use tide::{Body, Request, Response};
 //! #
 //! #[derive(Debug, serde::Deserialize, serde::Serialize)]
 //! struct Counter { count: usize }
@@ -61,7 +61,9 @@
 //!    let mut counter: Counter = req.body_json().await?;
 //!    println!("count is {}", counter.count);
 //!    counter.count += 1;
-//!    Ok(Response::new(tide::http::StatusCode::Ok).body_json(&counter)?)
+//!    let mut res = Response::new(200);
+//!    res.set_body(Body::from_json(&counter)?);
+//!    Ok(res)
 //! });
 //! app.listen("127.0.0.1:8080").await?;
 //! #

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -104,6 +104,8 @@ impl<T: AsRef<str>> Into<Response> for Redirect<T> {
 
 impl<T: AsRef<str>> Into<Response> for &Redirect<T> {
     fn into(self) -> Response {
-        Response::new(self.status).set_header(LOCATION, self.location.as_ref())
+        let mut res = Response::new(self.status);
+        res.insert_header(LOCATION, self.location.as_ref());
+        res
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,4 +1,4 @@
-use async_std::io::{self, prelude::*, BufReader};
+use async_std::io::{self, prelude::*};
 use async_std::task::{Context, Poll};
 use route_recognizer::Params;
 
@@ -448,8 +448,10 @@ impl<State> Into<http::Request> for Request<State> {
 // NOTE: From cannot be implemented for this conversion because `State` needs to
 // be constrained by a type.
 impl<State: Send + Sync + 'static> Into<Response> for Request<State> {
-    fn into(self) -> Response {
-        Response::new(StatusCode::Ok).body(BufReader::new(self))
+    fn into(mut self) -> Response {
+        let mut res = Response::new(StatusCode::Ok);
+        res.set_body(self.take_body());
+        res
     }
 }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -157,7 +157,7 @@ impl Response {
     /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// # async_std::task::block_on(async {
     /// #
-    /// use tide::{Body, Response};
+    /// use tide::Response;
     ///
     /// let mut req = Response::new(200);
     /// req.set_body("Hello, Nori!");

--- a/src/response.rs
+++ b/src/response.rs
@@ -29,7 +29,7 @@ impl Response {
         S: TryInto<StatusCode>,
         S::Error: Debug,
     {
-        let res = http_types::Response::new(status);
+        let res = http::Response::new(status);
         Self {
             res,
             cookie_events: vec![],

--- a/src/response.rs
+++ b/src/response.rs
@@ -176,7 +176,7 @@ impl Response {
     }
 
     /// Insert cookie in the cookie jar.
-    pub fn insert_cookie(&mut self, cookie: Cookie<'static>) {
+    pub fn append_cookie(&mut self, cookie: Cookie<'static>) {
         self.cookie_events.push(CookieEvent::Added(cookie));
     }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -176,7 +176,7 @@ impl Response {
     }
 
     /// Insert cookie in the cookie jar.
-    pub fn append_cookie(&mut self, cookie: Cookie<'static>) {
+    pub fn insert_cookie(&mut self, cookie: Cookie<'static>) {
         self.cookie_events.push(CookieEvent::Added(cookie));
     }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,14 +1,11 @@
-use async_std::io::prelude::*;
-use std::convert::TryFrom;
+use std::convert::TryInto;
+use std::fmt::Debug;
 use std::ops::Index;
-
-use serde::Serialize;
 
 use crate::http::cookies::Cookie;
 use crate::http::headers::{self, HeaderName, HeaderValues, ToHeaderValues};
+use crate::http::Mime;
 use crate::http::{self, Body, StatusCode};
-use crate::http::{mime, Mime};
-use crate::redirect::Redirect;
 
 #[derive(Debug)]
 pub(crate) enum CookieEvent {
@@ -27,50 +24,16 @@ pub struct Response {
 impl Response {
     /// Create a new instance.
     #[must_use]
-    pub fn new(status: StatusCode) -> Self {
+    pub fn new<S>(status: S) -> Self
+    where
+        S: TryInto<StatusCode>,
+        S::Error: Debug,
+    {
         let res = http_types::Response::new(status);
         Self {
             res,
             cookie_events: vec![],
         }
-    }
-
-    /// Create a new instance from a reader.
-    pub fn with_reader<R>(status: u16, reader: R) -> Self
-    where
-        R: BufRead + Unpin + Send + Sync + 'static,
-    {
-        let status = crate::StatusCode::try_from(status).expect("invalid status code");
-        let mut res = http_types::Response::new(status);
-        res.set_body(Body::from_reader(reader, None));
-
-        Self {
-            res,
-            cookie_events: vec![],
-        }
-    }
-
-    /// Creates a response that represents a redirect to `location`.
-    ///
-    /// Uses status code 302 Found.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use tide::{Response, Request, StatusCode};
-    /// # fn special_sale_today() -> Option<String> { None }
-    /// # #[allow(dead_code)]
-    /// async fn route_handler(request: Request<()>) -> tide::Result {
-    ///     if let Some(sale_url) = special_sale_today() {
-    ///         Ok(Response::redirect(sale_url))
-    ///     } else {
-    ///         //...
-    /// #       Ok(Response::new(StatusCode::Ok)) //...
-    ///     }
-    /// }
-    /// ```
-    pub fn redirect(location: impl AsRef<str>) -> Self {
-        Redirect::new(location).into()
     }
 
     /// Returns the statuscode.
@@ -104,21 +67,25 @@ impl Response {
         self.res.header(name)
     }
 
+    /// Get an HTTP header mutably.
+    #[must_use]
+    pub fn header_mut(&mut self, name: impl Into<HeaderName>) -> Option<&mut HeaderValues> {
+        self.res.header_mut(name)
+    }
+
     /// Remove a header.
     pub fn remove_header(&mut self, name: impl Into<HeaderName>) -> Option<HeaderValues> {
         self.res.remove_header(name)
     }
 
     /// Insert an HTTP header.
-    pub fn set_header(mut self, key: impl Into<HeaderName>, value: impl ToHeaderValues) -> Self {
+    pub fn insert_header(&mut self, key: impl Into<HeaderName>, value: impl ToHeaderValues) {
         self.res.insert_header(key, value);
-        self
     }
 
     /// Append an HTTP header.
-    pub fn append_header(mut self, key: impl Into<HeaderName>, value: impl ToHeaderValues) -> Self {
+    pub fn append_header(&mut self, key: impl Into<HeaderName>, value: impl ToHeaderValues) {
         self.res.append_header(key, value);
-        self
     }
 
     /// An iterator visiting all header pairs in arbitrary order.
@@ -161,84 +128,14 @@ impl Response {
     /// This sets the response `Content-Type` header.
     ///
     /// [Read more on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types)
-    #[must_use]
-    pub fn set_content_type(mut self, mime: impl Into<Mime>) -> Self {
+    pub fn set_content_type(&mut self, mime: impl Into<Mime>) {
         self.res.set_content_type(mime.into());
-        self
-    }
-
-    /// Pass a string as the response body.
-    ///
-    /// # Mime
-    ///
-    /// The content type is set to `text/plain; charset=utf-8`.
-    #[must_use]
-    pub fn body_string(mut self, string: String) -> Self {
-        self.res.set_body(string);
-        self.set_content_type(mime::PLAIN)
-    }
-
-    /// Pass raw bytes as the response body.
-    ///
-    /// # Mime
-    ///
-    /// The content type is set to `application/octet-stream`.
-    pub fn body<R>(mut self, reader: R) -> Self
-    where
-        R: BufRead + Unpin + Send + Sync + 'static,
-    {
-        self.res
-            .set_body(http_types::Body::from_reader(reader, None));
-        self.set_content_type(mime::BYTE_STREAM)
     }
 
     /// Set the body reader.
     pub fn set_body(&mut self, body: impl Into<Body>) {
         self.res.set_body(body);
     }
-
-    /// Encode a struct as a form and set as the response body.
-    ///
-    /// # Mime
-    ///
-    /// The content type is set to `application/x-www-form-urlencoded`.
-    pub async fn body_form<T: serde::Serialize>(
-        mut self,
-        form: T,
-    ) -> Result<Self, serde_qs::Error> {
-        // TODO: think about how to handle errors
-        self.res.set_body(serde_qs::to_string(&form)?.into_bytes());
-        Ok(self.set_status(StatusCode::Ok).set_content_type(mime::FORM))
-    }
-
-    /// Encode a struct as a form and set as the response body.
-    ///
-    /// # Mime
-    ///
-    /// The content type is set to `application/json`.
-    pub fn body_json(mut self, json: &impl Serialize) -> serde_json::Result<Self> {
-        self.res.set_body(serde_json::to_vec(json)?);
-        Ok(self.set_content_type(mime::JSON))
-    }
-
-    // fn body_multipart(&mut self) -> BoxTryFuture<Multipart<Cursor<Vec<u8>>>> {
-    //     const BOUNDARY: &str = "boundary=";
-    //     let boundary = self.headers().get("content-type").and_then(|ct| {
-    //         let ct = ct.to_str().ok()?;
-    //         let idx = ct.find(BOUNDARY)?;
-    //         Some(ct[idx + BOUNDARY.len()..].to_string())
-    //     });
-
-    //     let body = self.take_body();
-
-    //     Box::pin(async move {
-    //         let body = body.into_vec().await.client_err()?;
-    //         let boundary = boundary
-    //             .ok_or_else(|| StringError(format!("no boundary found")))
-    //             .client_err()?;
-    //         Ok(Multipart::with_body(Cursor::new(body), boundary))
-    //     })
-    // }
 
     /// Take the response body as a `Body`.
     //
@@ -250,8 +147,36 @@ impl Response {
         self.res.take_body()
     }
 
-    /// Add cookie to the cookie jar.
-    pub fn set_cookie(&mut self, cookie: Cookie<'static>) {
+    /// Swaps the value of the body with another body, without deinitializing
+    /// either one.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use async_std::io::prelude::*;
+    /// # fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    /// # async_std::task::block_on(async {
+    /// #
+    /// use tide::{Body, Response};
+    ///
+    /// let mut req = Response::new(200);
+    /// req.set_body("Hello, Nori!");
+    ///
+    /// let mut body = "Hello, Chashu!".into();
+    /// req.swap_body(&mut body);
+    ///
+    /// let mut string = String::new();
+    /// body.read_to_string(&mut string).await?;
+    /// assert_eq!(&string, "Hello, Nori!");
+    /// #
+    /// # Ok(()) }) }
+    /// ```
+    pub fn swap_body(&mut self, body: &mut Body) {
+        self.res.swap_body(body)
+    }
+
+    /// Insert cookie in the cookie jar.
+    pub fn insert_cookie(&mut self, cookie: Cookie<'static>) {
         self.cookie_events.push(CookieEvent::Added(cookie));
     }
 
@@ -286,9 +211,8 @@ impl Response {
     }
 
     /// Set a response scoped extension value.
-    pub fn set_ext<T: Send + Sync + 'static>(mut self, val: T) -> Self {
+    pub fn insert_ext<T: Send + Sync + 'static>(mut self, val: T) {
         self.res.ext_mut().insert(val);
-        self
     }
 
     /// Create a `tide::Response` from a type that can be converted into an
@@ -337,8 +261,12 @@ impl Into<http::Response> for Response {
 
 impl From<serde_json::Value> for Response {
     fn from(json_value: serde_json::Value) -> Self {
-        Response::new(StatusCode::Ok)
-            .body_json(&json_value)
+        Body::from_json(&json_value)
+            .map(|body| {
+                let mut res = Response::new(200);
+                res.set_body(body);
+                res
+            })
             .unwrap_or_else(|_| Response::new(StatusCode::InternalServerError))
     }
 }

--- a/tests/chunked-encode-large.rs
+++ b/tests/chunked-encode-large.rs
@@ -1,5 +1,4 @@
 mod test_utils;
-use async_std::io::Cursor;
 use async_std::prelude::*;
 use async_std::task;
 use http_types::mime;
@@ -72,10 +71,9 @@ async fn chunked_large() -> Result<(), http_types::Error> {
     let server = task::spawn(async move {
         let mut app = tide::new();
         app.at("/").get(|mut _req: tide::Request<()>| async {
-            let body = Cursor::new(TEXT.to_owned());
-            let res = Response::new(StatusCode::Ok)
-                .body(body)
-                .set_content_type(mime::PLAIN);
+            let mut res = Response::new(StatusCode::Ok);
+            res.set_content_type(mime::PLAIN);
+            res.set_body(TEXT);
             Ok(res)
         });
         app.listen(("localhost", port)).await?;

--- a/tests/chunked-encode-large.rs
+++ b/tests/chunked-encode-large.rs
@@ -1,10 +1,12 @@
 mod test_utils;
+use async_std::io::Cursor;
 use async_std::prelude::*;
 use async_std::task;
 use http_types::mime;
 use http_types::StatusCode;
 use std::time::Duration;
-use tide::Response;
+
+use tide::{Body, Response};
 
 const TEXT: &'static str = concat![
     "Et provident reprehenderit accusamus dolores et voluptates sed quia. Repellendus odit porro ut et hic molestiae. Sit autem reiciendis animi fugiat deleniti vel iste. Laborum id odio ullam ut impedit dolores. Vel aperiam dolorem voluptatibus dignissimos maxime.",
@@ -72,8 +74,9 @@ async fn chunked_large() -> Result<(), http_types::Error> {
         let mut app = tide::new();
         app.at("/").get(|mut _req: tide::Request<()>| async {
             let mut res = Response::new(StatusCode::Ok);
+            let body = Cursor::new(TEXT.to_owned());
+            res.set_body(Body::from_reader(body, None));
             res.set_content_type(mime::PLAIN);
-            res.set_body(TEXT);
             Ok(res)
         });
         app.listen(("localhost", port)).await?;

--- a/tests/chunked-encode-small.rs
+++ b/tests/chunked-encode-small.rs
@@ -1,5 +1,4 @@
 mod test_utils;
-use async_std::io::Cursor;
 use async_std::prelude::*;
 use async_std::task;
 use http_types::mime;
@@ -22,10 +21,9 @@ async fn chunked_large() -> Result<(), http_types::Error> {
     let server = task::spawn(async move {
         let mut app = tide::new();
         app.at("/").get(|_| async move {
-            let body = Cursor::new(TEXT.to_owned());
-            let res = Response::new(StatusCode::Ok)
-                .body(body)
-                .set_content_type(mime::PLAIN);
+            let mut res = Response::new(StatusCode::Ok);
+            res.set_content_type(mime::PLAIN);
+            res.set_body(TEXT);
             Ok(res)
         });
         app.listen(("localhost", port)).await?;

--- a/tests/chunked-encode-small.rs
+++ b/tests/chunked-encode-small.rs
@@ -1,11 +1,12 @@
 mod test_utils;
+use async_std::io::Cursor;
 use async_std::prelude::*;
 use async_std::task;
 use http_types::mime;
 use http_types::StatusCode;
 use std::time::Duration;
 
-use tide::Response;
+use tide::{Body, Response};
 
 const TEXT: &'static str = concat![
     "Eveniet delectus voluptatem in placeat modi. Qui nulla sunt aut non voluptas temporibus accusamus rem. Qui soluta nisi qui accusantium excepturi voluptatem. Ab rerum maiores neque ut expedita rem.",
@@ -22,8 +23,9 @@ async fn chunked_large() -> Result<(), http_types::Error> {
         let mut app = tide::new();
         app.at("/").get(|_| async move {
             let mut res = Response::new(StatusCode::Ok);
+            let body = Cursor::new(TEXT.to_owned());
+            res.set_body(Body::from_reader(body, None));
             res.set_content_type(mime::PLAIN);
-            res.set_body(TEXT);
             Ok(res)
         });
         app.listen(("localhost", port)).await?;

--- a/tests/cookies.rs
+++ b/tests/cookies.rs
@@ -14,9 +14,9 @@ async fn retrieve_cookie(cx: Request<()>) -> tide::Result<String> {
     ))
 }
 
-async fn append_cookie(_req: Request<()>) -> tide::Result {
+async fn insert_cookie(_req: Request<()>) -> tide::Result {
     let mut res = Response::new(StatusCode::Ok);
-    res.append_cookie(Cookie::new(COOKIE_NAME, "NewCookieValue"));
+    res.insert_cookie(Cookie::new(COOKIE_NAME, "NewCookieValue"));
     Ok(res)
 }
 
@@ -28,8 +28,8 @@ async fn remove_cookie(_req: Request<()>) -> tide::Result {
 
 async fn set_multiple_cookie(_req: Request<()>) -> tide::Result {
     let mut res = Response::new(StatusCode::Ok);
-    res.append_cookie(Cookie::new("C1", "V1"));
-    res.append_cookie(Cookie::new("C2", "V2"));
+    res.insert_cookie(Cookie::new("C1", "V1"));
+    res.insert_cookie(Cookie::new("C2", "V2"));
     Ok(res)
 }
 
@@ -37,7 +37,7 @@ fn app() -> crate::Server<()> {
     let mut app = tide::new();
 
     app.at("/get").get(retrieve_cookie);
-    app.at("/set").get(append_cookie);
+    app.at("/set").get(insert_cookie);
     app.at("/remove").get(remove_cookie);
     app.at("/multi").get(set_multiple_cookie);
     app
@@ -75,7 +75,7 @@ async fn successfully_retrieve_request_cookie() {
 }
 
 #[async_std::test]
-async fn successfully_append_cookie() {
+async fn successfully_insert_cookie() {
     let res = make_request("/set").await;
     assert_eq!(res.status(), StatusCode::Ok);
     assert_eq!(res[SET_COOKIE], "testCookie=NewCookieValue");

--- a/tests/cookies.rs
+++ b/tests/cookies.rs
@@ -14,9 +14,9 @@ async fn retrieve_cookie(cx: Request<()>) -> tide::Result<String> {
     ))
 }
 
-async fn insert_cookie(_req: Request<()>) -> tide::Result {
+async fn append_cookie(_req: Request<()>) -> tide::Result {
     let mut res = Response::new(StatusCode::Ok);
-    res.insert_cookie(Cookie::new(COOKIE_NAME, "NewCookieValue"));
+    res.append_cookie(Cookie::new(COOKIE_NAME, "NewCookieValue"));
     Ok(res)
 }
 
@@ -28,8 +28,8 @@ async fn remove_cookie(_req: Request<()>) -> tide::Result {
 
 async fn set_multiple_cookie(_req: Request<()>) -> tide::Result {
     let mut res = Response::new(StatusCode::Ok);
-    res.insert_cookie(Cookie::new("C1", "V1"));
-    res.insert_cookie(Cookie::new("C2", "V2"));
+    res.append_cookie(Cookie::new("C1", "V1"));
+    res.append_cookie(Cookie::new("C2", "V2"));
     Ok(res)
 }
 
@@ -37,7 +37,7 @@ fn app() -> crate::Server<()> {
     let mut app = tide::new();
 
     app.at("/get").get(retrieve_cookie);
-    app.at("/set").get(insert_cookie);
+    app.at("/set").get(append_cookie);
     app.at("/remove").get(remove_cookie);
     app.at("/multi").get(set_multiple_cookie);
     app
@@ -75,7 +75,7 @@ async fn successfully_retrieve_request_cookie() {
 }
 
 #[async_std::test]
-async fn successfully_insert_cookie() {
+async fn successfully_append_cookie() {
     let res = make_request("/set").await;
     assert_eq!(res.status(), StatusCode::Ok);
     assert_eq!(res[SET_COOKIE], "testCookie=NewCookieValue");

--- a/tests/cookies.rs
+++ b/tests/cookies.rs
@@ -14,9 +14,9 @@ async fn retrieve_cookie(cx: Request<()>) -> tide::Result<String> {
     ))
 }
 
-async fn set_cookie(_req: Request<()>) -> tide::Result {
+async fn insert_cookie(_req: Request<()>) -> tide::Result {
     let mut res = Response::new(StatusCode::Ok);
-    res.set_cookie(Cookie::new(COOKIE_NAME, "NewCookieValue"));
+    res.insert_cookie(Cookie::new(COOKIE_NAME, "NewCookieValue"));
     Ok(res)
 }
 
@@ -28,8 +28,8 @@ async fn remove_cookie(_req: Request<()>) -> tide::Result {
 
 async fn set_multiple_cookie(_req: Request<()>) -> tide::Result {
     let mut res = Response::new(StatusCode::Ok);
-    res.set_cookie(Cookie::new("C1", "V1"));
-    res.set_cookie(Cookie::new("C2", "V2"));
+    res.insert_cookie(Cookie::new("C1", "V1"));
+    res.insert_cookie(Cookie::new("C2", "V2"));
     Ok(res)
 }
 
@@ -37,7 +37,7 @@ fn app() -> crate::Server<()> {
     let mut app = tide::new();
 
     app.at("/get").get(retrieve_cookie);
-    app.at("/set").get(set_cookie);
+    app.at("/set").get(insert_cookie);
     app.at("/remove").get(remove_cookie);
     app.at("/multi").get(set_multiple_cookie);
     app
@@ -75,7 +75,7 @@ async fn successfully_retrieve_request_cookie() {
 }
 
 #[async_std::test]
-async fn successfully_set_cookie() {
+async fn successfully_insert_cookie() {
     let res = make_request("/set").await;
     assert_eq!(res.status(), StatusCode::Ok);
     assert_eq!(res[SET_COOKIE], "testCookie=NewCookieValue");

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -53,10 +53,7 @@ async fn nested_middleware() {
         ) -> BoxFuture<'a, tide::Result<tide::Response>> {
             Box::pin(async move {
                 let res = next.run(req).await?;
-                let res = res.set_header(
-                    HeaderName::from_bytes("X-Tide-Test".to_owned().into_bytes()).unwrap(),
-                    "1",
-                );
+                res.insert_header("X-Tide-Test", "1");
                 Ok(res)
             })
         }

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -1,4 +1,3 @@
-use http_types::headers::HeaderName;
 use http_types::{Method, Request, Response, Url};
 use test_utils::BoxFuture;
 use tide::{Middleware, Next};
@@ -52,7 +51,7 @@ async fn nested_middleware() {
             next: Next<'a, State>,
         ) -> BoxFuture<'a, tide::Result<tide::Response>> {
             Box::pin(async move {
-                let res = next.run(req).await?;
+                let mut res = next.run(req).await?;
                 res.insert_header("X-Tide-Test", "1");
                 Ok(res)
             })

--- a/tests/route_middleware.rs
+++ b/tests/route_middleware.rs
@@ -23,8 +23,9 @@ impl<State: Send + Sync + 'static> Middleware<State> for TestMiddleware {
         next: tide::Next<'a, State>,
     ) -> BoxFuture<'a, tide::Result<tide::Response>> {
         Box::pin(async move {
-            let res = next.run(req).await?;
-            Ok(res.set_header(self.0.clone(), self.1))
+            let mut res = next.run(req).await?;
+            res.insert_header(self.0.clone(), self.1);
+            Ok(res)
         })
     }
 }

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -4,7 +4,7 @@ use async_std::task;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
-use tide::{Request, Response, StatusCode};
+use tide::{Body, Request, Response, StatusCode};
 
 #[test]
 fn hello_world() -> Result<(), http_types::Error> {
@@ -16,7 +16,8 @@ fn hello_world() -> Result<(), http_types::Error> {
                 assert_eq!(req.body_string().await.unwrap(), "nori".to_string());
                 assert!(req.local_addr().unwrap().contains(&port.to_string()));
                 assert!(req.peer_addr().is_some());
-                let res = Response::new(StatusCode::Ok).body_string("says hello".to_string());
+                let mut res = Response::new(StatusCode::Ok);
+                res.set_body("says hello");
                 Ok(res)
             });
             app.listen(("localhost", port)).await?;
@@ -80,7 +81,8 @@ fn json() -> Result<(), http_types::Error> {
                 let mut counter: Counter = req.body_json().await.unwrap();
                 assert_eq!(counter.count, 0);
                 counter.count = 1;
-                let res = Response::new(StatusCode::Ok).body_json(&counter)?;
+                let mut res = Response::new(StatusCode::Ok);
+                res.set_body(Body::from_json(&counter)?);
                 Ok(res)
             });
             app.listen(("localhost", port)).await?;


### PR DESCRIPTION
This is a follow-up to #537. Brings Response in line with Request. Thanks!

## Changes
- Removed `Response::redirect` in favor of `tide::Redirect`
- Renamed `Reponse::set_cookie` to `Response::insert_cookie`.
- Various `Response` methods no longer return `Self`.
- `Response::new` now accepts `u16` as well as `StatusCode` as arguments.
- Added `Response::header_mut`
- Renamed `Response::set_header` to `Response::insert_header`.
- Removed `Response::{body_string, body_form, body_json, body}` in favor of `Response::set_body`.
- Added `Response::swap_body`.
- Renamed `Reponse::set_ext` to `Response::insert_ext`.