### PR TITLE
Response: remove #[must_use] for set_status()

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -43,7 +43,6 @@ impl Response {
     }
 
     /// Set the statuscode.
-    #[must_use]
     pub fn set_status(&mut self, status: crate::StatusCode) {
         self.res.set_status(status);
     }


### PR DESCRIPTION
This was missed in 2baf279 and causes unnecessary warnings.