### PR TITLE
use tide::Response interface in the sse endpoint

### DIFF
--- a/src/sse/endpoint.rs
+++ b/src/sse/endpoint.rs
@@ -58,8 +58,8 @@ where
             // Perform the handshake as described here:
             // https://html.spec.whatwg.org/multipage/server-sent-events.html#sse-processing-model
             let mut res = Response::new(StatusCode::Ok);
-            res.res.insert_header("Cache-Control", "no-cache").unwrap();
-            res.res.set_content_type(mime::SSE);
+            res.insert_header("Cache-Control", "no-cache");
+            res.set_content_type(mime::SSE);
 
             let body = Body::from_reader(BufReader::new(encoder), None);
             res.set_body(body);


### PR DESCRIPTION
instead of dropping down to the http-types equivalents. Addresses the issue raised in #571 in a slightly different way