### PR TITLE
Server: require State to be Clone

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ route-recognizer = "0.2.0"
 logtest = "2.0.0"
 async-trait = "0.1.36"
 futures-util = "0.3.5"
+pin-project-lite = "0.1.7"
 
 [dev-dependencies]
 async-std = { version = "1.6.0", features = ["unstable", "attributes"] }

--- a/examples/graphql.rs
+++ b/examples/graphql.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_std::task;
 use juniper::{http::graphiql, http::GraphQLRequest, RootNode};
 use std::sync::RwLock;
@@ -37,8 +39,9 @@ impl NewUser {
     }
 }
 
+#[derive(Clone)]
 pub struct State {
-    users: RwLock<Vec<User>>,
+    users: Arc<RwLock<Vec<User>>>,
 }
 impl juniper::Context for State {}
 
@@ -96,7 +99,7 @@ async fn handle_graphiql(_: Request<State>) -> tide::Result<impl Into<Response>>
 fn main() -> std::io::Result<()> {
     task::block_on(async {
         let mut app = Server::with_state(State {
-            users: RwLock::new(Vec::new()),
+            users: Arc::new(RwLock::new(Vec::new())),
         });
         app.at("/").get(Redirect::permanent("/graphiql"));
         app.at("/graphql").post(handle_graphql);

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -11,7 +11,7 @@ struct User {
     name: String,
 }
 
-#[derive(Default, Debug)]
+#[derive(Clone, Default, Debug)]
 struct UserDatabase;
 impl UserDatabase {
     async fn find_user(&self) -> Option<User> {
@@ -62,7 +62,7 @@ impl RequestCounterMiddleware {
 struct RequestCount(usize);
 
 #[tide::utils::async_trait]
-impl<State: Send + Sync + 'static> Middleware<State> for RequestCounterMiddleware {
+impl<State: Clone + Send + Sync + 'static> Middleware<State> for RequestCounterMiddleware {
     async fn handle(&self, mut req: Request<State>, next: Next<'_, State>) -> Result {
         let count = self.requests_counted.fetch_add(1, Ordering::Relaxed);
         tide::log::trace!("request counter", { count: count });

--- a/examples/upload.rs
+++ b/examples/upload.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_std::{fs::OpenOptions, io};
 use tempfile::TempDir;
 use tide::prelude::*;
@@ -6,7 +8,7 @@ use tide::{Body, Request, Response, StatusCode};
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
-    let mut app = tide::with_state(tempfile::tempdir()?);
+    let mut app = tide::with_state(Arc::new(tempfile::tempdir()?));
 
     // To test this example:
     // $ cargo run --example upload
@@ -14,7 +16,7 @@ async fn main() -> Result<(), std::io::Error> {
     // $ curl localhost:8080/README.md # this reads the file from the same temp directory
 
     app.at(":file")
-        .put(|req: Request<TempDir>| async move {
+        .put(|req: Request<Arc<TempDir>>| async move {
             let path: String = req.param("file")?;
             let fs_path = req.state().path().join(path);
 
@@ -33,7 +35,7 @@ async fn main() -> Result<(), std::io::Error> {
 
             Ok(json!({ "bytes": bytes_written }))
         })
-        .get(|req: Request<TempDir>| async move {
+        .get(|req: Request<Arc<TempDir>>| async move {
             let path: String = req.param("file")?;
             let fs_path = req.state().path().join(path);
 

--- a/examples/upload.rs
+++ b/examples/upload.rs
@@ -1,3 +1,5 @@
+use std::io::Error as IoError;
+use std::path::Path;
 use std::sync::Arc;
 
 use async_std::{fs::OpenOptions, io};
@@ -5,10 +7,27 @@ use tempfile::TempDir;
 use tide::prelude::*;
 use tide::{Body, Request, Response, StatusCode};
 
+#[derive(Clone)]
+struct TempDirState {
+    tempdir: Arc<TempDir>,
+}
+
+impl TempDirState {
+    fn try_new() -> Result<Self, IoError> {
+        Ok(Self {
+            tempdir: Arc::new(tempfile::tempdir()?),
+        })
+    }
+
+    fn path(&self) -> &Path {
+        self.tempdir.path()
+    }
+}
+
 #[async_std::main]
-async fn main() -> Result<(), std::io::Error> {
+async fn main() -> Result<(), IoError> {
     tide::log::start();
-    let mut app = tide::with_state(Arc::new(tempfile::tempdir()?));
+    let mut app = tide::with_state(TempDirState::try_new()?);
 
     // To test this example:
     // $ cargo run --example upload
@@ -16,7 +35,7 @@ async fn main() -> Result<(), std::io::Error> {
     // $ curl localhost:8080/README.md # this reads the file from the same temp directory
 
     app.at(":file")
-        .put(|req: Request<Arc<TempDir>>| async move {
+        .put(|req: Request<TempDirState>| async move {
             let path: String = req.param("file")?;
             let fs_path = req.state().path().join(path);
 
@@ -35,7 +54,7 @@ async fn main() -> Result<(), std::io::Error> {
 
             Ok(json!({ "bytes": bytes_written }))
         })
-        .get(|req: Request<Arc<TempDir>>| async move {
+        .get(|req: Request<TempDirState>| async move {
             let path: String = req.param("file")?;
             let fs_path = req.state().path().join(path);
 

--- a/src/cookies/middleware.rs
+++ b/src/cookies/middleware.rs
@@ -35,7 +35,7 @@ impl CookiesMiddleware {
 }
 
 #[async_trait]
-impl<State: Send + Sync + 'static> Middleware<State> for CookiesMiddleware {
+impl<State: Clone + Send + Sync + 'static> Middleware<State> for CookiesMiddleware {
     async fn handle(&self, mut ctx: Request<State>, next: Next<'_, State>) -> crate::Result {
         let cookie_jar = if let Some(cookie_data) = ctx.ext::<CookieData>() {
             cookie_data.content.clone()

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -45,7 +45,7 @@ use crate::{Middleware, Request, Response};
 ///
 /// Tide routes will also accept endpoints with `Fn` signatures of this form, but using the `async` keyword has better ergonomics.
 #[async_trait]
-pub trait Endpoint<State: Send + Sync + 'static>: Send + Sync + 'static {
+pub trait Endpoint<State: Clone + Send + Sync + 'static>: Send + Sync + 'static {
     /// Invoke the endpoint within the given context
     async fn call(&self, req: Request<State>) -> crate::Result;
 }
@@ -55,7 +55,7 @@ pub(crate) type DynEndpoint<State> = dyn Endpoint<State>;
 #[async_trait]
 impl<State, F, Fut, Res> Endpoint<State> for F
 where
-    State: Send + Sync + 'static,
+    State: Clone + Send + Sync + 'static,
     F: Send + Sync + 'static + Fn(Request<State>) -> Fut,
     Fut: Future<Output = Result<Res>> + Send + 'static,
     Res: Into<Response> + 'static,
@@ -93,7 +93,7 @@ impl<E, State> std::fmt::Debug for MiddlewareEndpoint<E, State> {
 
 impl<E, State> MiddlewareEndpoint<E, State>
 where
-    State: Send + Sync + 'static,
+    State: Clone + Send + Sync + 'static,
     E: Endpoint<State>,
 {
     pub fn wrap_with_middleware(ep: E, middleware: &[Arc<dyn Middleware<State>>]) -> Self {
@@ -107,7 +107,7 @@ where
 #[async_trait]
 impl<E, State> Endpoint<State> for MiddlewareEndpoint<E, State>
 where
-    State: Send + Sync + 'static,
+    State: Clone + Send + Sync + 'static,
     E: Endpoint<State>,
 {
     async fn call(&self, req: Request<State>) -> crate::Result {

--- a/src/fs/serve_dir.rs
+++ b/src/fs/serve_dir.rs
@@ -21,7 +21,7 @@ impl ServeDir {
 #[async_trait::async_trait]
 impl<State> Endpoint<State> for ServeDir
 where
-    State: Send + Sync + 'static,
+    State: Clone + Send + Sync + 'static,
 {
     async fn call(&self, req: Request<State>) -> Result {
         let path = req.url().path();
@@ -60,8 +60,6 @@ where
 mod test {
     use super::*;
 
-    use async_std::sync::Arc;
-
     use std::fs::{self, File};
     use std::io::Write;
 
@@ -83,7 +81,7 @@ mod test {
         let request = crate::http::Request::get(
             crate::http::Url::parse(&format!("http://localhost/{}", path)).unwrap(),
         );
-        crate::Request::new(Arc::new(()), request, vec![])
+        crate::Request::new((), request, vec![])
     }
 
     #[async_std::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,6 +259,7 @@ pub fn new() -> server::Server<()> {
 /// use tide::Request;
 ///
 /// /// The shared application state.
+/// #[derive(Clone)]
 /// struct State {
 ///     name: String,
 /// }
@@ -279,7 +280,7 @@ pub fn new() -> server::Server<()> {
 /// ```
 pub fn with_state<State>(state: State) -> server::Server<State>
 where
-    State: Send + Sync + 'static,
+    State: Clone + Send + Sync + 'static,
 {
     Server::with_state(state)
 }

--- a/src/listener/concurrent_listener.rs
+++ b/src/listener/concurrent_listener.rs
@@ -35,7 +35,7 @@ use futures_util::stream::{futures_unordered::FuturesUnordered, StreamExt};
 #[derive(Default)]
 pub struct ConcurrentListener<State>(Vec<Box<dyn Listener<State>>>);
 
-impl<State: Send + Sync + 'static> ConcurrentListener<State> {
+impl<State: Clone + Send + Sync + 'static> ConcurrentListener<State> {
     /// creates a new ConcurrentListener
     pub fn new() -> Self {
         Self(vec![])
@@ -78,7 +78,7 @@ impl<State: Send + Sync + 'static> ConcurrentListener<State> {
 }
 
 #[async_trait::async_trait]
-impl<State: Send + Sync + 'static> Listener<State> for ConcurrentListener<State> {
+impl<State: Clone + Send + Sync + 'static> Listener<State> for ConcurrentListener<State> {
     async fn listen(&mut self, app: Server<State>) -> io::Result<()> {
         let mut futures_unordered = FuturesUnordered::new();
 

--- a/src/listener/failover_listener.rs
+++ b/src/listener/failover_listener.rs
@@ -35,7 +35,7 @@ use async_std::io;
 #[derive(Default)]
 pub struct FailoverListener<State>(Vec<Box<dyn Listener<State>>>);
 
-impl<State: Send + Sync + 'static> FailoverListener<State> {
+impl<State: Clone + Send + Sync + 'static> FailoverListener<State> {
     /// creates a new FailoverListener
     pub fn new() -> Self {
         Self(vec![])
@@ -80,7 +80,7 @@ impl<State: Send + Sync + 'static> FailoverListener<State> {
 }
 
 #[async_trait::async_trait]
-impl<State: Send + Sync + 'static> Listener<State> for FailoverListener<State> {
+impl<State: Clone + Send + Sync + 'static> Listener<State> for FailoverListener<State> {
     async fn listen(&mut self, app: Server<State>) -> io::Result<()> {
         for listener in self.0.iter_mut() {
             let app = app.clone();

--- a/src/listener/parsed_listener.rs
+++ b/src/listener/parsed_listener.rs
@@ -31,7 +31,7 @@ impl Display for ParsedListener {
 }
 
 #[async_trait::async_trait]
-impl<State: Send + Sync + 'static> Listener<State> for ParsedListener {
+impl<State: Clone + Send + Sync + 'static> Listener<State> for ParsedListener {
     async fn listen(&mut self, app: Server<State>) -> io::Result<()> {
         match self {
             #[cfg(unix)]

--- a/src/listener/tcp_listener.rs
+++ b/src/listener/tcp_listener.rs
@@ -51,7 +51,7 @@ impl TcpListener {
     }
 }
 
-fn handle_tcp<State: Send + Sync + 'static>(app: Server<State>, stream: TcpStream) {
+fn handle_tcp<State: Clone + Send + Sync + 'static>(app: Server<State>, stream: TcpStream) {
     task::spawn(async move {
         let local_addr = stream.local_addr().ok();
         let peer_addr = stream.peer_addr().ok();
@@ -69,7 +69,7 @@ fn handle_tcp<State: Send + Sync + 'static>(app: Server<State>, stream: TcpStrea
 }
 
 #[async_trait::async_trait]
-impl<State: Send + Sync + 'static> Listener<State> for TcpListener {
+impl<State: Clone + Send + Sync + 'static> Listener<State> for TcpListener {
     async fn listen(&mut self, app: Server<State>) -> io::Result<()> {
         self.connect().await?;
         let listener = self.listener()?;

--- a/src/listener/to_listener.rs
+++ b/src/listener/to_listener.rs
@@ -52,7 +52,7 @@ use std::net::ToSocketAddrs;
 /// # Other implementations
 /// See below for additional provided implementations of ToListener.
 
-pub trait ToListener<State: Send + Sync + 'static> {
+pub trait ToListener<State: Clone + Send + Sync + 'static> {
     type Listener: Listener<State>;
     /// Transform self into a
     /// [`Listener`](crate::listener::Listener). Unless self is
@@ -63,7 +63,7 @@ pub trait ToListener<State: Send + Sync + 'static> {
     fn to_listener(self) -> io::Result<Self::Listener>;
 }
 
-impl<State: Send + Sync + 'static> ToListener<State> for Url {
+impl<State: Clone + Send + Sync + 'static> ToListener<State> for Url {
     type Listener = ParsedListener;
 
     fn to_listener(self) -> io::Result<Self::Listener> {
@@ -106,14 +106,14 @@ impl<State: Send + Sync + 'static> ToListener<State> for Url {
     }
 }
 
-impl<State: Send + Sync + 'static> ToListener<State> for String {
+impl<State: Clone + Send + Sync + 'static> ToListener<State> for String {
     type Listener = ParsedListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
         ToListener::<State>::to_listener(self.as_str())
     }
 }
 
-impl<State: Send + Sync + 'static> ToListener<State> for &str {
+impl<State: Clone + Send + Sync + 'static> ToListener<State> for &str {
     type Listener = ParsedListener;
 
     fn to_listener(self) -> io::Result<Self::Listener> {
@@ -133,7 +133,7 @@ impl<State: Send + Sync + 'static> ToListener<State> for &str {
 }
 
 #[cfg(unix)]
-impl<State: Send + Sync + 'static> ToListener<State> for async_std::path::PathBuf {
+impl<State: Clone + Send + Sync + 'static> ToListener<State> for async_std::path::PathBuf {
     type Listener = UnixListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(UnixListener::from_path(self))
@@ -141,28 +141,28 @@ impl<State: Send + Sync + 'static> ToListener<State> for async_std::path::PathBu
 }
 
 #[cfg(unix)]
-impl<State: Send + Sync + 'static> ToListener<State> for std::path::PathBuf {
+impl<State: Clone + Send + Sync + 'static> ToListener<State> for std::path::PathBuf {
     type Listener = UnixListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(UnixListener::from_path(self))
     }
 }
 
-impl<State: Send + Sync + 'static> ToListener<State> for async_std::net::TcpListener {
+impl<State: Clone + Send + Sync + 'static> ToListener<State> for async_std::net::TcpListener {
     type Listener = TcpListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(TcpListener::from_listener(self))
     }
 }
 
-impl<State: Send + Sync + 'static> ToListener<State> for std::net::TcpListener {
+impl<State: Clone + Send + Sync + 'static> ToListener<State> for std::net::TcpListener {
     type Listener = TcpListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(TcpListener::from_listener(self))
     }
 }
 
-impl<State: Send + Sync + 'static> ToListener<State> for (&str, u16) {
+impl<State: Clone + Send + Sync + 'static> ToListener<State> for (&str, u16) {
     type Listener = TcpListener;
 
     fn to_listener(self) -> io::Result<Self::Listener> {
@@ -171,7 +171,9 @@ impl<State: Send + Sync + 'static> ToListener<State> for (&str, u16) {
 }
 
 #[cfg(unix)]
-impl<State: Send + Sync + 'static> ToListener<State> for async_std::os::unix::net::UnixListener {
+impl<State: Clone + Send + Sync + 'static> ToListener<State>
+    for async_std::os::unix::net::UnixListener
+{
     type Listener = UnixListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(UnixListener::from_listener(self))
@@ -179,14 +181,14 @@ impl<State: Send + Sync + 'static> ToListener<State> for async_std::os::unix::ne
 }
 
 #[cfg(unix)]
-impl<State: Send + Sync + 'static> ToListener<State> for std::os::unix::net::UnixListener {
+impl<State: Clone + Send + Sync + 'static> ToListener<State> for std::os::unix::net::UnixListener {
     type Listener = UnixListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(UnixListener::from_listener(self))
     }
 }
 
-impl<State: Send + Sync + 'static> ToListener<State> for TcpListener {
+impl<State: Clone + Send + Sync + 'static> ToListener<State> for TcpListener {
     type Listener = Self;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(self)
@@ -194,42 +196,42 @@ impl<State: Send + Sync + 'static> ToListener<State> for TcpListener {
 }
 
 #[cfg(unix)]
-impl<State: Send + Sync + 'static> ToListener<State> for UnixListener {
+impl<State: Clone + Send + Sync + 'static> ToListener<State> for UnixListener {
     type Listener = Self;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(self)
     }
 }
 
-impl<State: Send + Sync + 'static> ToListener<State> for ConcurrentListener<State> {
+impl<State: Clone + Send + Sync + 'static> ToListener<State> for ConcurrentListener<State> {
     type Listener = Self;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(self)
     }
 }
 
-impl<State: Send + Sync + 'static> ToListener<State> for ParsedListener {
+impl<State: Clone + Send + Sync + 'static> ToListener<State> for ParsedListener {
     type Listener = Self;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(self)
     }
 }
 
-impl<State: Send + Sync + 'static> ToListener<State> for FailoverListener<State> {
+impl<State: Clone + Send + Sync + 'static> ToListener<State> for FailoverListener<State> {
     type Listener = Self;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(self)
     }
 }
 
-impl<State: Send + Sync + 'static> ToListener<State> for std::net::SocketAddr {
+impl<State: Clone + Send + Sync + 'static> ToListener<State> for std::net::SocketAddr {
     type Listener = TcpListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(TcpListener::from_addrs(vec![self]))
     }
 }
 
-impl<TL: ToListener<State>, State: Send + Sync + 'static> ToListener<State> for Vec<TL> {
+impl<TL: ToListener<State>, State: Clone + Send + Sync + 'static> ToListener<State> for Vec<TL> {
     type Listener = ConcurrentListener<State>;
     fn to_listener(self) -> io::Result<Self::Listener> {
         let mut concurrent_listener = ConcurrentListener::new();

--- a/src/listener/unix_listener.rs
+++ b/src/listener/unix_listener.rs
@@ -64,7 +64,7 @@ fn unix_socket_addr_to_string(result: io::Result<SocketAddr>) -> Option<String> 
     })
 }
 
-fn handle_unix<State: Send + Sync + 'static>(app: Server<State>, stream: UnixStream) {
+fn handle_unix<State: Clone + Send + Sync + 'static>(app: Server<State>, stream: UnixStream) {
     task::spawn(async move {
         let local_addr = unix_socket_addr_to_string(stream.local_addr());
         let peer_addr = unix_socket_addr_to_string(stream.peer_addr());
@@ -82,7 +82,7 @@ fn handle_unix<State: Send + Sync + 'static>(app: Server<State>, stream: UnixStr
 }
 
 #[async_trait::async_trait]
-impl<State: Send + Sync + 'static> Listener<State> for UnixListener {
+impl<State: Clone + Send + Sync + 'static> Listener<State> for UnixListener {
     async fn listen(&mut self, app: Server<State>) -> io::Result<()> {
         self.connect().await?;
         crate::log::info!("Server listening on {}", self);

--- a/src/log/middleware.rs
+++ b/src/log/middleware.rs
@@ -24,7 +24,7 @@ impl LogMiddleware {
     }
 
     /// Log a request and a response.
-    async fn log<'a, State: Send + Sync + 'static>(
+    async fn log<'a, State: Clone + Send + Sync + 'static>(
         &'a self,
         ctx: Request<State>,
         next: Next<'a, State>,
@@ -75,7 +75,7 @@ impl LogMiddleware {
 }
 
 #[async_trait::async_trait]
-impl<State: Send + Sync + 'static> Middleware<State> for LogMiddleware {
+impl<State: Clone + Send + Sync + 'static> Middleware<State> for LogMiddleware {
     async fn handle(&self, req: Request<State>, next: Next<'_, State>) -> crate::Result {
         self.log(req, next).await
     }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -23,7 +23,7 @@ pub trait Middleware<State>: Send + Sync + 'static {
 #[async_trait]
 impl<State, F> Middleware<State> for F
 where
-    State: Send + Sync + 'static,
+    State: Clone + Send + Sync + 'static,
     F: Send
         + Sync
         + 'static
@@ -44,7 +44,7 @@ pub struct Next<'a, State> {
     pub(crate) next_middleware: &'a [Arc<dyn Middleware<State>>],
 }
 
-impl<State: Send + Sync + 'static> Next<'_, State> {
+impl<State: Clone + Send + Sync + 'static> Next<'_, State> {
     /// Asynchronously execute the remaining middleware chain.
     pub async fn run(mut self, req: Request<State>) -> Response {
         if let Some((current, next)) = self.next_middleware.split_first() {

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -88,7 +88,7 @@ impl<T: AsRef<str>> Redirect<T> {
 #[async_trait::async_trait]
 impl<State, T> Endpoint<State> for Redirect<T>
 where
-    State: Send + Sync + 'static,
+    State: Clone + Send + Sync + 'static,
     T: AsRef<str> + Send + Sync + 'static,
 {
     async fn call(&self, _req: Request<State>) -> crate::Result<Response> {

--- a/src/route.rs
+++ b/src/route.rs
@@ -28,7 +28,7 @@ pub struct Route<'a, State> {
     prefix: bool,
 }
 
-impl<'a, State: Send + Sync + 'static> Route<'a, State> {
+impl<'a, State: Clone + Send + Sync + 'static> Route<'a, State> {
     pub(crate) fn new(router: &'a mut Router<State>, path: String) -> Route<'a, State> {
         Route {
             router,
@@ -101,8 +101,8 @@ impl<'a, State: Send + Sync + 'static> Route<'a, State> {
     /// [`Server`]: struct.Server.html
     pub fn nest<InnerState>(&mut self, service: crate::Server<InnerState>) -> &mut Self
     where
-        State: Send + Sync + 'static,
-        InnerState: Send + Sync + 'static,
+        State: Clone + Send + Sync + 'static,
+        InnerState: Clone + Send + Sync + 'static,
     {
         self.prefix = true;
         self.all(service);
@@ -276,7 +276,7 @@ impl<E> Clone for StripPrefixEndpoint<E> {
 #[async_trait::async_trait]
 impl<State, E> Endpoint<State> for StripPrefixEndpoint<E>
 where
-    State: Send + Sync + 'static,
+    State: Clone + Send + Sync + 'static,
     E: Endpoint<State>,
 {
     async fn call(&self, req: crate::Request<State>) -> crate::Result {

--- a/src/router.rs
+++ b/src/router.rs
@@ -21,7 +21,7 @@ pub struct Selection<'a, State> {
     pub(crate) params: Params,
 }
 
-impl<State: Send + Sync + 'static> Router<State> {
+impl<State: Clone + Send + Sync + 'static> Router<State> {
     pub fn new() -> Self {
         Router {
             method_map: HashMap::default(),
@@ -81,10 +81,14 @@ impl<State: Send + Sync + 'static> Router<State> {
     }
 }
 
-async fn not_found_endpoint<State: Send + Sync + 'static>(_req: Request<State>) -> crate::Result {
+async fn not_found_endpoint<State: Clone + Send + Sync + 'static>(
+    _req: Request<State>,
+) -> crate::Result {
     Ok(Response::new(StatusCode::NotFound))
 }
 
-async fn method_not_allowed<State: Send + Sync + 'static>(_req: Request<State>) -> crate::Result {
+async fn method_not_allowed<State: Clone + Send + Sync + 'static>(
+    _req: Request<State>,
+) -> crate::Result {
     Ok(Response::new(StatusCode::MethodNotAllowed))
 }

--- a/src/security/cors.rs
+++ b/src/security/cors.rs
@@ -133,7 +133,7 @@ impl CorsMiddleware {
 }
 
 #[async_trait::async_trait]
-impl<State: Send + Sync + 'static> Middleware<State> for CorsMiddleware {
+impl<State: Clone + Send + Sync + 'static> Middleware<State> for CorsMiddleware {
     async fn handle(&self, req: Request<State>, next: Next<'_, State>) -> Result {
         // TODO: how should multiple origin values be handled?
         let origins = req.header(&headers::ORIGIN).cloned();

--- a/src/sse/endpoint.rs
+++ b/src/sse/endpoint.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 /// Create an endpoint that can handle SSE connections.
 pub fn endpoint<F, Fut, State>(handler: F) -> SseEndpoint<F, Fut, State>
 where
-    State: Send + Sync + 'static,
+    State: Clone + Send + Sync + 'static,
     F: Fn(Request<State>, Sender) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<()>> + Send + Sync + 'static,
 {
@@ -28,7 +28,7 @@ where
 #[derive(Debug)]
 pub struct SseEndpoint<F, Fut, State>
 where
-    State: Send + Sync + 'static,
+    State: Clone + Send + Sync + 'static,
     F: Fn(Request<State>, Sender) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<()>> + Send + Sync + 'static,
 {
@@ -40,7 +40,7 @@ where
 #[async_trait::async_trait]
 impl<F, Fut, State> Endpoint<State> for SseEndpoint<F, Fut, State>
 where
-    State: Send + Sync + 'static,
+    State: Clone + Send + Sync + 'static,
     F: Fn(Request<State>, Sender) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<()>> + Send + Sync + 'static,
 {

--- a/src/sse/upgrade.rs
+++ b/src/sse/upgrade.rs
@@ -11,7 +11,7 @@ use async_std::task;
 /// Upgrade an existing HTTP connection to an SSE connection.
 pub fn upgrade<F, Fut, State>(req: Request<State>, handler: F) -> Response
 where
-    State: Send + Sync + 'static,
+    State: Clone + Send + Sync + 'static,
     F: Fn(Request<State>, Sender) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<()>> + Send + Sync + 'static,
 {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -27,7 +27,7 @@ pub struct Before<F>(pub F);
 #[async_trait]
 impl<State, F, Fut> Middleware<State> for Before<F>
 where
-    State: Send + Sync + 'static,
+    State: Clone + Send + Sync + 'static,
     F: Fn(Request<State>) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Request<State>> + Send + Sync + 'static,
 {
@@ -61,7 +61,7 @@ pub struct After<F>(pub F);
 #[async_trait]
 impl<State, F, Fut> Middleware<State> for After<F>
 where
-    State: Send + Sync + 'static,
+    State: Clone + Send + Sync + 'static,
     F: Fn(Response) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = crate::Result> + Send + Sync + 'static,
 {

--- a/tests/route_middleware.rs
+++ b/tests/route_middleware.rs
@@ -14,7 +14,7 @@ impl TestMiddleware {
 }
 
 #[async_trait::async_trait]
-impl<State: Send + Sync + 'static> Middleware<State> for TestMiddleware {
+impl<State: Clone + Send + Sync + 'static> Middleware<State> for TestMiddleware {
     async fn handle(
         &self,
         req: tide::Request<State>,

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -21,7 +21,7 @@ pub trait ServerTestingExt {
 #[async_trait::async_trait]
 impl<State> ServerTestingExt for Server<State>
 where
-    State: Send + Sync + 'static,
+    State: Clone + Send + Sync + 'static,
 {
     async fn request(&self, method: Method, path: &str) -> http::Response {
         let url = if path.starts_with("http:") {


### PR DESCRIPTION
Alternative to
https://github.com/http-rs/tide/pull/642

This approach is more flexible but requires the user ensure that their
state implements/derives `Clone`, or is wrapped in an `Arc`.

Co-authored-by: Jacob Rothstein <hi@jbr.me>

Notably while this has less new API surface, this requires more from user code.