### PR TITLE
update to async-sse 4.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ __internal__bench = []
 
 [dependencies]
 async-h1 = { version = "2.0.1", optional = true }
-async-sse = "3.0.1"
+async-sse = "4.0.0"
 async-std = { version = "1.6.0", features = ["unstable"] }
 femme = "2.0.1"
 http-types = "2.2.1"


### PR DESCRIPTION
3.0.1 was a breaking change, so it has been republished as 4.0.0