### PR TITLE
use async_trait to simplify async signatures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ serde = "1.0.102"
 serde_json = "1.0.41"
 route-recognizer = "0.2.0"
 logtest = "2.0.0"
+async-trait = "0.1.36"
 
 [dev-dependencies]
 async-std = { version = "1.6.0", features = ["unstable", "attributes"] }

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -61,7 +61,7 @@ impl RequestCounterMiddleware {
 
 struct RequestCount(usize);
 
-#[async_trait::async_trait]
+#[tide::utils::async_trait]
 impl<State: Send + Sync + 'static> Middleware<State> for RequestCounterMiddleware {
     async fn handle(&self, mut req: Request<State>, next: Next<'_, State>) -> Result {
         let count = self.requests_counted.fetch_add(1, Ordering::Relaxed);

--- a/src/log/middleware.rs
+++ b/src/log/middleware.rs
@@ -1,5 +1,4 @@
 use crate::log;
-use crate::utils::BoxFuture;
 use crate::{Middleware, Next, Request};
 
 /// Log all incoming requests and responses.
@@ -75,12 +74,9 @@ impl LogMiddleware {
     }
 }
 
+#[async_trait::async_trait]
 impl<State: Send + Sync + 'static> Middleware<State> for LogMiddleware {
-    fn handle<'a>(
-        &'a self,
-        ctx: Request<State>,
-        next: Next<'a, State>,
-    ) -> BoxFuture<'a, crate::Result> {
-        Box::pin(async move { self.log(ctx, next).await })
+    async fn handle(&self, req: Request<State>, next: Next<'_, State>) -> crate::Result {
+        self.log(req, next).await
     }
 }

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -17,7 +17,6 @@
 //! ```
 
 use crate::http::headers::LOCATION;
-use crate::utils::BoxFuture;
 use crate::StatusCode;
 use crate::{Endpoint, Request, Response};
 
@@ -86,14 +85,14 @@ impl<T: AsRef<str>> Redirect<T> {
     }
 }
 
+#[async_trait::async_trait]
 impl<State, T> Endpoint<State> for Redirect<T>
 where
     State: Send + Sync + 'static,
     T: AsRef<str> + Send + Sync + 'static,
 {
-    fn call<'a>(&'a self, _req: Request<State>) -> BoxFuture<'a, crate::Result<Response>> {
-        let res = self.into();
-        Box::pin(async move { Ok(res) })
+    async fn call(&self, _req: Request<State>) -> crate::Result<Response> {
+        Ok(self.into())
     }
 }
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -2,7 +2,6 @@ use route_recognizer::{Match, Params, Router as MethodRouter};
 use std::collections::HashMap;
 
 use crate::endpoint::DynEndpoint;
-use crate::utils::BoxFuture;
 use crate::{Request, Response, StatusCode};
 
 /// The routing table used by `Server`
@@ -82,14 +81,10 @@ impl<State: Send + Sync + 'static> Router<State> {
     }
 }
 
-fn not_found_endpoint<State: Send + Sync + 'static>(
-    _req: Request<State>,
-) -> BoxFuture<'static, crate::Result> {
-    Box::pin(async { Ok(Response::new(StatusCode::NotFound)) })
+async fn not_found_endpoint<State: Send + Sync + 'static>(_req: Request<State>) -> crate::Result {
+    Ok(Response::new(StatusCode::NotFound))
 }
 
-fn method_not_allowed<State: Send + Sync + 'static>(
-    _req: Request<State>,
-) -> BoxFuture<'static, crate::Result> {
-    Box::pin(async { Ok(Response::new(StatusCode::MethodNotAllowed)) })
+async fn method_not_allowed<State: Send + Sync + 'static>(_req: Request<State>) -> crate::Result {
+    Ok(Response::new(StatusCode::MethodNotAllowed))
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 //! Miscellaneous utilities.
 
 use crate::{Middleware, Next, Request, Response};
-use async_trait::async_trait;
+pub use async_trait::async_trait;
 use std::future::Future;
 
 /// Define a middleware that operates on incoming requests.

--- a/tests/function_middleware.rs
+++ b/tests/function_middleware.rs
@@ -1,4 +1,5 @@
-use test_utils::BoxFuture;
+use std::future::Future;
+use std::pin::Pin;
 use tide::http::{self, url::Url, Method};
 
 mod test_utils;
@@ -6,13 +7,13 @@ mod test_utils;
 fn auth_middleware<'a>(
     request: tide::Request<()>,
     next: tide::Next<'a, ()>,
