### PR TITLE
meta: fix the DCO by adding the text of DCO-1.1

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -55,9 +55,29 @@ that you *might* be wrong is critical for any successful open collaboration.
 
 Don't be a bad actor.
 
-## Developer Certificate of Origin
-All contributors must read and agree to the [Developer Certificate of
-Origin (DCO)](../CERTIFICATE).
+<a id="developers-certificate-of-origin"></a>
+## Developer's Certificate of Origin 1.1
 
-The DCO allows us to accept contributions from people to the project, similarly
-to how a license allows us to distribute our code.
+By making a contribution to this project, I certify that:
+
+* (a) The contribution was created in whole or in part by me and I
+  have the right to submit it under the open source license
+  indicated in the file; or
+
+* (b) The contribution is based upon previous work that, to the best
+  of my knowledge, is covered under an appropriate open source
+  license and I have the right under that license to submit that
+  work with modifications, whether created in whole or in part
+  by me, under the same open source license (unless I am
+  permitted to submit under a different license), as indicated
+  in the file; or
+
+* (c) The contribution was provided directly to me by some other
+  person who certified (a), (b) or (c) and I have not modified
+  it.
+
+* (d) I understand and agree that this project and the contribution
+  are public and that a record of the contribution (including all
+  personal information I submit with it, including my sign-off) is
+  maintained indefinitely and may be redistributed consistent with
+  this project or the open source license(s) involved.


### PR DESCRIPTION
The text was missing before. The DCO helps overcome some legal controversy regarding contribution authority for MIT in particular and perhaps also Apache-2.0. The Node.js Foundation (at the time) determined it was best to just stick the whole thing in the contributing document, which is what I am replicating here.
