### PR TITLE
introduce an extension trait for testing servers

### DIFF
--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -1,7 +1,4 @@
-use http_types::{Method, Request, Response, Url};
-use test_utils::BoxFuture;
-use tide::{Middleware, Next};
-
+use test_utils::ServerTestingExt;
 mod test_utils;
 
 #[async_std::test]
@@ -14,80 +11,36 @@ async fn nested() {
     // Nest the inner app on /foo
     outer.at("/foo").nest(inner);
 
-    let req = Request::new(
-        Method::Get,
-        Url::parse("http://example.com/foo/foo").unwrap(),
-    );
-    let mut res: Response = outer.respond(req).await.unwrap();
-    assert_eq!(res.status(), 200);
-    assert_eq!(res.body_string().await.unwrap(), "foo");
-
-    let req = Request::new(
-        Method::Get,
-        Url::parse("http://example.com/foo/bar").unwrap(),
-    );
-    let mut res: Response = outer.respond(req).await.unwrap();
-    assert_eq!(res.status(), 200);
-    assert_eq!(res.body_string().await.unwrap(), "bar");
+    assert_eq!(outer.get_body("/foo/foo").await, "foo");
+    assert_eq!(outer.get_body("/foo/bar").await, "bar");
 }
 
 #[async_std::test]
 async fn nested_middleware() {
     let echo_path = |req: tide::Request<()>| async move { Ok(req.url().path().to_string()) };
 
-    #[derive(Debug, Clone, Default)]
-    pub struct TestMiddleware;
-
-    impl TestMiddleware {
-        pub fn new() -> Self {
-            Self {}
-        }
-    }
-
-    impl<State: Send + Sync + 'static> Middleware<State> for TestMiddleware {
-        fn handle<'a>(
-            &'a self,
-            req: tide::Request<State>,
-            next: Next<'a, State>,
-        ) -> BoxFuture<'a, tide::Result<tide::Response>> {
-            Box::pin(async move {
-                let mut res = next.run(req).await;
-                res.insert_header("X-Tide-Test", "1");
-                Ok(res)
-            })
-        }
-    }
-
     let mut app = tide::new();
-
     let mut inner_app = tide::new();
-    inner_app.middleware(TestMiddleware::new());
+    inner_app.middleware(tide::utils::After(|mut res: tide::Response| async move {
+        res.insert_header("x-tide-test", "1");
+        Ok(res)
+    }));
     inner_app.at("/echo").get(echo_path);
     inner_app.at("/:foo/bar").strip_prefix().get(echo_path);
     app.at("/foo").nest(inner_app);
-
     app.at("/bar").get(echo_path);
 
-    let req = Request::new(
-        Method::Get,
-        Url::parse("http://example.com/foo/echo").unwrap(),
-    );
-    let mut res: Response = app.respond(req).await.unwrap();
+    let mut res = app.get("/foo/echo").await;
     assert_eq!(res["X-Tide-Test"], "1");
     assert_eq!(res.status(), 200);
     assert_eq!(res.body_string().await.unwrap(), "/echo");
 
-    let req = Request::new(
-        Method::Get,
-        Url::parse("http://example.com/foo/x/bar").unwrap(),
-    );
-    let mut res: Response = app.respond(req).await.unwrap();
+    let mut res = app.get("/foo/x/bar").await;
     assert_eq!(res["X-Tide-Test"], "1");
     assert_eq!(res.status(), 200);
     assert_eq!(res.body_string().await.unwrap(), "/");
 
-    let req = Request::new(Method::Get, Url::parse("http://example.com/bar").unwrap());
-    let mut res: Response = app.respond(req).await.unwrap();
+    let mut res = app.get("/bar").await;
     assert!(res.header("X-Tide-Test").is_none());
     assert_eq!(res.status(), 200);
     assert_eq!(res.body_string().await.unwrap(), "/bar");
@@ -104,13 +57,6 @@ async fn nested_with_different_state() {
     outer.at("/").get(|_| async { Ok("Hello, world!") });
     outer.at("/foo").nest(inner);
 
-    let req = Request::new(Method::Get, Url::parse("http://example.com/foo").unwrap());
-    let mut res: Response = outer.respond(req).await.unwrap();
-    assert_eq!(res.status(), 200);
-    assert_eq!(res.body_string().await.unwrap(), "the number is 42");
-
-    let req = Request::new(Method::Get, Url::parse("http://example.com/").unwrap());
-    let mut res: Response = outer.respond(req).await.unwrap();
-    assert_eq!(res.status(), 200);
-    assert_eq!(res.body_string().await.unwrap(), "Hello, world!");
+    assert_eq!(outer.get_body("/foo").await, "the number is 42");
+    assert_eq!(outer.get_body("/").await, "Hello, world!");
 }

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -2,6 +2,8 @@ use portpicker::pick_unused_port;
 
 use std::future::Future;
 use std::pin::Pin;
