### PR TITLE
Relax Sync bound on Fut required on sse::upgrade

### DIFF
--- a/src/sse/endpoint.rs
+++ b/src/sse/endpoint.rs
@@ -16,12 +16,11 @@ pub fn endpoint<F, Fut, State>(handler: F) -> SseEndpoint<F, Fut, State>
 where
     State: Send + Sync + 'static,
     F: Fn(Request<State>, Sender) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = Result<()>> + Send + Sync + 'static,
+    Fut: Future<Output = Result<()>> + Send + 'static,
 {
     SseEndpoint {
         handler: Arc::new(handler),
         __state: PhantomData,
-        __fut: PhantomData,
     }
 }
 
@@ -31,18 +30,17 @@ pub struct SseEndpoint<F, Fut, State>
 where
     State: Send + Sync + 'static,
     F: Fn(Request<State>, Sender) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = Result<()>> + Send + Sync + 'static,
+    Fut: Future<Output = Result<()>> + Send + 'static,
 {
     handler: Arc<F>,
     __state: PhantomData<State>,
-    __fut: PhantomData<Fut>,
 }
 
 impl<F, Fut, State> Endpoint<State> for SseEndpoint<F, Fut, State>
 where
     State: Send + Sync + 'static,
     F: Fn(Request<State>, Sender) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = Result<()>> + Send + Sync + 'static,
+    Fut: Future<Output = Result<()>> + Send + 'static,
 {
     fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, Result<Response>> {
         let handler = self.handler.clone();

--- a/src/sse/upgrade.rs
+++ b/src/sse/upgrade.rs
@@ -13,7 +13,7 @@ pub fn upgrade<F, Fut, State>(req: Request<State>, handler: F) -> Response
 where
     State: Send + Sync + 'static,
     F: Fn(Request<State>, Sender) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = Result<()>> + Send + Sync + 'static,
+    Fut: Future<Output = Result<()>> + Send + 'static,
 {
     let (sender, encoder) = async_sse::encode();
     task::spawn(async move {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Relax Sync bound on Fut required on sse::upgrade

## Motivation and Context
`async_std::spawn` doesn't seem to require a `Sync` bound on any `Futures`
used on it. `tide::sse::upgrade` will just `spawn` the `Future` returned by
the `Fn` parameter. With this in mind, the `Sync` bound on that returned
`Future` seems unnecessary.

This, in my experience, seems to conflict with any usages of `async-trait` within that future, since `async-trait` related futures don't appear to be Sync. The main README in the `async-trait` repo seems to suggest the same
> Async fns get transformed into methods that return Pin<Box<dyn Future + Send + 'async_trait>> and delegate to a private async freestanding function.

## How Has This Been Tested?
The code compiles and my project is happy. Not sure how to test this, but I'm open to suggestions!

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
