### PR TITLE
Proposal: Return `Into<Response>` from endpoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ portpicker = "0.1.0"
 surf = { git = "https://github.com/Fishrock123/surf", branch = "deps-http-types-response-optional-error", default-features = false, features = ["h1-client"] }
 serde = { version = "1.0.102", features = ["derive"] }
 criterion = "0.3.1"
-tempdir = "0.3.7"
+tempfile = "3.1.0"
 
 [[test]]
 name = "nested"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,24 +32,25 @@ unstable = []
 __internal__bench = []
 
 [dependencies]
-async-h1 = { version = "2.0.1", optional = true }
+async-h1 = { git = "https://github.com/Fishrock123/async-h1", branch = "deps-http-types-response-optional-error", optional = true }
 async-sse = "3.0.0"
 async-std = { version = "1.6.0", features = ["unstable"] }
 femme = "2.0.1"
-http-types = "2.0.1"
+http-types = { git = "https://github.com/Fishrock123/http-types", branch = "response-optional-error" }
 kv-log-macro = "1.0.4"
 route-recognizer = "0.1.13"
 serde = "1.0.102"
 serde_json = "1.0.41"
 
+
 [dev-dependencies]
 async-std = { version = "1.6.0", features = ["unstable", "attributes"] }
 juniper = "0.14.1"
 portpicker = "0.1.0"
-surf = { version = "2.0.0-alpha.3", default-features = false, features = ["h1-client"] }
+surf = { git = "https://github.com/Fishrock123/surf", branch = "deps-http-types-response-optional-error", default-features = false, features = ["h1-client"] }
 serde = { version = "1.0.102", features = ["derive"] }
 criterion = "0.3.1"
-tempfile = "3.1.0"
+tempdir = "0.3.7"
 
 [[test]]
 name = "nested"