+use tide::http::{self, url::Url, Method};
+use tide::Server;
 
 /// An owned dynamically typed [`Future`] for use in cases where you can't
 /// statically type your result or need to add some indirection.
@@ -12,4 +14,73 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 #[allow(dead_code)]
 pub async fn find_port() -> u16 {
     pick_unused_port().expect("No ports free")
+}
+
+pub trait ServerTestingExt {
+    fn request<'a>(
+        &'a self,
+        method: Method,
+        path: &str,
+    ) -> Pin<Box<dyn Future<Output = http::Response> + 'a + Send>>;
+    fn request_body<'a>(
+        &'a self,
+        method: Method,
+        path: &str,
+    ) -> Pin<Box<dyn Future<Output = String> + 'a + Send>>;
+    fn get<'a>(&'a self, path: &str) -> Pin<Box<dyn Future<Output = http::Response> + 'a + Send>>;
+    fn get_body<'a>(&'a self, path: &str) -> Pin<Box<dyn Future<Output = String> + 'a + Send>>;
+    fn post<'a>(&'a self, path: &str) -> Pin<Box<dyn Future<Output = http::Response> + 'a + Send>>;
+    fn put<'a>(&'a self, path: &str) -> Pin<Box<dyn Future<Output = http::Response> + 'a + Send>>;
+}
+
+impl<State> ServerTestingExt for Server<State>
+where
+    State: Send + Sync + 'static,
+{
+    fn request<'a>(
+        &'a self,
+        method: Method,
+        path: &str,
+    ) -> Pin<Box<dyn Future<Output = http::Response> + 'a + Send>> {
+        let url = if path.starts_with("http:") {
+            Url::parse(path).unwrap()
+        } else {
+            Url::parse("http://example.com/")
+                .unwrap()
+                .join(path)
+                .unwrap()
+        };
+
+        let request = http::Request::new(method, url);
+        let fut = self.respond(request);
+        Box::pin(async { fut.await.unwrap() })
+    }
+
+    fn request_body<'a>(
+        &'a self,
+        method: Method,
+        path: &str,
+    ) -> Pin<Box<dyn Future<Output = String> + 'a + Send>> {
+        let response_fut = self.request(method, path);
+        Box::pin(async move {
+            let mut response = response_fut.await;
+            response.body_string().await.unwrap()
+        })
+    }
+
+    fn get<'a>(&'a self, path: &str) -> Pin<Box<dyn Future<Output = http::Response> + 'a + Send>> {
+        self.request(Method::Get, path)
+    }
+
+    fn get_body<'a>(&'a self, path: &str) -> Pin<Box<dyn Future<Output = String> + 'a + Send>> {
+        self.request_body(Method::Get, path)
+    }
+
+    fn post<'a>(&'a self, path: &str) -> Pin<Box<dyn Future<Output = http::Response> + 'a + Send>> {
+        self.request(Method::Post, path)
+    }
+
+    fn put<'a>(&'a self, path: &str) -> Pin<Box<dyn Future<Output = http::Response> + 'a + Send>> {
+        self.request(Method::Put, path)
+    }
 }

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -1,6 +1,6 @@
-use http_types::{Method, StatusCode, Url};
-use tide::{http, Request};
-
+mod test_utils;
+use test_utils::ServerTestingExt;
+use tide::{Request, StatusCode};
 async fn add_one(req: Request<()>) -> Result<String, tide::Error> {
     match req.param::<i64>("num") {
         Ok(num) => Ok((num + 1).to_string()),
@@ -29,188 +29,80 @@ async fn echo_path(req: Request<()>) -> Result<String, tide::Error> {
 async fn wildcard() {
     let mut app = tide::Server::new();
     app.at("/add_one/:num").get(add_one);
-
-    let req = http::Request::new(
-        Method::Get,
-        Url::parse("http://localhost/add_one/3").unwrap(),
-    );
-    let mut res: http::Response = app.respond(req).await.unwrap();
-    assert_eq!(res.status(), StatusCode::Ok);
-    assert_eq!(&res.body_string().await.unwrap(), "4");
-
-    let req = http::Request::new(
-        Method::Get,
-        Url::parse("http://localhost/add_one/-7").unwrap(),
-    );
-    let mut res: http::Response = app.respond(req).await.unwrap();
-    assert_eq!(res.status(), StatusCode::Ok);
-    assert_eq!(&res.body_string().await.unwrap(), "-6");
+    assert_eq!(app.get_body("/add_one/3").await, "4");
+    assert_eq!(app.get_body("/add_one/-7").await, "-6");
 }
 
 #[async_std::test]
 async fn invalid_segment_error() {
     let mut app = tide::new();
     app.at("/add_one/:num").get(add_one);
-
-    let req = http::Request::new(
-        Method::Get,
-        Url::parse("http://localhost/add_one/a").unwrap(),
-    );
-    let res: http::Response = app.respond(req).await.unwrap();
-    assert_eq!(res.status(), StatusCode::BadRequest);
+    assert_eq!(app.get("/add_one/a").await.status(), StatusCode::BadRequest);
 }
 
 #[async_std::test]
 async fn not_found_error() {
     let mut app = tide::new();
     app.at("/add_one/:num").get(add_one);
-
-    let req = http::Request::new(
-        Method::Get,
-        Url::parse("http://localhost/add_one/").unwrap(),
-    );
-    let res: http::Response = app.respond(req).await.unwrap();
-    assert_eq!(res.status(), StatusCode::NotFound);
+    assert_eq!(app.get("/add_one/").await.status(), StatusCode::NotFound);
 }
 
 #[async_std::test]
 async fn wild_path() {
     let mut app = tide::new();
     app.at("/echo/*path").get(echo_path);
-
-    let req = http::Request::new(
-        Method::Get,
-        Url::parse("http://localhost/echo/some_path").unwrap(),
+    assert_eq!(app.get_body("/echo/some_path").await, "some_path");
+    assert_eq!(
+        app.get_body("/echo/multi/segment/path").await,
+        "multi/segment/path"
     );
-    let mut res: http::Response = app.respond(req).await.unwrap();
-    assert_eq!(res.status(), StatusCode::Ok);
-    assert_eq!(&res.body_string().await.unwrap(), "some_path");
-
-    let req = http::Request::new(
-        Method::Get,
-        Url::parse("http://localhost/echo/multi/segment/path").unwrap(),
-    );
-    let mut res: http::Response = app.respond(req).await.unwrap();
-    assert_eq!(res.status(), StatusCode::Ok);
-    assert_eq!(&res.body_string().await.unwrap(), "multi/segment/path");
-
-    let req = http::Request::new(Method::Get, Url::parse("http://localhost/echo/").unwrap());
-    let mut res: http::Response = app.respond(req).await.unwrap();
-    assert_eq!(res.status(), StatusCode::NotFound);
-    assert_eq!(&res.body_string().await.unwrap(), "");
+    assert_eq!(app.get("/echo/").await.status(), StatusCode::NotFound);
 }
 
 #[async_std::test]
 async fn multi_wildcard() {
     let mut app = tide::new();
     app.at("/add_two/:one/:two/").get(add_two);
-
-    let req = http::Request::new(
-        Method::Get,
-        Url::parse("http://localhost/add_two/1/2/").unwrap(),
-    );
-    let mut res: http::Response = app.respond(req).await.unwrap();
-    assert_eq!(res.status(), StatusCode::Ok);
-    assert_eq!(&res.body_string().await.unwrap(), "3");
-
-    let req = http::Request::new(
-        Method::Get,
-        Url::parse("http://localhost/add_two/-1/2/").unwrap(),
-    );
-    let mut res: http::Response = app.respond(req).await.unwrap();
-    assert_eq!(res.status(), 200);
-    assert_eq!(&res.body_string().await.unwrap(), "1");
-
-    let req = http::Request::new(
-        Method::Get,
-        Url::parse("http://localhost/add_two/1").unwrap(),
-    );
-    let res: http::Response = app.respond(req).await.unwrap();
-    assert_eq!(res.status(), StatusCode::NotFound);
+    assert_eq!(app.get_body("/add_two/1/2/").await, "3");
+    assert_eq!(app.get_body("/add_two/-1/2/").await, "1");
+    assert_eq!(app.get("/add_two/1").await.status(), StatusCode::NotFound);
 }
 
 #[async_std::test]
 async fn wild_last_segment() {
     let mut app = tide::new();
     app.at("/echo/:path/*").get(echo_path);
-
-    let req = http::Request::new(
-        Method::Get,
-        Url::parse("http://localhost/echo/one/two").unwrap(),
-    );
-    let mut res: http::Response = app.respond(req).await.unwrap();
-    assert_eq!(res.status(), StatusCode::Ok);
-    assert_eq!(&res.body_string().await.unwrap(), "one");
-
-    let req = http::Request::new(
-        Method::Get,
-        Url::parse("http://localhost/echo/one/two/three/four").unwrap(),
-    );
-    let mut res: http::Response = app.respond(req).await.unwrap();
-    assert_eq!(res.status(), StatusCode::Ok);
-    assert_eq!(&res.body_string().await.unwrap(), "one");
+    assert_eq!(app.get_body("/echo/one/two").await, "one");
+    assert_eq!(app.get_body("/echo/one/two/three/four").await, "one");
 }
 
 #[async_std::test]
 async fn invalid_wildcard() {
     let mut app = tide::new();
     app.at("/echo/*path/:one/").get(echo_path);
-
-    let req = http::Request::new(
-        Method::Get,
-        Url::parse("http://localhost/echo/one/two").unwrap(),
+    assert_eq!(
+        app.get("/echo/one/two").await.status(),
+        StatusCode::NotFound
     );
-    let res: http::Response = app.respond(req).await.unwrap();
-    assert_eq!(res.status(), StatusCode::NotFound);
 }
 
 #[async_std::test]
 async fn nameless_wildcard() {
     let mut app = tide::Server::new();
     app.at("/echo/:").get(|_| async { Ok("") });
-
-    let req = http::Request::new(
-        Method::Get,
-        Url::parse("http://localhost/echo/one/two").unwrap(),
+    assert_eq!(
+        app.get("/echo/one/two").await.status(),
+        StatusCode::NotFound
     );
-    let res: http::Response = app.respond(req).await.unwrap();
-    assert_eq!(res.status(), StatusCode::NotFound);
-
-    let req = http::Request::new(
-        Method::Get,
-        Url::parse("http://localhost/echo/one").unwrap(),
-    );
-    let res: http::Response = app.respond(req).await.unwrap();
-    assert_eq!(res.status(), StatusCode::Ok);
+    assert_eq!(app.get("/echo/one").await.status(), StatusCode::Ok);
 }
 
 #[async_std::test]
 async fn nameless_internal_wildcard() {
     let mut app = tide::new();
     app.at("/echo/:/:path").get(echo_path);
-
-    let req = http::Request::new(
-        Method::Get,
-        Url::parse("http://localhost/echo/one").unwrap(),
-    );
-    let res: http::Response = app.respond(req).await.unwrap();
-    assert_eq!(res.status(), StatusCode::NotFound);
-
-    let req = http::Request::new(
-        Method::Get,
-        Url::parse("http://localhost/echo/one/two").unwrap(),
-    );
-    let mut res: http::Response = app.respond(req).await.unwrap();
-    assert_eq!(res.status(), StatusCode::Ok);
-    assert_eq!(&res.body_string().await.unwrap(), "two");
-
-    let req = http::Request::new(
-        Method::Get,
-        Url::parse("http://localhost/echo/one/two").unwrap(),
-    );
-    let mut res: http::Response = app.respond(req).await.unwrap();
-    assert_eq!(res.status(), StatusCode::Ok);
-    assert_eq!(&res.body_string().await.unwrap(), "two");
+    assert_eq!(app.get("/echo/one").await.status(), StatusCode::NotFound);
+    assert_eq!(app.get_body("/echo/one/two").await, "two");
 }
 
 #[async_std::test]
@@ -221,11 +113,7 @@ async fn nameless_internal_wildcard2() {
         Ok("")
     });
 
-    let req = http::Request::new(
-        Method::Get,
-        Url::parse("http://localhost/echo/one/two").unwrap(),
-    );
-    let _: tide::Response = app.respond(req).await.unwrap();
+    app.get("/echo/one/two").await;
 }
 
 #[async_std::test]
@@ -233,12 +121,5 @@ async fn ambiguous_router_wildcard_vs_star() {
     let mut app = tide::new();
     app.at("/:one/:two").get(|_| async { Ok("one/two") });
     app.at("/posts/*").get(|_| async { Ok("posts/*") });
-    let req = http::Request::new(
-        Method::Get,
-        Url::parse("http://localhost/posts/10").unwrap(),
-    );
-
-    let mut response: http_types::Response = app.respond(req).await.unwrap();
-    let body_string = response.body_string().await.unwrap();
-    assert_eq!(body_string, "posts/*");
+    assert_eq!(app.get_body("/posts/10").await, "posts/*");
 }


### PR DESCRIPTION
This is a first step in the direction of a [superagent](https://visionmedia.github.io/superagent/)/[supertest](https://github.com/visionmedia/supertest) type testing utility for tide. Currently it just supports simple requests and is not exported for usage outside of tide, but the intent is that as it accumulates more features and stabilizes, it might eventually be public under a tide::testing namespace for tide apps to use.

```rust
// this:
    let req = Request::new(
        Method::Get,
        Url::parse("http://example.com/foo/echo").unwrap(),
    );
    let mut res: Response = app.respond(req).await.unwrap();

// becomes:
    let mut res = app.get("/foo/echo").await;
```


and

```rust
 // this:
    let req = http::Request::new(
        Method::Get,
        Url::parse("http://localhost/add_one/3").unwrap(),
    );
    let mut res: http::Response = app.respond(req).await.unwrap();
    assert_eq!(&res.body_string().await.unwrap(), "4");

// becomes:
    assert_eq!(app.get_body("/add_one/3").await, "4");
```
