### PR TITLE
docs --no-deps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,4 +85,4 @@ jobs:
       run: cargo fmt --all -- --check
 
     - name: Docs
-      run: cargo doc --features unstable
+      run: cargo doc --no-deps --features unstable


### PR DESCRIPTION
this addresses a change in `cookie-0.14.1`'s docs that breaks CI by requiring nightly features