--- a/benches/router.rs
+++ b/benches/router.rs
@@ -4,11 +4,7 @@ use tide::router::Router;
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut router = Router::<()>::new();
-    router.add(
-        "hello",
-        Method::Get,
-        Box::new(|_| async { Ok("hello world") }),
-    );
+    router.add("hello", Method::Get, Box::new(|_| async { "hello world" }));
 
     c.bench_function("route-match", |b| {
         b.iter(|| black_box(router.route("/hello", Method::Get)))

--- a/examples/chunked.rs
+++ b/examples/chunked.rs
@@ -1,14 +1,11 @@
 use async_std::task;
-use tide::{Body, Response, StatusCode};
+use tide::Body;
 
 fn main() -> Result<(), std::io::Error> {
     task::block_on(async {
         let mut app = tide::new();
-        app.at("/").get(|_| async {
-            let mut res = Response::new(StatusCode::Ok);
-            res.set_body(Body::from_file(file!()).await.unwrap());
-            Ok(res)
-        });
+        app.at("/")
+            .get(|_| async { Body::from_file(file!()).await });
         app.listen("127.0.0.1:8080").await?;
         Ok(())
     })

--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -1,0 +1,25 @@
+use tide::{After, Request, Response, Result, StatusCode};
+
+#[async_std::main]
+async fn main() -> Result<()> {
+    tide::log::start();
+    let mut app = tide::new();
+
+    app.middleware(After(|mut res: Response| async move {
+        if let Some(err) = res.downcast_error::<url::ParseError>() {
+            let msg = err.to_string().to_owned();
+            res = res.set_status(StatusCode::ImATeapot);
+            res.set_body(format!("Teapot Status: {}", msg));
+        }
+        Ok(res)
+    }));
+
+    app.at("/").get(|_req: Request<_>| async move {
+        let path = url::Url::parse("")?;
+        Ok(format!("Path is {}", path))
+    });
+
+    app.listen("127.0.0.1:8080").await?;
+
+    Ok(())
+}

--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -1,3 +1,4 @@
+use tide::http::url;
 use tide::{After, Request, Response, Result, StatusCode};
 
 #[async_std::main]
@@ -8,15 +9,16 @@ async fn main() -> Result<()> {
     app.middleware(After(|mut res: Response| async move {
         if let Some(err) = res.downcast_error::<url::ParseError>() {
             let msg = err.to_string().to_owned();
-            res = res.set_status(StatusCode::ImATeapot);
+            res.set_status(StatusCode::ImATeapot);
             res.set_body(format!("Teapot Status: {}", msg));
         }
-        Ok(res)
+
+        res
     }));
 
     app.at("/").get(|_req: Request<_>| async move {
         let path = url::Url::parse("")?;
-        Ok(format!("Path is {}", path))
+        Result::Ok(format!("Path is {}", path))
     });
 
     app.listen("127.0.0.1:8080").await?;

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,8 +1,9 @@
 #[async_std::main]
+
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
     let mut app = tide::new();
-    app.at("/").get(|_| async { Ok("Hello, world!") });
+    app.at("/").get(|_| async { "Hello, world!" });
     app.listen("127.0.0.1:8080").await?;
     Ok(())
 }

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -1,7 +1,7 @@
 use async_std::task;
 use serde::{Deserialize, Serialize};
 use tide::prelude::*;
-use tide::{Body, Request, Response};
+use tide::{Body, Request, Response, Result};
 
 #[derive(Deserialize, Serialize)]
 struct Cat {
@@ -22,17 +22,18 @@ fn main() -> tide::Result<()> {
 
             let mut res = Response::new(200);
             res.set_body(Body::from_json(&cat)?);
-            Ok(res)
+
+            Result::Ok(res)
         });
 
         app.at("/animals").get(|_| async {
-            Ok(json!({
+            json!({
                 "meta": { "count": 2 },
                 "animals": [
                     { "type": "cat", "name": "chashu" },
                     { "type": "cat", "name": "nori" }
                 ]
-            }))
+            })
         });
 
         app.listen("127.0.0.1:8080").await?;

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -105,15 +105,15 @@ async fn main() -> Result<()> {
                 let mut res = Response::new(404);
                 res.set_content_type(mime::HTML);
                 res.set_body(NOT_FOUND_HTML_PAGE);
-                Ok(res)
+                res
             }
             StatusCode::InternalServerError => {
                 let mut res = Response::new(500);
                 res.set_content_type(mime::HTML);
                 res.set_body(INTERNAL_SERVER_ERROR_HTML_PAGE);
-                Ok(res)
+                res
             }
-            _ => Ok(response),
+            _ => response,
         }
     }));
 
@@ -128,10 +128,7 @@ async fn main() -> Result<()> {
         let count: &RequestCount = req.ext().unwrap();
         let user: &User = req.ext().unwrap();
 
-        Ok(format!(
-            "Hello {}, this was request number {}!",
-            user.name, count.0
-        ))
+        format!("Hello {}, this was request number {}!", user.name, count.0)
     });
 
     app.listen("127.0.0.1:8080").await?;

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -1,11 +1,11 @@
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
     let mut app = tide::new();
-    app.at("/").get(|_| async { Ok("Root") });
+    app.at("/").get(|_| async { "Root" });
     app.at("/api").nest({
         let mut api = tide::new();
-        api.at("/hello").get(|_| async { Ok("Hello, world") });
-        api.at("/goodbye").get(|_| async { Ok("Goodbye, world") });
+        api.at("/hello").get(|_| async { "Hello, world" });
+        api.at("/goodbye").get(|_| async { "Goodbye, world" });
         api
     });
     app.listen("127.0.0.1:8080").await?;

--- a/examples/redirect.rs
+++ b/examples/redirect.rs
@@ -3,19 +3,19 @@ use tide::{http::StatusCode, Redirect, Response};
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
     let mut app = tide::new();
