### PR TITLE
handle tcp client disconnection

### DIFF
--- a/tests/chunked-encode-small.rs
+++ b/tests/chunked-encode-small.rs
@@ -1,6 +1,5 @@
 mod test_utils;
 use async_std::io::Cursor;
-use async_std::prelude::*;
 use async_std::task;
 use std::time::Duration;
 
@@ -17,26 +16,24 @@ const TEXT: &'static str = concat![
 #[async_std::test]
 async fn chunked_large() -> Result<(), http_types::Error> {
     let port = test_utils::find_port().await;
+
     let server = task::spawn(async move {
         let mut app = tide::new();
         app.at("/")
             .get(|_| async { Ok(Body::from_reader(Cursor::new(TEXT), None)) });
-        app.listen(("localhost", port)).await?;
-        Result::<(), http_types::Error>::Ok(())
+        app.listen(("localhost", port)).await
     });
 
-    let client = task::spawn(async move {
-        task::sleep(Duration::from_millis(100)).await;
-        let mut res = surf::get(format!("http://localhost:{}", port))
-            .await
-            .unwrap();
-        assert_eq!(res.status(), 200);
-        assert_eq!(res.header("transfer-encoding").unwrap(), "chunked");
-        assert!(res.header("content-length").is_none());
-        let string = res.body_string().await.unwrap();
-        assert_eq!(string, TEXT.to_string());
-        Ok(())
-    });
+    task::sleep(Duration::from_millis(100)).await;
+    let mut res = surf::get(format!("http://localhost:{}", port))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 200);
+    assert_eq!(res.header("transfer-encoding").unwrap(), "chunked");
+    assert!(res.header("content-length").is_none());
+    let string = res.body_string().await.unwrap();
+    assert_eq!(string, TEXT.to_string());
 
-    server.race(client).await
+    server.cancel().await;
+    Ok(())
 }

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,101 +1,85 @@
 mod test_utils;
-use async_std::prelude::*;
 use async_std::task;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use tide::{Body, Request};
 
