### PR TITLE
Make `ServeDir` return 404 if file does not exists

### DIFF
--- a/src/fs/serve_dir.rs
+++ b/src/fs/serve_dir.rs
@@ -61,10 +61,8 @@ mod test {
 
     use async_std::sync::Arc;
 
-    use std::{
-        fs::{self, File},
-        io::Write,
-    };
+    use std::fs::{self, File};
+    use std::io::Write;
 
     fn serve_dir(tempdir: &tempfile::TempDir) -> crate::Result<ServeDir> {
         let static_dir = tempdir.path().join("static");
@@ -94,11 +92,11 @@ mod test {
 
         let req = request("static/foo");
 
-        let resp = serve_dir.call(req).await.unwrap();
-        let mut resp: crate::http::Response = resp.into();
+        let res = serve_dir.call(req).await.unwrap();
+        let mut res: crate::http::Response = resp.into();
 
-        assert_eq!(resp.status(), 200);
-        assert_eq!(resp.body_string().await.unwrap(), "Foobar");
+        assert_eq!(res.status(), 200);
+        assert_eq!(res.body_string().await.unwrap(), "Foobar");
     }
 
     #[async_std::test]
@@ -108,9 +106,9 @@ mod test {
 
         let req = request("static/bar");
 
-        let resp = serve_dir.call(req).await.unwrap();
-        let resp: crate::http::Response = resp.into();
+        let res = serve_dir.call(req).await.unwrap();
+        let res: crate::http::Response = resp.into();
 
-        assert_eq!(resp.status(), 404);
+        assert_eq!(res.status(), 404);
     }
 }

--- a/src/fs/serve_dir.rs
+++ b/src/fs/serve_dir.rs
@@ -93,7 +93,7 @@ mod test {
         let req = request("static/foo");
 
         let res = serve_dir.call(req).await.unwrap();
-        let mut res: crate::http::Response = resp.into();
+        let mut res: crate::http::Response = res.into();
 
         assert_eq!(res.status(), 200);
         assert_eq!(res.body_string().await.unwrap(), "Foobar");
@@ -107,7 +107,7 @@ mod test {
         let req = request("static/bar");
 
         let res = serve_dir.call(req).await.unwrap();
-        let res: crate::http::Response = resp.into();
+        let res: crate::http::Response = res.into();
 
         assert_eq!(res.status(), 404);
     }

--- a/tests/serve_dir.rs
+++ b/tests/serve_dir.rs
@@ -1,0 +1,45 @@
+use tide::{http, Result, Server};
+
+use std::{
+    fs::{self, File},
+    io::Write,
+};
+
+fn app(tempdir: &tempfile::TempDir) -> Result<Server<()>> {
+    let static_dir = tempdir.path().join("static");
+    fs::create_dir(&static_dir)?;
+
+    let file_path = static_dir.join("foo");
+    let mut file = File::create(&file_path)?;
+    write!(file, "Foobar")?;
+
+    let mut app = Server::new();
+    app.at("/static/").serve_dir(static_dir.to_str().unwrap())?;
+
+    Ok(app)
+}
+
+fn request(path: &str) -> http_types::Request {
+    http_types::Request::get(
+        http_types::Url::parse(&format!("http://localhost/static/{}", path)).unwrap(),
+    )
+}
+
+#[async_std::test]
+async fn ok() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let app = app(&tempdir).unwrap();
+    let mut res: http::Response = app.respond(request("foo")).await.unwrap();
+
+    assert_eq!(res.status(), 200);
+    assert_eq!(res.body_string().await.unwrap().as_str(), "Foobar");
+}
+
+#[async_std::test]
+async fn not_found() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let app = app(&tempdir).unwrap();
+    let res: http::Response = app.respond(request("bar")).await.unwrap();
+
+    assert_eq!(res.status(), 404);
+}

--- a/tests/serve_dir.rs
+++ b/tests/serve_dir.rs
@@ -1,9 +1,7 @@
 use tide::{http, Result, Server};
 
-use std::{
-    fs::{self, File},
-    io::Write,
-};
+use std::fs::{self, File};
+use std::io::Write;
 
 fn app(tempdir: &tempfile::TempDir) -> Result<Server<()>> {
     let static_dir = tempdir.path().join("static");


### PR DESCRIPTION
## Description

Make `ServeDir` return `404 Not Found` response when the requested file does not exist.

## Motivation and Context

`ServeDir`, the internal static file serving endpoint, returns 500 when the file does not exist. But I expected 404.

## How Has This Been Tested?

`ServeDir` did not have any test, so I added some unit tests that call the `call` method directly and some integration tests that request to `ServeDir` using `Route::serve_dir`.

Unfortunately, I could not find any test case to produce a `401 Forbidden` error. The `http_types::Url` type seems to normalize the path segments so I couldn't produce any URL path that refers outside of the desired directory.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
