### PR TITLE
Add missing Debug impls

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,5 +1,6 @@
 //! Middleware types.
 
+use std::fmt::Debug;
 use std::sync::Arc;
 
 use crate::endpoint::DynEndpoint;
@@ -121,7 +122,6 @@ where
 }
 
 /// The remainder of a middleware chain, including the endpoint.
-#[allow(missing_debug_implementations)]
 pub struct Next<'a, State> {
     pub(crate) endpoint: &'a DynEndpoint<State>,
     pub(crate) next_middleware: &'a [Arc<dyn Middleware<State>>],
@@ -137,5 +137,11 @@ impl<'a, State: 'static> Next<'a, State> {
         } else {
             self.endpoint.call(req)
         }
+    }
+}
+
+impl<State> Debug for Next<'_, State> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Next").finish()
     }
 }

--- a/src/route.rs
+++ b/src/route.rs
@@ -17,7 +17,6 @@ use crate::{router::Router, Endpoint, Middleware};
 /// `nest`, it can be used to set up a subrouter.
 ///
 /// [`Server::at`]: ./struct.Server.html#method.at
-#[allow(missing_debug_implementations)]
 pub struct Route<'a, State> {
     router: &'a mut Router<State>,
     path: String,
@@ -256,6 +255,12 @@ impl<'a, State: 'static> Route<'a, State> {
     pub fn trace(&mut self, ep: impl Endpoint<State>) -> &mut Self {
         self.method(http_types::Method::Trace, ep);
         self
+    }
+}
+
+impl<State> Debug for Route<'_, State> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Route").finish()
     }
 }
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -9,14 +9,12 @@ use crate::{Request, Response, StatusCode};
 ///
 /// Internally, we have a separate state machine per http method; indexing
 /// by the method first allows the table itself to be more efficient.
-#[allow(missing_debug_implementations)]
 pub struct Router<State> {
     method_map: HashMap<http_types::Method, MethodRouter<Box<DynEndpoint<State>>>>,
     all_method_router: MethodRouter<Box<DynEndpoint<State>>>,
 }
 
 /// The result of routing a URL
-#[allow(missing_debug_implementations)]
 pub struct Selection<'a, State> {
     pub(crate) endpoint: &'a DynEndpoint<State>,
     pub(crate) params: Params,

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,5 +1,6 @@
 use route_recognizer::{Match, Params, Router as MethodRouter};
 use std::collections::HashMap;
+use std::fmt::Debug;
 
 use crate::endpoint::DynEndpoint;
 use crate::utils::BoxFuture;
@@ -14,10 +15,22 @@ pub struct Router<State> {
     all_method_router: MethodRouter<Box<DynEndpoint<State>>>,
 }
 
+impl<State> Debug for Router<State> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Router").finish()
+    }
+}
+
 /// The result of routing a URL
 pub struct Selection<'a, State> {
     pub(crate) endpoint: &'a DynEndpoint<State>,
     pub(crate) params: Params,
+}
+
+impl<State> Debug for Selection<'_, State> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Selection").finish()
+    }
 }
 
 impl<State: 'static> Router<State> {

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,6 +5,7 @@ use async_std::net::ToSocketAddrs;
 use async_std::prelude::*;
 use async_std::sync::Arc;
 use async_std::task;
+use std::fmt::Debug;
 
 use crate::cookies;
 use crate::log;
@@ -126,7 +127,6 @@ use crate::{Endpoint, Request, Route};
 /////     // app.run("127.0.0.1:8000").unwrap();
 ///// }
 ///// ```
-#[allow(missing_debug_implementations)]
 pub struct Server<State> {
     router: Arc<Router<State>>,
     state: Arc<State>,
@@ -429,6 +429,12 @@ impl<State> Clone for Server<State> {
             state: self.state.clone(),
             middleware: self.middleware.clone(),
         }
+    }
+}
+
+impl<State> Debug for Server<State> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Server").finish()
     }
 }
 


### PR DESCRIPTION
Adds missing Debug impls instead of the `#[allow(missing_debug_impls)]` we had before. Thanks!