### PR TITLE
run docs and fmt on nightly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,7 +73,7 @@ jobs:
 
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: nightly
         override: true
 
     - name: setup


### PR DESCRIPTION
because apparently cookie-0.14.1 uses a feature flag in docs