### PR TITLE
Send an empty response body to HEAD request

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,5 @@ required-features = ["unstable"]
 name = "router"
 harness = false
 
+[patch.crates-io]
+http-types = { git = "https://github.com/jbr/http-types", branch = "head-body" }

--- a/src/response.rs
+++ b/src/response.rs
@@ -306,6 +306,12 @@ impl AsMut<http::Headers> for Response {
     }
 }
 
+impl AsMut<Body> for Response {
+    fn as_mut(&mut self) -> &mut Body {
+        self.res.as_mut()
+    }
+}
+
 impl Into<http::Response> for Response {
     fn into(self) -> http_types::Response {
         self.res

--- a/tests/head_response_empty_body.rs
+++ b/tests/head_response_empty_body.rs
@@ -1,0 +1,37 @@
+use std::future::Future;
+use std::pin::Pin;
+use tide::http::{self, Method, Url};
+use tide::{Body, Next, Request, Response, Result};
+
+// this should be moved into tide, but not sure if as a middleware or hardcoded
+fn head_body<'a, State: Send + Sync + 'static>(
+    request: Request<State>,
+    next: Next<'a, State>,
+) -> Pin<Box<dyn Future<Output = Result> + Send + 'a>> {
+    Box::pin(async {
+        let method = request.method();
+        let result = next.run(request).await;
+        let mut response = result.unwrap_or_else(|e| Response::new(e.status()));
+
+        if method == Method::Head {
+            let body: &mut Body = response.as_mut();
+            body.make_head();
+        }
+
+        Ok(response)
+    })
+}
+
+#[async_std::test]
+async fn head_response_empty() {
+    let mut app = tide::new();
+    app.at("/")
+        .get(|_| async { Ok("this shouldn't exist in the body of a HEAD response") });
+
+    app.middleware(head_body);
+    let req = http::Request::new(Method::Head, Url::parse("http://example.com/").unwrap());
+    let mut res: http::Response = app.respond(req).await.unwrap();
+
+    let body = res.body_string().await.unwrap();
+    assert!(body.is_empty());
+}

--- a/tests/head_response_empty_body.rs
+++ b/tests/head_response_empty_body.rs
@@ -1,36 +1,13 @@
-use std::future::Future;
-use std::pin::Pin;
-use tide::http::{self, Method, Url};
-use tide::{Body, Next, Request, Response, Result};
-
-// this should be moved into tide, but not sure if as a middleware or hardcoded
-fn head_body<'a, State: Send + Sync + 'static>(
-    request: Request<State>,
-    next: Next<'a, State>,
-) -> Pin<Box<dyn Future<Output = Result> + Send + 'a>> {
-    Box::pin(async {
-        let method = request.method();
-        let result = next.run(request).await;
-        let mut response = result.unwrap_or_else(|e| Response::new(e.status()));
-
-        if method == Method::Head {
-            let body: &mut Body = response.as_mut();
-            body.make_head();
-        }
-
-        Ok(response)
-    })
-}
-
+use tide::http::{Method, Request, Response, Url};
 #[async_std::test]
 async fn head_response_empty() {
     let mut app = tide::new();
+
     app.at("/")
         .get(|_| async { Ok("this shouldn't exist in the body of a HEAD response") });
 
-    app.middleware(head_body);
-    let req = http::Request::new(Method::Head, Url::parse("http://example.com/").unwrap());
-    let mut res: http::Response = app.respond(req).await.unwrap();
+    let req = Request::new(Method::Head, Url::parse("http://example.com/").unwrap());
+    let mut res: Response = app.respond(req).await.unwrap();
 
     let body = res.body_string().await.unwrap();
     assert!(body.is_empty());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
HTTP HEAD requests [MUST NOT](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.4) return a response body

## Motivation and Context
Tide currently returns a response body, in violation of the spec, as reported in linked issue
Closes #623

## How Has This Been Tested?

Re-added the test mentioned in #623 and updated it for current tide api.

## Upstream changes:
This depends on http-rs/http-types#190

## Implementation concerns:
I'm not sure if this should be implemented as a default middleware and initially implemented it as one, but I cannot think of a situation in which tide users would want to break spec.
