### PR TITLE
Change log macro to be directly referenced

### DIFF
--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -27,11 +27,11 @@ pub use middleware::LogMiddleware;
 /// Start logging.
 pub fn start() {
     femme::start();
-    crate::log::info!("Logger started", { level: "Info" });
+    info!("Logger started", { level: "Info" });
 }
 
 /// Start logging with a log level.
 pub fn with_level(level: LevelFilter) {
     femme::with_level(level);
-    crate::log::info!("Logger started", { level: format!("{}", level) });
+    info!("Logger started", { level: format!("{}", level) });
 }


### PR DESCRIPTION
Someone had an issue compiling Tide, and although I can't replicate it seems maybe some compiler versions/env don't like this circular reference (more of a guess). I don't see any reason why this shouldn't be this way anyway, but let me know if I'm missing something :)

https://github.com/ChainSafe/forest/issues/510