### PR TITLE
Response: borrow for set_status()

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -44,9 +44,8 @@ impl Response {
 
     /// Set the statuscode.
     #[must_use]
-    pub fn set_status(mut self, status: crate::StatusCode) -> Self {
+    pub fn set_status(&mut self, status: crate::StatusCode) {
         self.res.set_status(status);
-        self
     }
 
     /// Get the length of the body.


### PR DESCRIPTION
This is the last of the chaining methods, presently inconsistent.