### PR TITLE
Response builder and related changes

### DIFF
--- a/examples/chunked.rs
+++ b/examples/chunked.rs
@@ -1,14 +1,10 @@
 use async_std::task;
-use tide::{Body, Response, StatusCode};
 
 fn main() -> Result<(), std::io::Error> {
     task::block_on(async {
         let mut app = tide::new();
-        app.at("/").get(|_| async {
-            let mut res = Response::new(StatusCode::Ok);
-            res.set_body(Body::from_file(file!()).await.unwrap());
-            Ok(res)
-        });
+        app.at("/")
+            .get(|_| async { Ok(tide::Body::from_file(file!()).await?) });
         app.listen("127.0.0.1:8080").await?;
         Ok(())
     })

--- a/examples/graphql.rs
+++ b/examples/graphql.rs
@@ -82,9 +82,9 @@ async fn handle_graphql(mut request: Request<State>) -> tide::Result {
         StatusCode::BadRequest
     };
 
-    Response::builder(status)
+    Ok(Response::builder(status)
         .body(Body::from_json(&response)?)
-        .into()
+        .build())
 }
 
 async fn handle_graphiql(_: Request<State>) -> tide::Result<impl Into<Response>> {

--- a/examples/graphql.rs
+++ b/examples/graphql.rs
@@ -82,14 +82,13 @@ async fn handle_graphql(mut request: Request<State>) -> tide::Result {
         StatusCode::BadRequest
     };
 
-    Response::build()
-        .status(status)
+    Response::builder(status)
         .body(Body::from_json(&response)?)
         .into()
 }
 
 async fn handle_graphiql(_: Request<State>) -> tide::Result {
-    Response::build()
+    Response::builder(200)
         .body(graphiql::graphiql_source("/graphql"))
         .content_type(mime::HTML)
         .into()

--- a/examples/graphql.rs
+++ b/examples/graphql.rs
@@ -87,11 +87,10 @@ async fn handle_graphql(mut request: Request<State>) -> tide::Result {
         .into()
 }
 
-async fn handle_graphiql(_: Request<State>) -> tide::Result {
-    Response::builder(200)
+async fn handle_graphiql(_: Request<State>) -> tide::Result<impl Into<Response>> {
+    Ok(Response::builder(200)
         .body(graphiql::graphiql_source("/graphql"))
-        .content_type(mime::HTML)
-        .into()
+        .content_type(mime::HTML))
 }
 
 fn main() -> std::io::Result<()> {

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -1,7 +1,7 @@
 use async_std::task;
 use serde::{Deserialize, Serialize};
 use tide::prelude::*;
-use tide::{Body, Request, Response};
+use tide::{Body, Request};
 
 #[derive(Deserialize, Serialize)]
 struct Cat {
@@ -20,9 +20,7 @@ fn main() -> tide::Result<()> {
                 name: "chashu".into(),
             };
 
-            let mut res = Response::new(200);
-            res.set_body(Body::from_json(&cat)?);
-            Ok(res)
+            Ok(Body::from_json(&cat)?)
         });
 
         app.at("/animals").get(|_| async {

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -103,14 +103,12 @@ async fn main() -> Result<()> {
     app.middleware(After(|result: Result| async move {
         let response = result.unwrap_or_else(|e| Response::new(e.status()));
         match response.status() {
-            StatusCode::NotFound => Response::build()
-                .status(404)
+            StatusCode::NotFound => Response::builder(404)
                 .content_type(mime::HTML)
                 .body(NOT_FOUND_HTML_PAGE)
                 .into(),
 
-            StatusCode::InternalServerError => Response::build()
-                .status(500)
+            StatusCode::InternalServerError => Response::builder(500)
                 .content_type(mime::HTML)
                 .body(INTERNAL_SERVER_ERROR_HTML_PAGE)
                 .into(),

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -103,18 +103,18 @@ async fn main() -> Result<()> {
     app.middleware(After(|result: Result| async move {
         let response = result.unwrap_or_else(|e| Response::new(e.status()));
         match response.status() {
-            StatusCode::NotFound => {
-                let mut res = Response::new(404);
-                res.set_content_type(mime::HTML);
-                res.set_body(NOT_FOUND_HTML_PAGE);
-                Ok(res)
-            }
-            StatusCode::InternalServerError => {
-                let mut res = Response::new(500);
-                res.set_content_type(mime::HTML);
-                res.set_body(INTERNAL_SERVER_ERROR_HTML_PAGE);
-                Ok(res)
-            }
+            StatusCode::NotFound => Response::build()
+                .status(404)
+                .content_type(mime::HTML)
+                .body(NOT_FOUND_HTML_PAGE)
+                .into(),
+
+            StatusCode::InternalServerError => Response::build()
+                .status(500)
+                .content_type(mime::HTML)
+                .body(INTERNAL_SERVER_ERROR_HTML_PAGE)
+                .into(),
+
             _ => Ok(response),
         }
     }));

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -102,19 +102,22 @@ async fn main() -> Result<()> {
 
     app.middleware(After(|result: Result| async move {
         let response = result.unwrap_or_else(|e| Response::new(e.status()));
-        match response.status() {
+
+        let response = match response.status() {
             StatusCode::NotFound => Response::builder(404)
                 .content_type(mime::HTML)
                 .body(NOT_FOUND_HTML_PAGE)
-                .into(),
+                .build(),
 
             StatusCode::InternalServerError => Response::builder(500)
                 .content_type(mime::HTML)
                 .body(INTERNAL_SERVER_ERROR_HTML_PAGE)
-                .into(),
+                .build(),
 
-            _ => Ok(response),
-        }
+            _ => response,
+        };
+
+        Ok(response)
     }));
 
     app.middleware(user_loader);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@
 //! [`Request::ext`].
 //!
 //! If the endpoint needs to share values with middleware, response scoped state can be set via
-//! [`Response::set_ext`] and is available through [`Response::ext`].
+//! [`Response::insert_ext`] and is available through [`Response::ext`].
 //!
 //! Application scoped state is used when a complete application needs access to a particular
 //! value. Examples of this include: database connections, websocket connections, or

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,7 @@ mod middleware;
 mod redirect;
 mod request;
 mod response;
+mod response_builder;
 mod route;
 
 #[cfg(not(feature = "__internal__bench"))]
@@ -218,6 +219,7 @@ pub use middleware::{Middleware, Next};
 pub use redirect::Redirect;
 pub use request::Request;
 pub use response::Response;
+pub use response_builder::ResponseBuilder;
 pub use route::Route;
 pub use server::Server;
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -209,7 +209,7 @@ impl Response {
     }
 
     /// Set a response scoped extension value.
-    pub fn insert_ext<T: Send + Sync + 'static>(mut self, val: T) {
+    pub fn insert_ext<T: Send + Sync + 'static>(&mut self, val: T) {
         self.res.ext_mut().insert(val);
     }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -37,17 +37,54 @@ impl Response {
         }
     }
 
+    /// Begin a chained response builder. For more details, see [ResponseBuilder](crate::ResponseBuilder)
+    ///
+    /// # Example:
+    /// ```rust
+    /// # use tide::{StatusCode, Response};
+    /// # async_std::task::block_on(async move {
+    /// let mut response = Response::build()
+    ///     .body("body")
+    ///     .status(203)
+    ///     .header("custom-header", "value")
+    ///     .unwrap();
+    ///
+    /// assert_eq!(response.take_body().into_string().await.unwrap(), "body");
+    /// assert_eq!(response.status(), StatusCode::NonAuthoritativeInformation);
+    /// assert_eq!(response["custom-header"], "value");
+    /// # });
+    /// ```
+    #[must_use]
     pub fn build() -> ResponseBuilder {
         ResponseBuilder::new()
     }
 
-    /// Returns the statuscode.
+    /// Returns the http status code.
     #[must_use]
     pub fn status(&self) -> crate::StatusCode {
         self.res.status()
     }
 
-    /// Set the statuscode.
+    /// Set the http status code.
+    ///
+    /// # Example:
+    /// ```rust
+    /// # use tide::{StatusCode, Response};
+    /// let mut response = Response::new(StatusCode::Ok);
+    ///
+    /// response.set_status(418); // the status can be a valid u16 http status code
+    /// assert_eq!(response.status(), StatusCode::ImATeapot);
+    ///
+    /// response.set_status(StatusCode::NonAuthoritativeInformation); // or a tide::StatusCode
+    /// assert_eq!(response.status(), StatusCode::NonAuthoritativeInformation);
+    /// ```
+    /// # Panics
+    /// `set_status` will panic if the status argument cannot be successfully converted into a StatusCode.
+    ///
+    /// ```should_panic
+    /// # use tide::Response;
+    /// Response::new(200).set_status(210); // this is not an established status code and will panic
+    /// ```
     pub fn set_status<S>(&mut self, status: S)
     where
         S: TryInto<StatusCode>,
@@ -196,7 +233,7 @@ impl Response {
     ///
     /// ## Warning
     /// Take care when calling this function with a cookie that was returned by
-    /// [`Request::cookie`](Request::cookie).  As per [section 5.3 step 11 of RFC 6265], a new
+    /// [`Request::cookie`](crate::Request::cookie).  As per [section 5.3 step 11 of RFC 6265], a new
     /// cookie is only treated as the same as an old one if it has a matching name, domain and
     /// path.
     ///
@@ -208,7 +245,7 @@ impl Response {
     ///
     /// To avoid this you can manually set the [domain](Cookie::set_domain) and
     /// [path](Cookie::set_path) as necessary after retrieving the cookie using
-    /// [`Request::cookie`](Request::cookie).
+    /// [`Request::cookie`](crate::Request::cookie).
     ///
     /// [section 5.3 step 11 of RFC 6265]: https://tools.ietf.org/html/rfc6265#section-5.3
     pub fn remove_cookie(&mut self, cookie: Cookie<'static>) {

--- a/src/response.rs
+++ b/src/response.rs
@@ -6,6 +6,7 @@ use crate::http::cookies::Cookie;
 use crate::http::headers::{self, HeaderName, HeaderValues, ToHeaderValues};
 use crate::http::Mime;
 use crate::http::{self, Body, StatusCode};
+use crate::ResponseBuilder;
 
 #[derive(Debug)]
 pub(crate) enum CookieEvent {
@@ -34,6 +35,10 @@ impl Response {
             res,
             cookie_events: vec![],
         }
+    }
+
+    pub fn build() -> ResponseBuilder {
+        ResponseBuilder::new()
     }
 
     /// Returns the statuscode.

--- a/src/response.rs
+++ b/src/response.rs
@@ -43,7 +43,15 @@ impl Response {
     }
 
     /// Set the statuscode.
-    pub fn set_status(&mut self, status: crate::StatusCode) {
+    pub fn set_status<S>(&mut self, status: S)
+    where
+        S: TryInto<StatusCode>,
+        S::Error: Debug,
+    {
+        let status = status
+            .try_into()
+            .expect("Could not convert into a valid `StatusCode`");
+
         self.res.set_status(status);
     }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -41,22 +41,27 @@ impl Response {
     ///
     /// # Example:
     /// ```rust
-    /// # use tide::{StatusCode, Response};
+    /// # use tide::{StatusCode, Response, http::mime};
     /// # async_std::task::block_on(async move {
-    /// let mut response = Response::build()
-    ///     .body("body")
-    ///     .status(203)
+    /// let mut response = Response::builder(203)
+    ///     .body("<html>hi</html>")
     ///     .header("custom-header", "value")
-    ///     .unwrap();
+    ///     .content_type(mime::HTML)
+    ///     .build();
     ///
-    /// assert_eq!(response.take_body().into_string().await.unwrap(), "body");
+    /// assert_eq!(response.take_body().into_string().await.unwrap(), "<html>hi</html>");
     /// assert_eq!(response.status(), StatusCode::NonAuthoritativeInformation);
     /// assert_eq!(response["custom-header"], "value");
+    /// assert_eq!(response["content-type"], "text/html;charset=utf-8");
     /// # });
     /// ```
     #[must_use]
-    pub fn build() -> ResponseBuilder {
-        ResponseBuilder::new()
+    pub fn builder<S>(status: S) -> ResponseBuilder
+    where
+        S: TryInto<StatusCode>,
+        S::Error: Debug,
+    {
+        ResponseBuilder::new(status)
     }
 
     /// Returns the http status code.

--- a/src/response_builder.rs
+++ b/src/response_builder.rs
@@ -1,0 +1,53 @@
+use crate::http::headers::{HeaderName, ToHeaderValues};
+use crate::http::{Body, Mime, StatusCode};
+use crate::Response;
+use std::convert::TryInto;
+
+#[derive(Debug)]
+pub struct ResponseBuilder(Response);
+
+impl ResponseBuilder {
+    pub fn new() -> Self {
+        Self(Response::new(StatusCode::Ok))
+    }
+
+    pub fn unwrap(self) -> Response {
+        self.0
+    }
+
+    pub fn status<S>(mut self, status: S) -> Self
+    where
+        S: TryInto<StatusCode>,
+        S::Error: std::fmt::Debug,
+    {
+        self.0.set_status(status);
+        self
+    }
+
+    pub fn header(mut self, key: impl Into<HeaderName>, value: impl ToHeaderValues) -> Self {
+        self.0.insert_header(key, value);
+        self
+    }
+
+    pub fn content_type(mut self, content_type: impl Into<Mime>) -> Self {
+        self.0.set_content_type(content_type);
+        self
+    }
+
+    pub fn body(mut self, body: impl Into<Body>) -> Self {
+        self.0.set_body(body);
+        self
+    }
+}
+
+impl Into<Response> for ResponseBuilder {
+    fn into(self) -> Response {
+        self.unwrap()
+    }
+}
+
+impl Into<crate::Result> for ResponseBuilder {
+    fn into(self) -> crate::Result {
+        Ok(self.unwrap())
+    }
+}

--- a/src/response_builder.rs
+++ b/src/response_builder.rs
@@ -4,17 +4,55 @@ use crate::Response;
 use std::convert::TryInto;
 
 #[derive(Debug)]
+
+/// Response Builder
+///
+/// Provides an ergonomic way to chain the creation of a response. This is generally accessed through [`Response::build`](crate::Response::build)
+///
+/// # Example
+/// ```rust
+/// # use tide::{StatusCode, ResponseBuilder};
+/// # async_std::task::block_on(async move {
+/// let mut response = ResponseBuilder::new()
+///     .body("body")
+///     .status(203)
+///     .header("custom-header", "value")
+///     .unwrap();
+///
+/// assert_eq!(response.take_body().into_string().await.unwrap(), "body");
+/// assert_eq!(response.status(), StatusCode::NonAuthoritativeInformation);
+/// assert_eq!(response["custom-header"], "value");
+/// # });
+
 pub struct ResponseBuilder(Response);
 
 impl ResponseBuilder {
+    /// Creates a new ResponseBuilder. This will default to an 200 OK status code.
+    /// ```rust
+    /// # use tide::{StatusCode, ResponseBuilder};
+    /// assert_eq!(ResponseBuilder::new().unwrap().status(), StatusCode::Ok)
+    /// ```
     pub fn new() -> Self {
         Self(Response::new(StatusCode::Ok))
     }
 
+    /// Returns the inner Response
     pub fn unwrap(self) -> Response {
         self.0
     }
 
+    /// Sets the http status on the response.
+    /// ```
+    /// # use tide::{ResponseBuilder, StatusCode};
+    /// let response = ResponseBuilder::new().status(418).unwrap();
+    /// assert_eq!(response.status(), StatusCode::ImATeapot);
+    /// ```
+    /// # Panics:
+    /// `status` will panic if the status argument cannot be successfully converted into a StatusCode.
+    /// ```should_panic
+    /// # use tide::ResponseBuilder;
+    /// ResponseBuilder::new().status(210); // this is not an established status code and will panic
+    /// ```
     pub fn status<S>(mut self, status: S) -> Self
     where
         S: TryInto<StatusCode>,
@@ -24,16 +62,36 @@ impl ResponseBuilder {
         self
     }
 
+    /// Sets a header on the response.
+    /// ```
+    /// # use tide::ResponseBuilder;
+    /// let response = ResponseBuilder::new().header("header-name", "header-value").unwrap();
+    /// assert_eq!(response["header-name"], "header-value");
+    /// ```
     pub fn header(mut self, key: impl Into<HeaderName>, value: impl ToHeaderValues) -> Self {
         self.0.insert_header(key, value);
         self
     }
 
+    /// Sets a header on the response.
+    /// ```
+    /// # use tide::{http::mime, ResponseBuilder};
+    /// let response = ResponseBuilder::new().content_type(mime::HTML).unwrap();
+    /// assert_eq!(response["content-type"], "text/html;charset=utf-8");
+    /// ```
     pub fn content_type(mut self, content_type: impl Into<Mime>) -> Self {
         self.0.set_content_type(content_type);
         self
     }
 
+    /// Sets the body of the response.
+    /// ```
+    /// # async_std::task::block_on(async move {
+    /// # use tide::{ResponseBuilder, convert::json};
+    /// let mut response = ResponseBuilder::new().body(json!({ "any": "Into<Body>"})).unwrap();
+    /// assert_eq!(response.take_body().into_string().await.unwrap(), "{\"any\":\"Into<Body>\"}");
+    /// # });
+    /// ```
     pub fn body(mut self, body: impl Into<Body>) -> Self {
         self.0.set_body(body);
         self

--- a/src/response_builder.rs
+++ b/src/response_builder.rs
@@ -82,9 +82,3 @@ impl Into<Response> for ResponseBuilder {
         self.build()
     }
 }
-
-impl Into<crate::Result> for ResponseBuilder {
-    fn into(self) -> crate::Result {
-        Ok(self.build())
-    }
-}

--- a/src/response_builder.rs
+++ b/src/response_builder.rs
@@ -73,7 +73,7 @@ impl ResponseBuilder {
         self
     }
 
-    /// Sets a header on the response.
+    /// Sets the Content-Type header on the response.
     /// ```
     /// # use tide::{http::mime, ResponseBuilder};
     /// let response = ResponseBuilder::new().content_type(mime::HTML).unwrap();

--- a/tests/chunked-encode-large.rs
+++ b/tests/chunked-encode-large.rs
@@ -2,11 +2,9 @@ mod test_utils;
 use async_std::io::Cursor;
 use async_std::prelude::*;
 use async_std::task;
-use http_types::mime;
-use http_types::StatusCode;
 use std::time::Duration;
 
-use tide::{Body, Response};
+use tide::Body;
 
 const TEXT: &'static str = concat![
     "Et provident reprehenderit accusamus dolores et voluptates sed quia. Repellendus odit porro ut et hic molestiae. Sit autem reiciendis animi fugiat deleniti vel iste. Laborum id odio ullam ut impedit dolores. Vel aperiam dolorem voluptatibus dignissimos maxime.",
@@ -72,13 +70,8 @@ async fn chunked_large() -> Result<(), http_types::Error> {
     let port = test_utils::find_port().await;
     let server = task::spawn(async move {
         let mut app = tide::new();
-        app.at("/").get(|mut _req: tide::Request<()>| async {
-            let mut res = Response::new(StatusCode::Ok);
-            let body = Cursor::new(TEXT.to_owned());
-            res.set_body(Body::from_reader(body, None));
-            res.set_content_type(mime::PLAIN);
-            Ok(res)
-        });
+        app.at("/")
+            .get(|_| async { Ok(Body::from_reader(Cursor::new(TEXT), None)) });
         app.listen(("localhost", port)).await?;
         Result::<(), http_types::Error>::Ok(())
     });

--- a/tests/chunked-encode-small.rs
+++ b/tests/chunked-encode-small.rs
@@ -2,11 +2,9 @@ mod test_utils;
 use async_std::io::Cursor;
 use async_std::prelude::*;
 use async_std::task;
-use http_types::mime;
-use http_types::StatusCode;
 use std::time::Duration;
 
-use tide::{Body, Response};
+use tide::Body;
 
 const TEXT: &'static str = concat![
     "Eveniet delectus voluptatem in placeat modi. Qui nulla sunt aut non voluptas temporibus accusamus rem. Qui soluta nisi qui accusantium excepturi voluptatem. Ab rerum maiores neque ut expedita rem.",
@@ -21,13 +19,8 @@ async fn chunked_large() -> Result<(), http_types::Error> {
     let port = test_utils::find_port().await;
     let server = task::spawn(async move {
         let mut app = tide::new();
-        app.at("/").get(|_| async {
-            let mut res = Response::new(StatusCode::Ok);
-            let body = Cursor::new(TEXT.to_owned());
-            res.set_body(Body::from_reader(body, None));
-            res.set_content_type(mime::PLAIN);
-            Ok(res)
-        });
+        app.at("/")
+            .get(|_| async { Ok(Body::from_reader(Cursor::new(TEXT), None)) });
         app.listen(("localhost", port)).await?;
         Result::<(), http_types::Error>::Ok(())
     });

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -4,7 +4,7 @@ use async_std::task;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
-use tide::{Body, Request, Response, StatusCode};
+use tide::{Body, Request};
 
 #[test]
 fn hello_world() -> Result<(), http_types::Error> {
@@ -16,9 +16,7 @@ fn hello_world() -> Result<(), http_types::Error> {
                 assert_eq!(req.body_string().await.unwrap(), "nori".to_string());
                 assert!(req.local_addr().unwrap().contains(&port.to_string()));
                 assert!(req.peer_addr().is_some());
-                let mut res = Response::new(StatusCode::Ok);
-                res.set_body("says hello");
-                Ok(res)
+                Ok("says hello")
             });
             app.listen(("localhost", port)).await?;
             Result::<(), http_types::Error>::Ok(())
@@ -31,7 +29,7 @@ fn hello_world() -> Result<(), http_types::Error> {
                 .recv_string()
                 .await
                 .unwrap();
-            assert_eq!(string, "says hello".to_string());
+            assert_eq!(string, "says hello");
             Ok(())
         });
 
@@ -81,9 +79,7 @@ fn json() -> Result<(), http_types::Error> {
                 let mut counter: Counter = req.body_json().await.unwrap();
                 assert_eq!(counter.count, 0);
                 counter.count = 1;
-                let mut res = Response::new(StatusCode::Ok);
-                res.set_body(Body::from_json(&counter)?);
-                Ok(res)
+                Ok(Body::from_json(&counter)?)
             });
             app.listen(("localhost", port)).await?;
             Result::<(), http_types::Error>::Ok(())

--- a/tests/unix.rs
+++ b/tests/unix.rs
@@ -3,9 +3,10 @@ mod unix_tests {
     use async_std::os::unix::net::UnixStream;
     use async_std::prelude::*;
     use async_std::task;
-    use http_types::{url::Url, Method, Request, Response, StatusCode};
+    use http_types::{url::Url, Method, Request};
     use std::time::Duration;
     use tempfile::tempdir;
+    use tide::prelude::*;
 
     #[test]
     fn hello_unix_world() -> Result<(), http_types::Error> {
@@ -17,12 +18,7 @@ mod unix_tests {
             let server = task::spawn(async move {
                 let mut app = tide::new();
                 app.at("/").get(|req: tide::Request<()>| async move {
-                    let mut res = Response::new(StatusCode::Ok);
-                    res.set_body(serde_json::json!({
-                        "peer_addr": req.peer_addr().unwrap(),
-                        "local_addr": req.local_addr().unwrap()
-                    }));
-                    Ok(res)
+                    Ok(json!({ "peer_addr": req.peer_addr().unwrap(), "local_addr": req.local_addr().unwrap() }))
                 });
                 app.listen_unix(sock_path).await?;
                 http_types::Result::Ok(())


### PR DESCRIPTION
This PR does several things that are related, but could be distinct PRs. Please let me know if you'd prefer I break them out for independent review.

* changes insert_ext from taking `mut self` to taking `&mut self` to conform to the rest of the response interface
* allows Response::set_status to take any `TryInto<StatusCode>` like `Response::new()` does
```rust
let mut res = Response::new(StatusCode::Ok);
res.set_status(203);
```
* ~~provides a `From<Body> for Response` and uses that conversion in other Body -> Response conversions that already existed.~~ Extracted to #584 

* adds a response builder:
```rust
app.at("/").get(|_| async {
    Ok(Response::builder(203)
        .body("body")
        .header("custom-header", "value"))
})
```
