### PR TITLE
use route-recognizer 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,9 @@ async-std = { version = "1.6.0", features = ["unstable"] }
 femme = "2.0.1"
 http-types = "2.0.1"
 kv-log-macro = "1.0.4"
-route-recognizer = "0.1.13"
 serde = "1.0.102"
 serde_json = "1.0.41"
+route-recognizer = "0.2.0"
 
 [dev-dependencies]
 async-std = { version = "1.6.0", features = ["unstable", "attributes"] }


### PR DESCRIPTION
closes #593 
refs http-rs/route-recognizer#40

This doesn't seem like an ideal solution, but this resolves the conflicting routes issue until there's a route-recognizer release