### PR TITLE
Multi item log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ kv-log-macro = "1.0.4"
 serde = "1.0.102"
 serde_json = "1.0.41"
 route-recognizer = "0.2.0"
+logtest = "2.0.0"
 
 [dev-dependencies]
 async-std = { version = "1.6.0", features = ["unstable", "attributes"] }

--- a/src/server.rs
+++ b/src/server.rs
@@ -311,7 +311,7 @@ impl<State: Send + Sync + 'static> Server<State> {
         } else {
             "release"
         };
-        log::info!("Server listening", { address: addr, target: target, tls: tls });
+        log::info!("Server listening on {}", addr, { address: addr, target: target, tls: tls });
 
         let mut incoming = listener.incoming();
         while let Some(stream) = incoming.next().await {
@@ -346,7 +346,7 @@ impl<State: Send + Sync + 'static> Server<State> {
             .ok()
             .map(|addr| format!("unix://{:?}", addr));
 
-        log::info!("Server listening", { address: address, target: target, tls: tls });
+        log::info!("Server listening on {}", address, { address: address, target: target, tls: tls });
 
         let mut incoming = listener.incoming();
         while let Some(stream) = incoming.next().await {

--- a/src/server.rs
+++ b/src/server.rs
@@ -341,12 +341,8 @@ impl<State: Send + Sync + 'static> Server<State> {
             "release"
         };
 
-        let address = listener
-            .local_addr()
-            .ok()
-            .map(|addr| format!("unix://{:?}", addr));
-
-        log::info!("Server listening on {}", address, { address: address, target: target, tls: tls });
+        let addr = format!("unix://{:?}", listener.local_addr()?);
+        log::info!("Server listening on {}", addr, { address: addr, target: target, tls: tls });
 
         let mut incoming = listener.incoming();
         while let Some(stream) = incoming.next().await {

--- a/tests/log.rs
+++ b/tests/log.rs
@@ -1,0 +1,17 @@
+use async_std::prelude::*;
+use std::time::Duration;
+
+mod test_utils;
+
+#[async_std::test]
+async fn start_server_log() {
+    let logger = logtest::start();
+
+    let port = test_utils::find_port().await;
+    let app = tide::new();
+    let res = app.listen(("localhost", port)).timeout(Duration::from_millis(60)).await;
+    assert!(res.is_err());
+
+    let record = logger.filter(|rec| rec.args().starts_with("Server listening")).next().unwrap();
+    assert_eq!(record.args(), format!("Server listening on http://[::1]:{}", port));
+}

--- a/tests/log.rs
+++ b/tests/log.rs
@@ -9,9 +9,18 @@ async fn start_server_log() {
 
     let port = test_utils::find_port().await;
     let app = tide::new();
-    let res = app.listen(("localhost", port)).timeout(Duration::from_millis(60)).await;
+    let res = app
+        .listen(("localhost", port))
+        .timeout(Duration::from_millis(60))
+        .await;
     assert!(res.is_err());
 
-    let record = logger.filter(|rec| rec.args().starts_with("Server listening")).next().unwrap();
-    assert_eq!(record.args(), format!("Server listening on http://[::1]:{}", port));
+    let record = logger
+        .filter(|rec| rec.args().starts_with("Server listening"))
+        .next()
+        .unwrap();
+    assert_eq!(
+        record.args(),
+        format!("Server listening on http://[::1]:{}", port)
+    );
 }


### PR DESCRIPTION
Print the address in the log string. This adds some redundancy, but this helps bridge this information to non-kv-aware log impls such as the log <-> tracing bridge. Ran into this limitation during a project, and this will help with that. Thanks!