-) -> BoxFuture<'a, tide::Result> {
-    Box::pin(async {
-        let authenticated = match request.header("X-Auth") {
-            Some(header) => header == "secret_key",
-            None => false,
-        };
+) -> Pin<Box<dyn Future<Output = tide::Result> + 'a + Send>> {
+    let authenticated = match request.header("X-Auth") {
+        Some(header) => header == "secret_key",
+        None => false,
+    };
 
+    Box::pin(async move {
         if authenticated {
             Ok(next.run(request).await)
         } else {

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -1,5 +1,5 @@
-use test_utils::ServerTestingExt;
 mod test_utils;
+use test_utils::ServerTestingExt;
 
 #[async_std::test]
 async fn nested() {
@@ -18,7 +18,6 @@ async fn nested() {
 #[async_std::test]
 async fn nested_middleware() {
     let echo_path = |req: tide::Request<()>| async move { Ok(req.url().path().to_string()) };
-
     let mut app = tide::new();
     let mut inner_app = tide::new();
     inner_app.middleware(tide::utils::After(|mut res: tide::Response| async move {

--- a/tests/route_middleware.rs
+++ b/tests/route_middleware.rs
@@ -1,7 +1,7 @@
 mod test_utils;
 use http_types::headers::HeaderName;
 use std::convert::TryInto;
-use test_utils::{BoxFuture, ServerTestingExt};
+use test_utils::ServerTestingExt;
 use tide::Middleware;
 
 #[derive(Debug)]
@@ -13,17 +13,16 @@ impl TestMiddleware {
     }
 }
 
+#[async_trait::async_trait]
 impl<State: Send + Sync + 'static> Middleware<State> for TestMiddleware {
-    fn handle<'a>(
-        &'a self,
+    async fn handle(
+        &self,
         req: tide::Request<State>,
-        next: tide::Next<'a, State>,
-    ) -> BoxFuture<'a, tide::Result<tide::Response>> {
-        Box::pin(async move {
-            let mut res = next.run(req).await;
-            res.insert_header(self.0.clone(), self.1);
-            Ok(res)
-        })
+        next: tide::Next<'_, State>,
+    ) -> tide::Result<tide::Response> {
+        let mut res = next.run(req).await;
+        res.insert_header(self.0.clone(), self.1);
+        Ok(res)
     }
 }
 

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -1,14 +1,6 @@
 use portpicker::pick_unused_port;
-
-use std::future::Future;
-use std::pin::Pin;
 use tide::http::{self, url::Url, Method};
 use tide::Server;
-
-/// An owned dynamically typed [`Future`] for use in cases where you can't
-/// statically type your result or need to add some indirection.
-#[allow(dead_code)]
-pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 /// Find an unused port.
 #[allow(dead_code)]
@@ -16,32 +8,22 @@ pub async fn find_port() -> u16 {
     pick_unused_port().expect("No ports free")
 }
 
+#[async_trait::async_trait]
 pub trait ServerTestingExt {
-    fn request<'a>(
-        &'a self,
-        method: Method,
-        path: &str,
-    ) -> Pin<Box<dyn Future<Output = http::Response> + 'a + Send>>;
-    fn request_body<'a>(
-        &'a self,
-        method: Method,
-        path: &str,
-    ) -> Pin<Box<dyn Future<Output = String> + 'a + Send>>;
-    fn get<'a>(&'a self, path: &str) -> Pin<Box<dyn Future<Output = http::Response> + 'a + Send>>;
-    fn get_body<'a>(&'a self, path: &str) -> Pin<Box<dyn Future<Output = String> + 'a + Send>>;
-    fn post<'a>(&'a self, path: &str) -> Pin<Box<dyn Future<Output = http::Response> + 'a + Send>>;
-    fn put<'a>(&'a self, path: &str) -> Pin<Box<dyn Future<Output = http::Response> + 'a + Send>>;
+    async fn request(&self, method: Method, path: &str) -> http::Response;
+    async fn request_body(&self, method: Method, path: &str) -> String;
+    async fn get(&self, path: &str) -> http::Response;
+    async fn get_body(&self, path: &str) -> String;
+    async fn post(&self, path: &str) -> http::Response;
+    async fn put(&self, path: &str) -> http::Response;
 }
 
+#[async_trait::async_trait]
 impl<State> ServerTestingExt for Server<State>
 where
     State: Send + Sync + 'static,
 {
-    fn request<'a>(
-        &'a self,
-        method: Method,
-        path: &str,
-    ) -> Pin<Box<dyn Future<Output = http::Response> + 'a + Send>> {
+    async fn request(&self, method: Method, path: &str) -> http::Response {
         let url = if path.starts_with("http:") {
             Url::parse(path).unwrap()
         } else {
@@ -52,35 +34,27 @@ where
         };
 
         let request = http::Request::new(method, url);
-        let fut = self.respond(request);
-        Box::pin(async { fut.await.unwrap() })
+        self.respond(request).await.unwrap()
     }
 
-    fn request_body<'a>(
-        &'a self,
-        method: Method,
-        path: &str,
-    ) -> Pin<Box<dyn Future<Output = String> + 'a + Send>> {
-        let response_fut = self.request(method, path);
-        Box::pin(async move {
-            let mut response = response_fut.await;
-            response.body_string().await.unwrap()
-        })
+    async fn request_body(&self, method: Method, path: &str) -> String {
+        let mut response = self.request(method, path).await;
+        response.body_string().await.unwrap()
     }
 
-    fn get<'a>(&'a self, path: &str) -> Pin<Box<dyn Future<Output = http::Response> + 'a + Send>> {
-        self.request(Method::Get, path)
+    async fn get(&self, path: &str) -> http::Response {
+        self.request(Method::Get, path).await
     }
 
-    fn get_body<'a>(&'a self, path: &str) -> Pin<Box<dyn Future<Output = String> + 'a + Send>> {
-        self.request_body(Method::Get, path)
+    async fn get_body(&self, path: &str) -> String {
+        self.request_body(Method::Get, path).await
     }
 
-    fn post<'a>(&'a self, path: &str) -> Pin<Box<dyn Future<Output = http::Response> + 'a + Send>> {
-        self.request(Method::Post, path)
+    async fn post(&self, path: &str) -> http::Response {
+        self.request(Method::Post, path).await
     }
 
-    fn put<'a>(&'a self, path: &str) -> Pin<Box<dyn Future<Output = http::Response> + 'a + Send>> {
-        self.request(Method::Put, path)
+    async fn put(&self, path: &str) -> http::Response {
+        self.request(Method::Put, path).await
     }
 }


### PR DESCRIPTION
closes #576 

This change does not actually alter the output code, but hides the use of `Pin<Box<dyn Future<Output = T> + Send>>` behind [async_trait](https://docs.rs/async-trait/0.1.36/async_trait/index.html)

In particular, this simplifies implementing Middleware and Endpoint.
