### PR TITLE
Fix panic in sse endpoint

### DIFF
--- a/src/sse/endpoint.rs
+++ b/src/sse/endpoint.rs
@@ -58,7 +58,7 @@ where
             // Perform the handshake as described here:
             // https://html.spec.whatwg.org/multipage/server-sent-events.html#sse-processing-model
             let mut res = Response::new(StatusCode::Ok);
-            res.res.insert_header("Cache-Control", "no-cache").unwrap();
+            let _old_val = res.res.insert_header("Cache-Control", "no-cache");
             res.res.set_content_type(mime::SSE);
 
             let body = Body::from_reader(BufReader::new(encoder), None);


### PR DESCRIPTION
The `sse.rs` example was panicking for me; this seems to fix it.