-#[test]
-fn hello_world() -> Result<(), http_types::Error> {
-    task::block_on(async {
-        let port = test_utils::find_port().await;
-        let server = task::spawn(async move {
-            let mut app = tide::new();
-            app.at("/").get(move |mut req: Request<()>| async move {
-                assert_eq!(req.body_string().await.unwrap(), "nori".to_string());
-                assert!(req.local_addr().unwrap().contains(&port.to_string()));
-                assert!(req.peer_addr().is_some());
-                Ok("says hello")
-            });
-            app.listen(("localhost", port)).await?;
-            Result::<(), http_types::Error>::Ok(())
+#[async_std::test]
+async fn hello_world() -> Result<(), http_types::Error> {
+    let port = test_utils::find_port().await;
+    let server = task::spawn(async move {
+        let mut app = tide::new();
+        app.at("/").get(move |mut req: Request<()>| async move {
+            assert_eq!(req.body_string().await.unwrap(), "nori".to_string());
+            assert!(req.local_addr().unwrap().contains(&port.to_string()));
+            assert!(req.peer_addr().is_some());
+            Ok("says hello")
         });
+        app.listen(("localhost", port)).await
+    });
 
-        let client = task::spawn(async move {
-            task::sleep(Duration::from_millis(100)).await;
-            let string = surf::get(format!("http://localhost:{}", port))
-                .body_string("nori".to_string())
-                .recv_string()
-                .await
-                .unwrap();
-            assert_eq!(string, "says hello");
-            Ok(())
-        });
+    task::sleep(Duration::from_millis(100)).await;
+    let string = surf::get(format!("http://localhost:{}", port))
+        .body_string("nori".to_string())
+        .recv_string()
+        .await
+        .unwrap();
+    assert_eq!(string, "says hello");
 
-        server.race(client).await
-    })
+    server.cancel().await;
+    Ok(())
 }
 
-#[test]
-fn echo_server() -> Result<(), http_types::Error> {
-    task::block_on(async {
-        let port = test_utils::find_port().await;
-        let server = task::spawn(async move {
-            let mut app = tide::new();
-            app.at("/").get(|req| async move { Ok(req) });
+#[async_std::test]
+async fn echo_server() -> Result<(), http_types::Error> {
+    let port = test_utils::find_port().await;
+    let server = task::spawn(async move {
+        let mut app = tide::new();
+        app.at("/").get(|req| async move { Ok(req) });
 
-            app.listen(("localhost", port)).await?;
-            Result::<(), http_types::Error>::Ok(())
-        });
+        app.listen(("localhost", port)).await
+    });
 
-        let client = task::spawn(async move {
-            task::sleep(Duration::from_millis(100)).await;
-            let string = surf::get(format!("http://localhost:{}", port))
-                .body_string("chashu".to_string())
-                .recv_string()
-                .await
-                .unwrap();
-            assert_eq!(string, "chashu".to_string());
-            Ok(())
-        });
+    task::sleep(Duration::from_millis(100)).await;
+    let string = surf::get(format!("http://localhost:{}", port))
+        .body_string("chashu".to_string())
+        .recv_string()
+        .await
+        .unwrap();
+    assert_eq!(string, "chashu".to_string());
 
-        server.race(client).await
-    })
+    server.cancel().await;
+    Ok(())
 }
 
-#[test]
-fn json() -> Result<(), http_types::Error> {
+#[async_std::test]
+async fn json() -> Result<(), http_types::Error> {
     #[derive(Deserialize, Serialize)]
     struct Counter {
         count: usize,
     }
 
-    task::block_on(async {
-        let port = test_utils::find_port().await;
-        let server = task::spawn(async move {
-            let mut app = tide::new();
-            app.at("/").get(|mut req: Request<()>| async move {
-                let mut counter: Counter = req.body_json().await.unwrap();
-                assert_eq!(counter.count, 0);
-                counter.count = 1;
-                Ok(Body::from_json(&counter)?)
-            });
-            app.listen(("localhost", port)).await?;
-            Result::<(), http_types::Error>::Ok(())
+    let port = test_utils::find_port().await;
+    let server = task::spawn(async move {
+        let mut app = tide::new();
+        app.at("/").get(|mut req: Request<()>| async move {
+            let mut counter: Counter = req.body_json().await.unwrap();
+            assert_eq!(counter.count, 0);
+            counter.count = 1;
+            Ok(Body::from_json(&counter)?)
         });
+        app.listen(("localhost", port)).await
+    });
 
-        let client = task::spawn(async move {
-            task::sleep(Duration::from_millis(100)).await;
-            let counter: Counter = surf::get(format!("http://localhost:{}", &port))
-                .body_json(&Counter { count: 0 })?
-                .recv_json()
-                .await
-                .unwrap();
-            assert_eq!(counter.count, 1);
-            Ok(())
-        });
+    task::sleep(Duration::from_millis(100)).await;
+    let counter: Counter = surf::get(format!("http://localhost:{}", &port))
+        .body_json(&Counter { count: 0 })?
+        .recv_json()
+        .await
+        .unwrap();
+    assert_eq!(counter.count, 1);
 
-        server.race(client).await
-    })
+    server.cancel().await;
+    Ok(())
 }


### PR DESCRIPTION
## Description
This PR provides a way for the endpoint future to be dropped if the client disconnects

## Motivation and Context
Run this code on tide master
```rust
#[async_std::main]
async fn main() -> Result<(), std::io::Error> {
    tide::log::start();
    let mut app = tide::new();
    app.at("/").get(|_| async {
        let mut i: i32 = 0;
        loop {
            i += 1;
            println!("{:?}", i);
            async_std::task::sleep(std::time::Duration::from_secs(1)).await;
        }

        #[allow(unreachable_code)]
        Ok("unreachable")
    });
    app.listen("127.0.0.1:8080").await?;
    Ok(())
}
```
and `curl 127.0.0.1:8080` and then C-c.  The server will continue printing until it's stopped.

With this change, the server stops printing when the client disconnects.

Although this is a contrived example, this change allows potentially long-running operations to be canceled by early-disconnect.

