### PR TITLE
Rework middleware to receive Response directly, add optional errors to Response

### DIFF
--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -1,0 +1,33 @@
+use tide::utils::After;
+use tide::{Body, Request, Response, Result, StatusCode};
+
+#[async_std::main]
+async fn main() -> Result<()> {
+    tide::log::start();
+    let mut app = tide::new();
+
+    app.at("/")
+        .middleware(After(|mut res: Response| async {
+            if let Some(err) = res.downcast_error::<async_std::io::Error>() {
+                let msg = err.to_string().to_owned();
+                res.set_status(StatusCode::ImATeapot);
+                res.set_body(format!("Teapot Status: {}", msg));
+            }
+            Ok(res)
+        }))
+        .get(|_req: Request<_>| async {
+            let mut res = Response::new(StatusCode::Ok);
+            res.set_body(Body::from_file("./does-not-exist").await?);
+            Ok(res)
+        });
+
+    app.at("/uncaught").get(|_req: Request<_>| async {
+        let mut res = Response::new(StatusCode::Ok);
+        res.set_body(Body::from_file("./does-not-exist").await?);
+        Ok(res)
+    });
+
+    app.listen("127.0.0.1:8080").await?;
+
+    Ok(())
+}

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -32,7 +32,7 @@ fn user_loader<'a>(
         if let Some(user) = request.state().find_user().await {
             tide::log::trace!("user loaded", {user: user.name});
             request.set_ext(user);
-            next.run(request).await
+            Ok(next.run(request).await)
         // this middleware only needs to run before the endpoint, so
         // it just passes through the result of Next
         } else {
@@ -72,7 +72,7 @@ impl<State: Send + Sync + 'static> Middleware<State> for RequestCounterMiddlewar
             tide::log::trace!("request counter", { count: count });
             req.set_ext(RequestCount(count));
 
-            let mut res = next.run(req).await?;
+            let mut res = next.run(req).await;
 
             res.insert_header("request-number", count.to_string());
             Ok(res)
@@ -100,9 +100,7 @@ async fn main() -> Result<()> {
     tide::log::start();
     let mut app = tide::with_state(UserDatabase::default());
 
-    app.middleware(After(|result: Result| async move {
-        let response = result.unwrap_or_else(|e| Response::new(e.status()));
-
+    app.middleware(After(|response: Response| async move {
         let response = match response.status() {
             StatusCode::NotFound => Response::builder(404)
                 .content_type(mime::HTML)

--- a/src/cookies/middleware.rs
+++ b/src/cookies/middleware.rs
@@ -51,7 +51,7 @@ impl<State: Send + Sync + 'static> Middleware<State> for CookiesMiddleware {
                 content
             };
 
-            let mut res = next.run(ctx).await?;
+            let mut res = next.run(ctx).await;
 
             // Don't do anything if there are no cookies.
             if res.cookie_events.is_empty() {

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -44,16 +44,17 @@ use crate::{Middleware, Request, Response};
 /// ```
 ///
 /// Tide routes will also accept endpoints with `Fn` signatures of this form, but using the `async` keyword has better ergonomics.
-pub trait Endpoint<State>: Send + Sync + 'static {
+pub trait Endpoint<State: Send + Sync + 'static>: Send + Sync + 'static {
     /// Invoke the endpoint within the given context
     fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, crate::Result>;
 }
 
 pub(crate) type DynEndpoint<State> = dyn Endpoint<State>;
 
-impl<State, F: Send + Sync + 'static, Fut, Res> Endpoint<State> for F
+impl<State, F, Fut, Res> Endpoint<State> for F
 where
-    F: Fn(Request<State>) -> Fut,
+    State: Send + Sync + 'static,
+    F: Send + Sync + 'static + Fn(Request<State>) -> Fut,
     Fut: Future<Output = Result<Res>> + Send + 'static,
     Res: Into<Response>,
 {
@@ -92,6 +93,7 @@ impl<E, State> std::fmt::Debug for MiddlewareEndpoint<E, State> {
 
 impl<E, State> MiddlewareEndpoint<E, State>
 where
+    State: Send + Sync + 'static,
     E: Endpoint<State>,
 {
     pub fn wrap_with_middleware(ep: E, middleware: &[Arc<dyn Middleware<State>>]) -> Self {
@@ -102,8 +104,9 @@ where
     }
 }
 
-impl<E, State: 'static> Endpoint<State> for MiddlewareEndpoint<E, State>
+impl<E, State> Endpoint<State> for MiddlewareEndpoint<E, State>
 where
+    State: Send + Sync + 'static,
     E: Endpoint<State>,
 {
     fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, crate::Result> {
@@ -111,6 +114,6 @@ where
             endpoint: &self.endpoint,
             next_middleware: &self.middleware,
         };
-        next.run(req)
+        Box::pin(async move { Ok(next.run(req).await) })
     }
 }

--- a/src/fs/serve_dir.rs
+++ b/src/fs/serve_dir.rs
@@ -17,7 +17,10 @@ impl ServeDir {
     }
 }
 
-impl<State> Endpoint<State> for ServeDir {
+impl<State> Endpoint<State> for ServeDir
+where
+    State: Send + Sync + 'static,
+{
     fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, Result> {
         let path = req.url().path();
         let path = path.trim_start_matches(&self.prefix);

--- a/src/log/middleware.rs
+++ b/src/log/middleware.rs
@@ -40,12 +40,22 @@ impl LogMiddleware {
         let response = next.run(ctx).await;
         let status = response.status();
         if status.is_server_error() {
-            log::error!("--> Response sent", {
-                method: method,
-                path: path,
-                status: status as u16,
-                duration: format!("{:?}", start.elapsed()),
-            });
+            if let Some(error) = response.error() {
+                log::error!("Internal error --> Response sent", {
+                    message: error.to_string(),
+                    method: method,
+                    path: path,
+                    status: status as u16,
+                    duration: format!("{:?}", start.elapsed()),
+                });
+            } else {
+                log::error!("Internal error --> Response sent", {
+                    method: method,
+                    path: path,
+                    status: status as u16,
+                    duration: format!("{:?}", start.elapsed()),
+                });
+            }
         } else if status.is_client_error() {
             log::warn!("--> Response sent", {
                 method: method,

--- a/src/log/middleware.rs
+++ b/src/log/middleware.rs
@@ -37,43 +37,31 @@ impl LogMiddleware {
             path: path,
         });
         let start = std::time::Instant::now();
-        match next.run(ctx).await {
-            Ok(res) => {
-                let status = res.status();
-                if status.is_server_error() {
-                    log::error!("--> Response sent", {
-                        method: method,
-                        path: path,
-                        status: status as u16,
-                        duration: format!("{:?}", start.elapsed()),
-                    });
-                } else if status.is_client_error() {
-                    log::warn!("--> Response sent", {
-                        method: method,
-                        path: path,
-                        status: status as u16,
-                        duration: format!("{:?}", start.elapsed()),
-                    });
-                } else {
-                    log::info!("--> Response sent", {
-                        method: method,
-                        path: path,
-                        status: status as u16,
-                        duration: format!("{:?}", start.elapsed()),
-                    });
-                }
-                Ok(res)
-            }
-            Err(err) => {
-                log::error!("{}", err.to_string(), {
-                    method: method,
-                    path: path,
-                    status: err.status() as u16,
-                    duration: format!("{:?}", start.elapsed()),
-                });
-                Err(err)
-            }
+        let response = next.run(ctx).await;
+        let status = response.status();
+        if status.is_server_error() {
+            log::error!("--> Response sent", {
+                method: method,
+                path: path,
+                status: status as u16,
+                duration: format!("{:?}", start.elapsed()),
+            });
+        } else if status.is_client_error() {
+            log::warn!("--> Response sent", {
+                method: method,
+                path: path,
+                status: status as u16,
+                duration: format!("{:?}", start.elapsed()),
+            });
+        } else {
+            log::info!("--> Response sent", {
+                method: method,
+                path: path,
+                status: status as u16,
+                duration: format!("{:?}", start.elapsed()),
+            });
         }
+        Ok(response)
     }
 }
 

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -51,9 +51,15 @@ impl<'a, State: Send + Sync + 'static> Next<'a, State> {
         Box::pin(async move {
             if let Some((current, next)) = self.next_middleware.split_first() {
                 self.next_middleware = next;
-                current.handle(req, self).await.into()
+                match current.handle(req, self).await {
+                    Ok(request) => request,
+                    Err(err) => err.into(),
+                }
             } else {
-                self.endpoint.call(req).await.into()
+                match self.endpoint.call(req).await {
+                    Ok(request) => request,
+                    Err(err) => err.into(),
+                }
             }
         })
     }

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -88,6 +88,7 @@ impl<T: AsRef<str>> Redirect<T> {
 
 impl<State, T> Endpoint<State> for Redirect<T>
 where
+    State: Send + Sync + 'static,
     T: AsRef<str> + Send + Sync + 'static,
 {
     fn call<'a>(&'a self, _req: Request<State>) -> BoxFuture<'a, crate::Result<Response>> {

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,11 +1,10 @@
 use std::convert::TryInto;
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 use std::ops::Index;
 
 use crate::http::cookies::Cookie;
 use crate::http::headers::{self, HeaderName, HeaderValues, ToHeaderValues};
-use crate::http::Mime;
-use crate::http::{self, Body, StatusCode};
+use crate::http::{self, Body, Error, Mime, StatusCode};
 use crate::ResponseBuilder;
 
 #[derive(Debug)]
@@ -18,6 +17,7 @@ pub(crate) enum CookieEvent {
 #[derive(Debug)]
 pub struct Response {
     pub(crate) res: http::Response,
+    pub(crate) error: Option<Error>,
     // tracking here
     pub(crate) cookie_events: Vec<CookieEvent>,
 }
@@ -33,6 +33,7 @@ impl Response {
         let res = http::Response::new(status);
         Self {
             res,
+            error: None,
             cookie_events: vec![],
         }
     }
@@ -257,6 +258,54 @@ impl Response {
         self.cookie_events.push(CookieEvent::Removed(cookie));
     }
 
+    /// Returns an optional reference to an error if the response contains one.
+    pub fn error(&self) -> Option<&Error> {
+        self.error.as_ref()
+    }
+
+    /// Returns a reference to the original error associated with this response if there is one and
+    /// if it can be downcast to the specified type.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use std::io::ErrorKind;
+    /// # use async_std::task::block_on;
+    /// # fn main() -> Result<(), std::io::Error> { block_on(async {
+    /// #
+    /// use tide::Response;
+    ///
+    /// let error = std::io::Error::new(ErrorKind::Other, "oh no!");
+    /// let error = tide::http::Error::from(error);
+    ///
+    /// let mut res = Response::new(400);
+    /// res.set_error(error);
+    ///
+    /// if let Some(err) = res.downcast_error::<std::io::Error>() {
+    ///   // Do something with the `std::io::Error`.
+    /// }
+    /// # Ok(())
+    /// # })}
+    pub fn downcast_error<E>(&self) -> Option<&E>
+    where
+        E: Display + Debug + Send + Sync + 'static,
+    {
+        self.error.as_ref()?.downcast_ref()
+    }
+
+    /// Takes the error from the response if one exists, replacing it with `None`.
+    pub fn take_error(&mut self) -> Option<Error> {
+        self.error.take()
+    }
+
+    /// Sets the response's error, overwriting any existing error.
+    ///
+    /// This is particularly useful for middleware which would like to notify further
+    /// middleware that an error has occured without overwriting the existing response.
+    pub fn set_error(&mut self, error: impl Into<Error>) {
+        self.error = Some(error.into());
+    }
+
     /// Get a response scoped extension value.
     #[must_use]
     pub fn ext<T: Send + Sync + 'static>(&self) -> Option<&T> {
@@ -277,6 +326,7 @@ impl Response {
         let res: http_types::Response = value.into();
         Self {
             res,
+            error: None,
             cookie_events: vec![],
         }
     }
@@ -328,10 +378,30 @@ impl From<serde_json::Value> for Response {
     }
 }
 
+impl From<Error> for Response {
+    fn from(err: Error) -> Self {
+        Self {
+            res: http::Response::new(err.status()),
+            error: Some(err),
+            cookie_events: vec![],
+        }
+    }
+}
+
+impl From<crate::Result> for Response {
+    fn from(result: crate::Result) -> Self {
+        match result {
+            Ok(res) => res,
+            Err(err) => err.into(),
+        }
+    }
+}
+
 impl From<http::Response> for Response {
     fn from(res: http::Response) -> Self {
         Self {
             res,
+            error: None,
             cookie_events: vec![],
         }
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -388,15 +388,6 @@ impl From<Error> for Response {
     }
 }
 
-impl From<crate::Result> for Response {
-    fn from(result: crate::Result) -> Self {
-        match result {
-            Ok(res) => res,
-            Err(err) => err.into(),
-        }
-    }
-}
-
 impl From<http::Response> for Response {
     fn from(res: http::Response) -> Self {
         Self {

--- a/src/route.rs
+++ b/src/route.rs
@@ -29,7 +29,7 @@ pub struct Route<'a, State> {
     prefix: bool,
 }
 
-impl<'a, State: 'static> Route<'a, State> {
+impl<'a, State: Send + Sync + 'static> Route<'a, State> {
     pub(crate) fn new(router: &'a mut Router<State>, path: String) -> Route<'a, State> {
         Route {
             router,
@@ -274,7 +274,11 @@ impl<E> Clone for StripPrefixEndpoint<E> {
     }
 }
 
-impl<State, E: Endpoint<State>> Endpoint<State> for StripPrefixEndpoint<E> {
+impl<State, E> Endpoint<State> for StripPrefixEndpoint<E>
+where
+    State: Send + Sync + 'static,
+    E: Endpoint<State>,
+{
     fn call<'a>(&'a self, req: crate::Request<State>) -> BoxFuture<'a, crate::Result> {
         let crate::Request {
             state,

--- a/src/router.rs
+++ b/src/router.rs
@@ -22,7 +22,7 @@ pub struct Selection<'a, State> {
     pub(crate) params: Params,
 }
 
-impl<State: 'static> Router<State> {
+impl<State: Send + Sync + 'static> Router<State> {
     pub fn new() -> Self {
         Router {
             method_map: HashMap::default(),
@@ -82,10 +82,14 @@ impl<State: 'static> Router<State> {
     }
 }
 
-fn not_found_endpoint<State>(_req: Request<State>) -> BoxFuture<'static, crate::Result> {
+fn not_found_endpoint<State: Send + Sync + 'static>(
+    _req: Request<State>,
+) -> BoxFuture<'static, crate::Result> {
     Box::pin(async { Ok(Response::new(StatusCode::NotFound)) })
 }
 
-fn method_not_allowed<State>(_req: Request<State>) -> BoxFuture<'static, crate::Result> {
+fn method_not_allowed<State: Send + Sync + 'static>(
+    _req: Request<State>,
+) -> BoxFuture<'static, crate::Result> {
     Box::pin(async { Ok(Response::new(StatusCode::MethodNotAllowed)) })
 }

--- a/src/security/cors.rs
+++ b/src/security/cors.rs
@@ -141,7 +141,7 @@ impl<State: Send + Sync + 'static> Middleware<State> for CorsMiddleware {
 
             if origins.is_none() {
                 // This is not a CORS request if there is no Origin header
-                return next.run(req).await;
+                return Ok(next.run(req).await);
             }
 
             let origins = origins.unwrap();
@@ -156,7 +156,7 @@ impl<State: Send + Sync + 'static> Middleware<State> for CorsMiddleware {
                 return Ok(self.build_preflight_response(&origins).into());
             }
 
-            let mut response = next.run(req).await?;
+            let mut response = next.run(req).await;
 
             response.insert_header(
                 headers::ACCESS_CONTROL_ALLOW_ORIGIN,

--- a/src/server.rs
+++ b/src/server.rs
@@ -427,22 +427,7 @@ impl<State: Send + Sync + 'static> Server<State> {
             next_middleware: &middleware,
         };
 
-        let mut res = next.run(req).await;
-        if res.len().is_some() {
-            let res: http_types::Response = res.into();
-            return Ok(res.into());
-        }
-
-        if let Some(err) = res.error() {
-            // Only send the message if it is a non-500 range error. All
-            // errors default to 500 by default, so sending the error
-            // body is opt-in at the call site.
-            if !err.status().is_server_error() {
-                let msg = err.to_string();
-                res.set_body(msg);
-            }
-        }
-
+        let res = next.run(req).await;
         let res: http_types::Response = res.into();
         Ok(res.into())
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -427,26 +427,24 @@ impl<State: Send + Sync + 'static> Server<State> {
             next_middleware: &middleware,
         };
 
-        match next.run(req).await {
-            Ok(value) => {
-                let res: http_types::Response = value.into();
-                // We assume that if an error was manually cast to a
-                // Response that we actually want to send the body to the
-                // client. At this point we don't scrub the message.
-                Ok(res.into())
-            }
-            Err(err) => {
-                let mut res = http_types::Response::new(err.status());
-                res.set_content_type(http_types::mime::PLAIN);
-                // Only send the message if it is a non-500 range error. All
-                // errors default to 500 by default, so sending the error
-                // body is opt-in at the call site.
-                if !res.status().is_server_error() {
-                    res.set_body(err.to_string());
-                }
-                Ok(res.into())
+        let mut res = next.run(req).await;
+        if res.len().is_some() {
+            let res: http_types::Response = res.into();
+            return Ok(res.into());
+        }
+
+        if let Some(err) = res.error() {
+            // Only send the message if it is a non-500 range error. All
+            // errors default to 500 by default, so sending the error
+            // body is opt-in at the call site.
+            if !err.status().is_server_error() {
+                let msg = err.to_string();
+                res.set_body(msg);
             }
         }
+
+        let res: http_types::Response = res.into();
+        Ok(res.into())
     }
 }
 
@@ -485,8 +483,7 @@ impl<State: Sync + Send + 'static, InnerState: Sync + Send + 'static> Endpoint<S
                 next_middleware: &middleware,
             };
 
-            let res = next.run(req).await?;
-            Ok(res)
+            Ok(next.run(req).await)
         })
     }
 }

--- a/tests/function_middleware.rs
+++ b/tests/function_middleware.rs
@@ -14,7 +14,7 @@ fn auth_middleware<'a>(
         };
 
         if authenticated {
-            next.run(request).await
+            Ok(next.run(request).await)
         } else {
             Ok(tide::Response::new(tide::StatusCode::Unauthorized))
         }

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -51,7 +51,7 @@ async fn nested_middleware() {
             next: Next<'a, State>,
         ) -> BoxFuture<'a, tide::Result<tide::Response>> {
             Box::pin(async move {
-                let mut res = next.run(req).await?;
+                let mut res = next.run(req).await;
                 res.insert_header("X-Tide-Test", "1");
                 Ok(res)
             })

--- a/tests/response.rs
+++ b/tests/response.rs
@@ -74,3 +74,21 @@ async fn json_content_type() {
     let body = resp.take_body().into_bytes().await.unwrap();
     assert_eq!(body, br##"{"a":2,"b":4,"c":6}"##);
 }
+
+#[test]
+fn from_response() {
+    let msg = "This is an error";
+
+    let error = http::Error::from_str(StatusCode::NotFound, msg);
+    let mut res: Response = error.into();
+
+    assert!(res.error().is_some());
+    // Ensure we did not consume the error
+    assert!(res.error().is_some());
+
+    assert_eq!(res.error().unwrap().status(), StatusCode::NotFound);
+    assert_eq!(res.error().unwrap().to_string(), msg);
+
+    res.take_error();
+    assert!(res.error().is_none());
+}

--- a/tests/route_middleware.rs
+++ b/tests/route_middleware.rs
@@ -23,7 +23,7 @@ impl<State: Send + Sync + 'static> Middleware<State> for TestMiddleware {
         next: tide::Next<'a, State>,
     ) -> BoxFuture<'a, tide::Result<tide::Response>> {
         Box::pin(async move {
-            let mut res = next.run(req).await?;
+            let mut res = next.run(req).await;
             res.insert_header(self.0.clone(), self.1);
             Ok(res)
         })


### PR DESCRIPTION
Rework middleware so that:
- `next.run().await` always returns a `Response`.
- middleware return of `tide::Result` is always transformed into a `Response` with error set.

Adds the following things to `Response`:
- `pub fn error(&self) -> Option<&Error>`
- `pub fn downcast_error<E>(&self) -> Option<&E>`
- `pub fn take_error(&mut self) -> Option<Error>`
- `impl From<Error> for Response`
- `impl From<crate::Result> for Response`

An example of this being used for an error handling middleware is included at [`examples/error_handling.rs`](https://github.com/http-rs/tide/pull/570/files#diff-e15a65d5009515d8f5b742a83df921f8), and Jacob has transformed someone else's in https://github.com/http-rs/tide/issues/452#issuecomment-640938184.

Dependencies:
- ~~[x] Merge https://github.com/http-rs/http-types/pull/174 (ABI breaking)~~
- ~~[ ] `http-types` release~~
- ~~[ ] `http-client` release~~
- ~~[ ] Surf release~~
- [x] https://github.com/http-rs/tide/pull/612

**Note**: Please let me rebase before merging