### PR TITLE
src: move State off of Request (WIP)

### DIFF
--- a/src/cookies/middleware.rs
+++ b/src/cookies/middleware.rs
@@ -37,7 +37,7 @@ impl CookiesMiddleware {
 impl<State: Send + Sync + 'static> Middleware<State> for CookiesMiddleware {
     fn handle<'a>(
         &'a self,
-        mut ctx: Request<State>,
+        mut ctx: Request,
         next: Next<'a, State>,
     ) -> BoxFuture<'a, crate::Result> {
         Box::pin(async move {
@@ -117,7 +117,7 @@ impl LazyJar {
 }
 
 impl CookieData {
-    pub(crate) fn from_request<S>(req: &Request<S>) -> Self {
+    pub(crate) fn from_request(req: &Request) -> Self {
         let jar = if let Some(cookie_headers) = req.header(&headers::COOKIE) {
             let mut jar = CookieJar::new();
             for cookie_header in cookie_headers {

--- a/src/fs/serve_dir.rs
+++ b/src/fs/serve_dir.rs
@@ -23,7 +23,7 @@ impl<State> Endpoint<State> for ServeDir
 where
     State: Send + Sync + 'static,
 {
-    fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, Result> {
+    fn call<'a>(&'a self, req: Request) -> BoxFuture<'a, Result> {
         let path = req.url().path();
         let path = path.trim_start_matches(&self.prefix);
         let path = path.trim_start_matches('/');
@@ -81,7 +81,7 @@ mod test {
         })
     }
 
-    fn request(path: &str) -> crate::Request<()> {
+    fn request(path: &str) -> crate::Request {
         let request = crate::http::Request::get(
             crate::http::Url::parse(&format!("http://localhost/{}", path)).unwrap(),
         );

--- a/src/log/middleware.rs
+++ b/src/log/middleware.rs
@@ -27,7 +27,7 @@ impl LogMiddleware {
     /// Log a request and a response.
     async fn log<'a, State: Send + Sync + 'static>(
         &'a self,
-        ctx: Request<State>,
+        ctx: Request,
         next: Next<'a, State>,
     ) -> crate::Result {
         let path = ctx.url().path().to_owned();
@@ -78,7 +78,7 @@ impl LogMiddleware {
 impl<State: Send + Sync + 'static> Middleware<State> for LogMiddleware {
     fn handle<'a>(
         &'a self,
-        ctx: Request<State>,
+        ctx: Request,
         next: Next<'a, State>,
     ) -> BoxFuture<'a, crate::Result> {
         Box::pin(async move { self.log(ctx, next).await })

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -91,7 +91,7 @@ where
     State: Send + Sync + 'static,
     T: AsRef<str> + Send + Sync + 'static,
 {
-    fn call<'a>(&'a self, _req: Request<State>) -> BoxFuture<'a, crate::Result<Response>> {
+    fn call<'a>(&'a self, _req: Request) -> BoxFuture<'a, crate::Result<Response>> {
         let res = self.into();
         Box::pin(async move { Ok(res) })
     }

--- a/src/route.rs
+++ b/src/route.rs
@@ -279,9 +279,8 @@ where
     State: Send + Sync + 'static,
     E: Endpoint<State>,
 {
-    fn call<'a>(&'a self, req: crate::Request<State>) -> BoxFuture<'a, crate::Result> {
+    fn call<'a>(&'a self, req: crate::Request, _: State) -> BoxFuture<'a, crate::Result> {
         let crate::Request {
-            state,
             mut req,
             route_params,
         } = req;
@@ -290,7 +289,6 @@ where
         req.url_mut().set_path(&rest);
 
         self.0.call(crate::Request {
-            state,
             req,
             route_params,
         })

--- a/src/router.rs
+++ b/src/router.rs
@@ -82,14 +82,14 @@ impl<State: Send + Sync + 'static> Router<State> {
     }
 }
 
-fn not_found_endpoint<State: Send + Sync + 'static>(
-    _req: Request<State>,
+fn not_found_endpoint(
+    _req: Request,
 ) -> BoxFuture<'static, crate::Result> {
     Box::pin(async { Ok(Response::new(StatusCode::NotFound)) })
 }
 
-fn method_not_allowed<State: Send + Sync + 'static>(
-    _req: Request<State>,
+fn method_not_allowed(
+    _req: Request,
 ) -> BoxFuture<'static, crate::Result> {
     Box::pin(async { Ok(Response::new(StatusCode::MethodNotAllowed)) })
 }

--- a/src/security/cors.rs
+++ b/src/security/cors.rs
@@ -134,7 +134,7 @@ impl CorsMiddleware {
 }
 
 impl<State: Send + Sync + 'static> Middleware<State> for CorsMiddleware {
-    fn handle<'a>(&'a self, req: Request<State>, next: Next<'a, State>) -> BoxFuture<'a, Result> {
+    fn handle<'a>(&'a self, req: Request, next: Next<'a, State>) -> BoxFuture<'a, Result> {
         Box::pin(async move {
             // TODO: how should multiple origin values be handled?
             let origins = req.header(&headers::ORIGIN).cloned();

--- a/src/server.rs
+++ b/src/server.rs
@@ -442,7 +442,7 @@ impl<State> Clone for Server<State> {
 impl<State: Sync + Send + 'static, InnerState: Sync + Send + 'static> Endpoint<State>
     for Server<InnerState>
 {
-    fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, crate::Result> {
+    fn call<'a>(&'a self, req: Request) -> BoxFuture<'a, crate::Result> {
         let Request {
             req,
             mut route_params,

--- a/src/sse/endpoint.rs
+++ b/src/sse/endpoint.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 pub fn endpoint<F, Fut, State>(handler: F) -> SseEndpoint<F, Fut, State>
 where
     State: Send + Sync + 'static,
-    F: Fn(Request<State>, Sender) -> Fut + Send + Sync + 'static,
+    F: Fn(Request, Sender) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<()>> + Send + Sync + 'static,
 {
     SseEndpoint {
@@ -30,7 +30,7 @@ where
 pub struct SseEndpoint<F, Fut, State>
 where
     State: Send + Sync + 'static,
-    F: Fn(Request<State>, Sender) -> Fut + Send + Sync + 'static,
+    F: Fn(Request, Sender) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<()>> + Send + Sync + 'static,
 {
     handler: Arc<F>,
@@ -41,10 +41,10 @@ where
 impl<F, Fut, State> Endpoint<State> for SseEndpoint<F, Fut, State>
 where
     State: Send + Sync + 'static,
-    F: Fn(Request<State>, Sender) -> Fut + Send + Sync + 'static,
+    F: Fn(Request, Sender) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<()>> + Send + Sync + 'static,
 {
-    fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, Result<Response>> {
+    fn call<'a>(&'a self, req: Request) -> BoxFuture<'a, Result<Response>> {
         let handler = self.handler.clone();
         Box::pin(async move {
             let (sender, encoder) = async_sse::encode();

--- a/src/sse/upgrade.rs
+++ b/src/sse/upgrade.rs
@@ -9,10 +9,10 @@ use async_std::io::BufReader;
 use async_std::task;
 
 /// Upgrade an existing HTTP connection to an SSE connection.
-pub fn upgrade<F, Fut, State>(req: Request<State>, handler: F) -> Response
+pub fn upgrade<F, Fut, State>(req: Request, handler: F) -> Response
 where
     State: Send + Sync + 'static,
-    F: Fn(Request<State>, Sender) -> Fut + Send + Sync + 'static,
+    F: Fn(Request, Sender) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<()>> + Send + Sync + 'static,
 {
     let (sender, encoder) = async_sse::encode();


### PR DESCRIPTION
```
error[E0119]: conflicting implementations of trait `endpoint::Endpoint<_>`:
  --> src\endpoint.rs:70:1
   |
54 | / impl<State, F, Fut, Res> Endpoint<State> for F
55 | | where
56 | |     State: Send + Sync + 'static,
57 | |     F: Send + Sync + 'static + Fn(Request) -> Fut,
...  |
67 | |     }
68 | | }
   | |_- first implementation here
69 |
70 | / impl<State, F, Fut, Res> Endpoint<State> for F
71 | | where
72 | |     State: Send + Sync + 'static,
73 | |     F: Send + Sync + 'static + Fn(Request, State) -> Fut,
...  |
83 | |     }
84 | | }
   | |_^ conflicting implementation
```

Not sure I understand this error. `F` should be a distinct type for both??