-    app.at("/").get(|_| async { Ok("Root") });
+    app.at("/").get(|_| async { "Root" });
 
     // Redirect hackers to YouTube.
     app.at("/.env")
         .get(Redirect::new("https://www.youtube.com/watch?v=dQw4w9WgXcQ"));
 
     app.at("/users-page").get(|_| async {
-        Ok(if signed_in() {
+        if signed_in() {
             Response::new(StatusCode::Ok)
         } else {
             // If the user is not signed in then lets redirect them to home page.
             Redirect::new("/").into()
-        })
+        }
     });
 
     app.listen("127.0.0.1:8080").await?;

--- a/examples/static_file.rs
+++ b/examples/static_file.rs
@@ -2,7 +2,7 @@
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
     let mut app = tide::new();
-    app.at("/").get(|_| async move { Ok("visit /src/*") });
+    app.at("/").get(|_| async { "visit /src/*" });
     app.at("/src").serve_dir("src/")?;
     app.listen("127.0.0.1:8080").await?;
     Ok(())

--- a/src/cookies/middleware.rs
+++ b/src/cookies/middleware.rs
@@ -16,12 +16,12 @@ use std::sync::{Arc, RwLock};
 /// # use tide::http::cookies::Cookie;
 /// let mut app = tide::Server::new();
 /// app.at("/get").get(|req: Request<()>| async move {
-///     Ok(req.cookie("testCookie").unwrap().value().to_string())
+///     req.cookie("testCookie").unwrap().value().to_string()
 /// });
 /// app.at("/set").get(|_| async {
 ///     let mut res = Response::new(StatusCode::Ok);
 ///     res.insert_cookie(Cookie::new("testCookie", "NewCookieValue"));
-///     Ok(res)
+///     res
 /// });
 /// ```
 #[derive(Debug, Clone, Default)]

--- a/src/cookies/middleware.rs
+++ b/src/cookies/middleware.rs
@@ -51,7 +51,7 @@ impl<State: Send + Sync + 'static> Middleware<State> for CookiesMiddleware {
                 content
             };
 
-            let mut res = next.run(ctx).await?;
+            let mut res = next.run(ctx).await;
 
             // Don't do anything if there are no cookies.
             if res.cookie_events.is_empty() {

--- a/src/fs/serve_dir.rs
+++ b/src/fs/serve_dir.rs
@@ -17,7 +17,10 @@ impl ServeDir {
     }
 }
 
