### PR TITLE
restore .github docs

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,75 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of
+experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
+address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+professional setting
+
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at yoshuawuyts@gmail.com, or through
+IRC. All complaints will be reviewed and investigated and will result in a
+response that is deemed necessary and appropriate to the circumstances. The
+project team is obligated to maintain confidentiality with regard to the
+reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 1.4,
+available at
+https://www.contributor-covenant.org/version/1/4/code-of-conduct.html

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing
+Contributions include code, documentation, answering user questions, running the
+project's infrastructure, and advocating for all types of users.
+
+The project welcomes all contributions from anyone willing to work in good faith
+with other contributors and the community. No contribution is too small and all
+contributions are valued.
+
+This guide explains the process for contributing to the project's GitHub
+Repository.
+
+- [Code of Conduct](#code-of-conduct)
+- [Bad Actors](#bad-actors)
+- [Developer Certificate of Origin](#developer-certificate-of-origin)
+
+## Code of Conduct
+The project has a [Code of Conduct](./CODE_OF_CONDUCT.md) that *all*
+contributors are expected to follow. This code describes the *minimum* behavior
+expectations for all contributors.
+
+As a contributor, how you choose to act and interact towards your
+fellow contributors, as well as to the community, will reflect back not only
+on yourself but on the project as a whole. The Code of Conduct is designed and
+intended, above all else, to help establish a culture within the project that
+allows anyone and everyone who wants to contribute to feel safe doing so.
+
+Should any individual act in any way that is considered in violation of the
+[Code of Conduct](./CODE_OF_CONDUCT.md), corrective actions will be taken. It is
+possible, however, for any individual to *act* in such a manner that is not in
+violation of the strict letter of the Code of Conduct guidelines while still
+going completely against the spirit of what that Code is intended to accomplish.
+
+Open, diverse, and inclusive communities live and die on the basis of trust.
+Contributors can disagree with one another so long as they trust that those
+disagreements are in good faith and everyone is working towards a common
+goal.
+
+## Bad Actors
+All contributors to tacitly agree to abide by both the letter and
+spirit of the [Code of Conduct](./CODE_OF_CONDUCT.md). Failure, or
+unwillingness, to do so will result in contributions being respectfully
+declined.
+
+A *bad actor* is someone who repeatedly violates the *spirit* of the Code of
+Conduct through consistent failure to self-regulate the way in which they
+interact with other contributors in the project. In doing so, bad actors
+alienate other contributors, discourage collaboration, and generally reflect
+poorly on the project as a whole.
+
+Being a bad actor may be intentional or unintentional. Typically, unintentional
+bad behavior can be easily corrected by being quick to apologize and correct
+course *even if you are not entirely convinced you need to*. Giving other
+contributors the benefit of the doubt and having a sincere willingness to admit
+that you *might* be wrong is critical for any successful open collaboration.
+
+Don't be a bad actor.
+
+## Developer Certificate of Origin
+All contributors must read and agree to the [Developer Certificate of
+Origin (DCO)](../CERTIFICATE).
+
+The DCO allows us to accept contributions from people to the project, similarly
+to how a license allows us to distribute our code.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+---
+<!--- Provide a general summary of the issue in the Title above -->
+## Bug Report
+
+#### Current Behavior
+<!--- A clear and concise description of the behavior -->
+
+
+#### Code/Gist
+<!--- Any code, gist links, or repo links you have available that would be helpful for debugging -->
+
+
+#### Expected behavior/code
+<!--- A clear and concise description of what you expected to happen (or code). -->
+
+
+#### Environment
+<!--
+- Rust toolchain version(s): [e.g. nightly-2018-10-01-x86_64-apple-darwin]
+- OS: [e.g. OSX 10.13.4, Windows 10]
+-->
+- Rust toolchain version(s):
+- OS: [e.g. OSX 10.13.4, Windows 10]
+
+#### Possible Solution
+<!--- Only if you have suggestions on a fix for the bug -->
+
+#### Additional context/Screenshots
+<!--- Add any other context about the problem here. If applicable, add screenshots to help explain. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+---
+<!--- Provide a general summary of the issue in the Title above -->
+## Feature Request
+
+## Detailed Description
+<!--- Provide a detailed description of the change or addition you are proposing -->
+
+## Context
+<!--- Why is this change important to you? How would you use it? -->
+<!--- How can it benefit other users? -->
+
+## Possible Implementation
+<!--- Not obligatory, but suggest an idea for implementing addition or change -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,13 @@
+---
+name: Question
+about: Ask any question about the Tide framework
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+## Question
+
+<!--- Provide your detailed question here -->
+
+## Additional context
+<!--- Optionally, supply any additional context of what you are trying to do -->
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed.

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+daysUntilStale: 90
+daysUntilClose: 7
+exemptLabels:
+  - pinned
+  - security
+exemptProjects: false
+exemptMilestones: false
+staleLabel: wontfix
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+unmarkComment: false
+closeComment: false
+limitPerRun: 30


### PR DESCRIPTION
On #337, the .github folder was deleted, including important documents such as CONTRIBUTING and CODE_OF_CONDUCT. I opened this PR to restore the files that could be considered relevant. Also, it aims to solve #421 and #491. 

This first commit just restores the documents as they were before #337. Therefore they may need to be updated and some of those files may not be necessary.