### PR TITLE
return a result from sse sender

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ __internal__bench = []
 
 [dependencies]
 async-h1 = { version = "2.0.1", optional = true }
-async-sse = "3.0.0"
+async-sse = "3.0.1"
 async-std = { version = "1.6.0", features = ["unstable"] }
 femme = "2.0.1"
 http-types = "2.2.1"

--- a/examples/sse.rs
+++ b/examples/sse.rs
@@ -4,8 +4,8 @@ use tide::sse;
 async fn main() -> Result<(), std::io::Error> {
     let mut app = tide::new();
     app.at("/sse").get(sse::endpoint(|_req, sender| async move {
-        sender.send("fruit", "banana", None).await;
-        sender.send("fruit", "apple", None).await;
+        sender.send("fruit", "banana", None).await?;
+        sender.send("fruit", "apple", None).await?;
         Ok(())
     }));
     app.listen("localhost:8080").await?;

--- a/src/sse/mod.rs
+++ b/src/sse/mod.rs
@@ -18,8 +18,8 @@
 //!
 //! let mut app = tide::new();
 //! app.at("/sse").get(sse::endpoint(|_req, sender| async move {
-//!     sender.send("fruit", "banana", None).await;
-//!     sender.send("fruit", "apple", None).await;
+//!     sender.send("fruit", "banana", None).await?;
+//!     sender.send("fruit", "apple", None).await?;
 //!     Ok(())
 //! }));
 //! app.listen("localhost:8080").await?;

--- a/src/sse/sender.rs
+++ b/src/sse/sender.rs
@@ -12,8 +12,13 @@ impl Sender {
 
     /// Send data from the SSE channel.
     ///
-    /// Each message constists of a "name" and "data".
-    pub async fn send(&self, name: &str, data: impl AsRef<str>, id: Option<&str>) {
-        self.sender.send(name, data.as_ref(), id).await;
+    /// Each message consists of a "name" and "data".
+    pub async fn send(
+        &self,
+        name: &str,
+        data: impl AsRef<str>,
+        id: Option<&str>,
+    ) -> async_std::io::Result<()> {
+        self.sender.send(name, data.as_ref(), id).await
     }
 }


### PR DESCRIPTION
in order to allow endpoints to break out of loops

dependent on: http-rs/async-sse#3

closes #591