-impl<State> Endpoint<State> for ServeDir {
+impl<State> Endpoint<State> for ServeDir
+where
+    State: Send + Sync + 'static,
+{
     fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, Result> {
         let path = req.url().path();
         let path = path.trim_start_matches(&self.prefix);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //! # fn main() -> Result<(), std::io::Error> { block_on(async {
 //! #
 //! let mut app = tide::new();
-//! app.at("/").get(|_| async { Ok("Hello, world!") });
+//! app.at("/").get(|_| async { "Hello, world!" });
 //! app.listen("127.0.0.1:8080").await?;
 //! #
 //! # Ok(()) }) }
@@ -41,7 +41,7 @@
 //! # fn main() -> Result<(), std::io::Error> { block_on(async {
 //! #
 //! let mut app = tide::new();
-//! app.at("/").get(|req| async { Ok(req) });
+//! app.at("/").get(|req| async { req });
 //! app.listen("127.0.0.1:8080").await?;
 //! #
 //! # Ok(()) }) }
@@ -63,7 +63,7 @@
 //!    counter.count += 1;
 //!    let mut res = Response::new(200);
 //!    res.set_body(Body::from_json(&counter)?);
-//!    Ok(res)
+//!    tide::Result::Ok(res)
 //! });
 //! app.listen("127.0.0.1:8080").await?;
 //! #
@@ -166,7 +166,7 @@
 //! #[async_std::main]
 //! async fn main() -> Result<(), std::io::Error> {
 //!     let mut app = tide::new();
-//!     app.at("/").get(|req: Request<()>| async move { Ok(req.bark()) });
+//!     app.at("/").get(|req: Request<()>| async move { req.bark() });
 //!     app.listen("127.0.0.1:8080").await
 //! }
 //! ```
@@ -233,7 +233,7 @@ pub use http_types::{self as http, Body, Error, Status, StatusCode};
 /// # fn main() -> Result<(), std::io::Error> { block_on(async {
 /// #
 /// let mut app = tide::new();
-/// app.at("/").get(|_| async { Ok("Hello, world!") });
+/// app.at("/").get(|_| async { "Hello, world!" });
 /// app.listen("127.0.0.1:8080").await?;
 /// #
 /// # Ok(()) }) }
@@ -268,7 +268,7 @@ pub fn new() -> server::Server<()> {
 /// // Initialize the application with state.
 /// let mut app = tide::with_state(state);
 /// app.at("/").get(|req: Request<State>| async move {
-///     Ok(format!("Hello, {}!", &req.state().name))
+///     format!("Hello, {}!", &req.state().name)
 /// });
 /// app.listen("127.0.0.1:8080").await?;
 /// #

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -9,7 +9,7 @@
 //! use tide::Redirect;
 //!
 //! let mut app = tide::new();
-//! app.at("/").get(|_| async { Ok("meow") });
+//! app.at("/").get(|_| async { "meow" });
 //! app.at("/nori").get(Redirect::temporary("/"));
 //! app.listen("127.0.0.1:8080").await?;
 //! #

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -88,6 +88,7 @@ impl<T: AsRef<str>> Redirect<T> {
 
 impl<State, T> Endpoint<State> for Redirect<T>
 where
+    State: Send + Sync + 'static,
     T: AsRef<str> + Send + Sync + 'static,
 {
     fn call<'a>(&'a self, _req: Request<State>) -> BoxFuture<'a, crate::Result<Response>> {

--- a/src/request.rs
+++ b/src/request.rs
@@ -48,12 +48,12 @@ impl<State> Request<State> {
     /// # use async_std::task::block_on;
     /// # fn main() -> Result<(), std::io::Error> { block_on(async {
     /// #
-    /// use tide::Request;
+    /// use tide::{Request, Response};
     ///
     /// let mut app = tide::new();
     /// app.at("/").get(|req: Request<()>| async move {
     ///     assert_eq!(req.method(), http_types::Method::Get);
-    ///     Ok("")
+    ///     Response::new(200)
     /// });
     /// app.listen("127.0.0.1:8080").await?;
     /// #
@@ -72,12 +72,12 @@ impl<State> Request<State> {
     /// # use async_std::task::block_on;
     /// # fn main() -> Result<(), std::io::Error> { block_on(async {
     /// #
-    /// use tide::Request;
+    /// use tide::{Request, Response};
     ///
     /// let mut app = tide::new();
     /// app.at("/").get(|req: Request<()>| async move {
     ///     assert_eq!(req.url(), &"/".parse::<tide::http::Url>().unwrap());
-    ///     Ok("")
+    ///     Response::new(200)
     /// });
     /// app.listen("127.0.0.1:8080").await?;
     /// #
@@ -96,12 +96,12 @@ impl<State> Request<State> {
     /// # use async_std::task::block_on;
     /// # fn main() -> Result<(), std::io::Error> { block_on(async {
     /// #
-    /// use tide::Request;
+    /// use tide::{Request, Response};
     ///
     /// let mut app = tide::new();
     /// app.at("/").get(|req: Request<()>| async move {
     ///     assert_eq!(req.version(), Some(http_types::Version::Http1_1));
-    ///     Ok("")
+    ///     Response::new(200)
     /// });
     /// app.listen("127.0.0.1:8080").await?;
     /// #
@@ -167,12 +167,12 @@ impl<State> Request<State> {
     /// # use async_std::task::block_on;
     /// # fn main() -> Result<(), std::io::Error> { block_on(async {
     /// #
-    /// use tide::Request;
+    /// use tide::{Request, Response};
     ///
     /// let mut app = tide::new();
     /// app.at("/").get(|req: Request<()>| async move {
     ///     assert_eq!(req.header("X-Forwarded-For").unwrap(), "127.0.0.1");
-    ///     Ok("")
+    ///     Response::new(200)
     /// });
     /// app.listen("127.0.0.1:8080").await?;
     /// #
@@ -316,12 +316,12 @@ impl<State> Request<State> {
     /// # use async_std::task::block_on;
     /// # fn main() -> Result<(), std::io::Error> { block_on(async {
     /// #
-    /// use tide::Request;
+    /// use tide::{Request, Response};
     ///
     /// let mut app = tide::new();
     /// app.at("/").get(|mut req: Request<()>| async move {
     ///     let _body: Vec<u8> = req.body_bytes().await.unwrap();
-    ///     Ok("")
+    ///     Response::new(200)
     /// });
     /// app.listen("127.0.0.1:8080").await?;
     /// #
@@ -350,12 +350,12 @@ impl<State> Request<State> {
     /// # use async_std::task::block_on;
     /// # fn main() -> Result<(), std::io::Error> { block_on(async {
     /// #
-    /// use tide::Request;
+    /// use tide::{Request, Response};
     ///
     /// let mut app = tide::new();
     /// app.at("/").get(|mut req: Request<()>| async move {
     ///     let _body: String = req.body_string().await.unwrap();
-    ///     Ok("")
+    ///     Response::new(200)
     /// });
     /// app.listen("127.0.0.1:8080").await?;
     /// #

--- a/src/route.rs
+++ b/src/route.rs
@@ -29,7 +29,7 @@ pub struct Route<'a, State> {
     prefix: bool,
 }
 
-impl<'a, State: 'static> Route<'a, State> {
+impl<'a, State: 'static + Send + Sync> Route<'a, State> {
     pub(crate) fn new(router: &'a mut Router<State>, path: String) -> Route<'a, State> {
         Route {
             router,
@@ -274,7 +274,11 @@ impl<E> Clone for StripPrefixEndpoint<E> {
     }
 }
 
-impl<State, E: Endpoint<State>> Endpoint<State> for StripPrefixEndpoint<E> {
+impl<State, E> Endpoint<State> for StripPrefixEndpoint<E>
+where
+    State: 'static + Send + Sync,
+    E: Endpoint<State>,
+{
     fn call<'a>(&'a self, req: crate::Request<State>) -> BoxFuture<'a, crate::Result> {
         let crate::Request {
             state,

--- a/src/router.rs
+++ b/src/router.rs
@@ -22,7 +22,7 @@ pub struct Selection<'a, State> {
     pub(crate) params: Params,
 }
 
-impl<State: 'static> Router<State> {
+impl<State: 'static + Send + Sync> Router<State> {
     pub fn new() -> Self {
         Router {
             method_map: HashMap::default(),

--- a/src/security/cors.rs
+++ b/src/security/cors.rs
@@ -141,7 +141,7 @@ impl<State: Send + Sync + 'static> Middleware<State> for CorsMiddleware {
 
             if origins.is_none() {
                 // This is not a CORS request if there is no Origin header
-                return next.run(req).await;
+                return Ok(next.run(req).await);
             }
 
             let origins = origins.unwrap();
@@ -156,7 +156,7 @@ impl<State: Send + Sync + 'static> Middleware<State> for CorsMiddleware {
                 return Ok(self.build_preflight_response(&origins).into());
             }
 
-            let mut response: http_types::Response = next.run(req).await?.into();
+            let mut response: http_types::Response = next.run(req).await.into();
 
             response.insert_header(
                 headers::ACCESS_CONTROL_ALLOW_ORIGIN,

--- a/src/security/cors.rs
+++ b/src/security/cors.rs
@@ -253,7 +253,7 @@ mod test {
 
     fn app() -> crate::Server<()> {
         let mut app = crate::Server::new();
-        app.at(ENDPOINT).get(|_| async { Ok("Hello World") });
+        app.at(ENDPOINT).get(|_| async { "Hello World" });
 
         app
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -143,7 +143,7 @@ impl Server<()> {
     /// # fn main() -> Result<(), std::io::Error> { block_on(async {
     /// #
     /// let mut app = tide::new();
-    /// app.at("/").get(|_| async { Ok("Hello, world!") });
+    /// app.at("/").get(|_| async { "Hello, world!" });
     /// app.listen("127.0.0.1:8080").await?;
     /// #
     /// # Ok(()) }) }
@@ -186,7 +186,7 @@ impl<State: Send + Sync + 'static> Server<State> {
     /// // Initialize the application with state.
     /// let mut app = tide::with_state(state);
     /// app.at("/").get(|req: Request<State>| async move {
-    ///     Ok(format!("Hello, {}!", &req.state().name))
+    ///     format!("Hello, {}!", &req.state().name)
     /// });
     /// app.listen("127.0.0.1:8080").await?;
     /// #
@@ -213,7 +213,7 @@ impl<State: Send + Sync + 'static> Server<State> {
     ///
     /// ```rust,no_run
     /// # let mut app = tide::Server::new();
-    /// app.at("/").get(|_| async { Ok("Hello, world!") });
+    /// app.at("/").get(|_| async { "Hello, world!" });
     /// ```
     ///
     /// A path is comprised of zero or many segments, i.e. non-empty strings
@@ -369,7 +369,7 @@ impl<State: Send + Sync + 'static> Server<State> {
     /// use tide::http::{Url, Method, Request, Response};
     ///
     /// let mut app = tide::new();
-    /// app.at("/").get(|_| async { Ok("hello world") });
+    /// app.at("/").get(|_| async { "hello world" });
     ///
     /// let req = Request::new(Method::Get, Url::parse("https://example.com")?);
     /// let res: Response = app.respond(req).await?;

--- a/tests/chunked-encode-large.rs
+++ b/tests/chunked-encode-large.rs
@@ -6,7 +6,7 @@ use http_types::mime;
 use http_types::StatusCode;
 use std::time::Duration;
 
-use tide::{Body, Response};
+use tide::{Body, Response, Result};
 
 const TEXT: &'static str = concat![
     "Et provident reprehenderit accusamus dolores et voluptates sed quia. Repellendus odit porro ut et hic molestiae. Sit autem reiciendis animi fugiat deleniti vel iste. Laborum id odio ullam ut impedit dolores. Vel aperiam dolorem voluptatibus dignissimos maxime.",
@@ -68,7 +68,7 @@ const TEXT: &'static str = concat![
 ];
 
 #[async_std::test]
-async fn chunked_large() -> Result<(), http_types::Error> {
+async fn chunked_large() -> Result<()> {
     let port = test_utils::find_port().await;
     let server = task::spawn(async move {
         let mut app = tide::new();
@@ -77,10 +77,10 @@ async fn chunked_large() -> Result<(), http_types::Error> {
             let body = Cursor::new(TEXT.to_owned());
             res.set_body(Body::from_reader(body, None));
             res.set_content_type(mime::PLAIN);
-            Ok(res)
+            res
         });
         app.listen(("localhost", port)).await?;
-        Result::<(), http_types::Error>::Ok(())
+        Result::Ok(())
     });
 
     let client = task::spawn(async move {

--- a/tests/chunked-encode-small.rs
+++ b/tests/chunked-encode-small.rs
@@ -26,7 +26,7 @@ async fn chunked_large() -> Result<(), http_types::Error> {
             let body = Cursor::new(TEXT.to_owned());
             res.set_body(Body::from_reader(body, None));
             res.set_content_type(mime::PLAIN);
-            Ok(res)
+            res
         });
         app.listen(("localhost", port)).await?;
         Result::<(), http_types::Error>::Ok(())

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -51,7 +51,7 @@ async fn nested_middleware() {
             next: Next<'a, State>,
         ) -> BoxFuture<'a, tide::Result<tide::Response>> {
             Box::pin(async move {
-                let mut res = next.run(req).await?;
+                let mut res = next.run(req).await;
                 res.insert_header("X-Tide-Test", "1");
                 Ok(res)
             })

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -7,8 +7,8 @@ mod test_utils;
 #[async_std::test]
 async fn nested() {
     let mut inner = tide::new();
-    inner.at("/foo").get(|_| async { Ok("foo") });
-    inner.at("/bar").get(|_| async { Ok("bar") });
+    inner.at("/foo").get(|_| async { "foo" });
+    inner.at("/bar").get(|_| async { "bar" });
 
     let mut outer = tide::new();
     // Nest the inner app on /foo
@@ -33,7 +33,7 @@ async fn nested() {
 
 #[async_std::test]
 async fn nested_middleware() {
-    let echo_path = |req: tide::Request<()>| async move { Ok(req.url().path().to_string()) };
+    let echo_path = |req: tide::Request<()>| async move { req.url().path().to_string() };
 
     #[derive(Debug, Clone, Default)]
     pub struct TestMiddleware;
@@ -97,11 +97,10 @@ async fn nested_middleware() {
 async fn nested_with_different_state() {
     let mut outer = tide::new();
     let mut inner = tide::with_state(42);
-    inner.at("/").get(|req: tide::Request<i32>| async move {
-        let num = req.state();
-        Ok(format!("the number is {}", num))
-    });
-    outer.at("/").get(|_| async { Ok("Hello, world!") });
+    inner
+        .at("/")
+        .get(|req: tide::Request<i32>| async move { format!("the number is {}", req.state()) });
+    outer.at("/").get(|_| async { "Hello, world!" });
     outer.at("/foo").nest(inner);
 
     let req = Request::new(Method::Get, Url::parse("http://example.com/foo").unwrap());

--- a/tests/response.rs
+++ b/tests/response.rs
@@ -49,8 +49,9 @@ async fn json_content_type() {
         map.insert(None, 6);
         let mut resp = Response::new(StatusCode::Ok);
         resp.set_body(Body::from_json(&map)?);
-        Ok(resp)
+        tide::Result::Ok(resp)
     });
+
     let req = http::Request::new(
         Method::Get,
         Url::parse("http://localhost/json_content_type").unwrap(),

--- a/tests/route_middleware.rs
+++ b/tests/route_middleware.rs
@@ -23,7 +23,7 @@ impl<State: Send + Sync + 'static> Middleware<State> for TestMiddleware {
         next: tide::Next<'a, State>,
     ) -> BoxFuture<'a, tide::Result<tide::Response>> {
         Box::pin(async move {
-            let mut res = next.run(req).await?;
+            let mut res = next.run(req).await;
             res.insert_header(self.0.clone(), self.1);
             Ok(res)
         })

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -4,10 +4,10 @@ use async_std::task;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
-use tide::{Body, Request, Response, StatusCode};
+use tide::{Body, Request, Response, Result, StatusCode};
 
 #[test]
-fn hello_world() -> Result<(), http_types::Error> {
+fn hello_world() -> Result<()> {
     task::block_on(async {
         let port = test_utils::find_port().await;
         let server = task::spawn(async move {
@@ -18,10 +18,10 @@ fn hello_world() -> Result<(), http_types::Error> {
                 assert!(req.peer_addr().is_some());
                 let mut res = Response::new(StatusCode::Ok);
                 res.set_body("says hello");
-                Ok(res)
+                res
             });
             app.listen(("localhost", port)).await?;
-            Result::<(), http_types::Error>::Ok(())
+            Result::Ok(())
         });
 
         let client = task::spawn(async move {
@@ -40,15 +40,15 @@ fn hello_world() -> Result<(), http_types::Error> {
 }
 
 #[test]
-fn echo_server() -> Result<(), http_types::Error> {
+fn echo_server() -> Result<()> {
     task::block_on(async {
         let port = test_utils::find_port().await;
         let server = task::spawn(async move {
             let mut app = tide::new();
-            app.at("/").get(|req| async move { Ok(req) });
+            app.at("/").get(|req| async move { req });
 
             app.listen(("localhost", port)).await?;
-            Result::<(), http_types::Error>::Ok(())
+            Result::Ok(())
         });
 
         let client = task::spawn(async move {
@@ -67,7 +67,7 @@ fn echo_server() -> Result<(), http_types::Error> {
 }
 
 #[test]
-fn json() -> Result<(), http_types::Error> {
+fn json() -> Result<()> {
     #[derive(Deserialize, Serialize)]
     struct Counter {
         count: usize,
@@ -83,10 +83,10 @@ fn json() -> Result<(), http_types::Error> {
                 counter.count = 1;
                 let mut res = Response::new(StatusCode::Ok);
                 res.set_body(Body::from_json(&counter)?);
-                Ok(res)
+                Result::Ok(res)
             });
             app.listen(("localhost", port)).await?;
-            Result::<(), http_types::Error>::Ok(())
+            tide::Result::Ok(())
         });
 
         let client = task::spawn(async move {

--- a/tests/unix.rs
+++ b/tests/unix.rs
@@ -22,10 +22,10 @@ mod unix_tests {
                         "peer_addr": req.peer_addr().unwrap(),
                         "local_addr": req.local_addr().unwrap()
                     }));
-                    Ok(res)
+                    res
                 });
                 app.listen_unix(sock_path).await?;
-                http_types::Result::Ok(())
+                tide::Result::Ok(())
             });
 
             let client = task::spawn(async move {

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -174,7 +174,7 @@ async fn invalid_wildcard() {
 #[async_std::test]
 async fn nameless_wildcard() {
     let mut app = tide::Server::new();
-    app.at("/echo/:").get(|_| async { Ok("") });
+    app.at("/echo/:").get(|_| async { "" });
 
     let req = http::Request::new(
         Method::Get,


### PR DESCRIPTION
Contingent on #570. With that PR merged, we can convert any Result into a Response, which means that we can allow endpoints to return `Into<Response>`. This means that hello world examples become `app.at("/").get(|_| async { "hello world" })` again, but for endpoints with error handling logic that requires `?`, they can return `Result<generic Into<Response>, generic Into<tide::Error>>`.

The only breaking change people will run into with this is that for closure-style endpoints that previously inferred a return type, they will need to change `Ok(into_response)` into `tide::Result::Ok(into_response)` or if `?` is unused, just return `into_response`. This is because rust cannot infer what the error type is with just `|_| async { Ok(…) }`.

I personally believe that this tradeoff is worthwhile. My hunch is that most route handlers that are fallible also already have explicit Result signatures, and that the ability to skip Ok() in infallbile endpoints is a valuable reduction of boilerplate.

For `async fn` route handler definitions with an explicit `Result<Response>` return signature, this doesn't break any code, but will optionally allow any infallible handler to return Response (or anything that's `Into<Response>`).

To see how this would impact actual usage, check out the updated examples and tide code.

This will also play well with #580, as it will allow
```rust
    app.at("/hello").get(|_| async {
        Response::builder(200)
            .header("header", "value")
            .body(json!({ "returning": "a builder" }))
    });
```

All changes specific to this PR are in this commit: https://github.com/http-rs/tide/pull/596/commits/7a680502483982719cb15491edf537933291a2c9