### PR TITLE
Convert

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,0 +1,4 @@
+//! Traits for conversions between types.
+
+#[doc(inline)]
+pub use http_types::convert::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,6 +207,7 @@ pub mod router;
 mod server;
 mod utils;
 
+pub mod convert;
 pub mod log;
 pub mod prelude;
 pub mod security;
@@ -218,7 +219,6 @@ pub use redirect::Redirect;
 pub use request::Request;
 pub use response::Response;
 pub use route::Route;
-pub use serde_json;
 pub use server::Server;
 
 #[doc(inline)]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,3 +1,3 @@
 //! The Tide prelude.
+pub use crate::convert::{json, Deserialize, Serialize};
 pub use http_types::Status;
-pub use serde_json::json;


### PR DESCRIPTION
I noticed we were exporting `serde_json` as-is after merging #523. This copies the approach in `http-types` and exports it as part of a `convert` submodule instead. Thanks!

__edit:__ also added more of `serde` to the prelude.