### PR TITLE
make ServeDir public

### DIFF
--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -1,3 +1,3 @@
 mod serve_dir;
 
-pub(crate) use serve_dir::ServeDir;
+pub use serve_dir::ServeDir;

--- a/src/fs/serve_dir.rs
+++ b/src/fs/serve_dir.rs
@@ -1,10 +1,18 @@
 use crate::log;
+use crate::utils::BoxFuture;
 use crate::{Body, Endpoint, Request, Response, Result, StatusCode};
 
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
-type BoxFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + 'a + Send>>;
+/// An endpoint for serving static files from a base local file system
+/// `dir`, mounted at a given route `prefix`.  As an example,
+/// `ServeDir::new("/static", "./build/assets")` would resolve a
+/// request to `/static/index.html` to
+/// `(pwd)/build/assets/index.html`.
+///
+/// If that file did not exist, ServeDir would send a 404 Not found by default.
+#[derive(Debug, Clone)]
 pub struct ServeDir {
     prefix: String,
     dir: PathBuf,
@@ -12,16 +20,24 @@ pub struct ServeDir {
 
 impl ServeDir {
     /// Create a new instance of `ServeDir`.
-    pub(crate) fn new(prefix: String, dir: PathBuf) -> Self {
-        Self { prefix, dir }
+    pub fn new(prefix: impl Into<String>, dir: impl Into<PathBuf>) -> Self {
+        Self {
+            prefix: prefix.into(),
+            dir: dir.into(),
+        }
     }
-}
 
-impl<State> Endpoint<State> for ServeDir {
-    fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, Result> {
-        let path = req.url().path();
-        let path = path.trim_start_matches(&self.prefix);
-        let path = path.trim_start_matches('/');
+    /// Resolves a local filesystem path from a request's url path,
+    /// taking the ServeDir's route `prefix` into consideration. If
+    /// the path is not within the ServeDir's `dir`, this method
+    /// returns None.
+    pub fn resolve_path<State>(&self, request: &Request<State>) -> Option<PathBuf> {
+        let path = request
+            .url()
+            .path()
+            .trim_start_matches(&self.prefix)
+            .trim_start_matches('/');
+
         let mut file_path = self.dir.clone();
         for p in Path::new(path) {
             if p == OsStr::new(".") {
@@ -33,17 +49,29 @@ impl<State> Endpoint<State> for ServeDir {
             }
         }
 
-        log::info!("Requested file: {:?}", file_path);
+        if file_path.starts_with(&self.dir) {
+            log::info!("Requested file: {:?}", file_path);
+            Some(file_path)
+        } else {
+            log::warn!("Unauthorized attempt to read: {:?}", file_path);
+            None
+        }
+    }
+}
 
+impl<State> Endpoint<State> for ServeDir {
+    fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, Result> {
+        let file_path = self.resolve_path(&req);
         Box::pin(async move {
-            if !file_path.starts_with(&self.dir) {
-                log::warn!("Unauthorized attempt to read: {:?}", file_path);
-                return Ok(Response::new(StatusCode::Forbidden));
+            if let Some(file_path) = file_path {
+                if let Ok(body) = Body::from_file(&file_path).await {
+                    Ok(body.into())
+                } else {
+                    Ok(Response::new(StatusCode::NotFound))
+                }
+            } else {
+                Ok(Response::new(StatusCode::Forbidden))
             }
-            let body = Body::from_file(&file_path).await?;
-            let mut res = Response::new(StatusCode::Ok);
-            res.set_body(body);
-            Ok(res)
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,6 @@
 
 mod cookies;
 mod endpoint;
-mod fs;
 mod middleware;
 mod redirect;
 mod request;
@@ -207,6 +206,7 @@ pub mod router;
 mod server;
 
 pub mod convert;
+pub mod fs;
 pub mod log;
 pub mod prelude;
 pub mod security;


### PR DESCRIPTION
In trying to find a workaround for #593, it turned out to be really useful to be able to create a ServeDir outside of tide itself.  With this PR, the following workaround for conflicting routing is possible:

```rust
use tide::{fs::ServeDir, Endpoint, Request};

#[async_std::main]
async fn main() -> Result<(), std::io::Error> {
    tide::log::start();
    let mut app = tide::new();
    app.at("/static").serve_dir("./src")?;
    app.at("/:owner/:repo")
        .get(|request: Request<_>| async move {
            if request.param::<String>("owner").unwrap() == "static" {
                ServeDir::new("/static", "./src").call(request).await
            } else {
                Ok("do whatever we'd be doing otherwise".into())
            }
        });

    app.listen("127.0.0.1:8080").await?;

    Ok(())
}
```

---

Although this use is not especially normal, there might reasonably be other situations in which people would want to conditionally use ServeDir logic on a route that is not mounted by Route::serve_dir