### PR TITLE
Examples: consistency improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ pin-project-lite = "0.1.7"
 [dev-dependencies]
 async-std = { version = "1.6.0", features = ["unstable", "attributes"] }
 juniper = "0.14.1"
+lazy_static = "1.4.0"
 portpicker = "0.1.0"
 surf = { version = "2.0.0-alpha.3", default-features = false, features = ["h1-client"] }
 serde = { version = "1.0.102", features = ["derive"] }

--- a/examples/chunked.rs
+++ b/examples/chunked.rs
@@ -1,11 +1,13 @@
-use async_std::task;
+use tide::Body;
 
-fn main() -> Result<(), std::io::Error> {
-    task::block_on(async {
-        let mut app = tide::new();
-        app.at("/")
-            .get(|_| async { Ok(tide::Body::from_file(file!()).await?) });
-        app.listen("127.0.0.1:8080").await?;
-        Ok(())
-    })
+#[async_std::main]
+async fn main() -> Result<(), std::io::Error> {
+    tide::log::start();
+    let mut app = tide::new();
+    app.at("/").get(|_| async {
+        // File sends are chunked by default.
+        Ok(Body::from_file(file!()).await?)
+    });
+    app.listen("127.0.0.1:8080").await?;
+    Ok(())
 }

--- a/examples/concurrent_listeners.rs
+++ b/examples/concurrent_listeners.rs
@@ -1,9 +1,11 @@
+use tide::Request;
+
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
     let mut app = tide::new();
 
-    app.at("/").get(|request: tide::Request<_>| async move {
+    app.at("/").get(|request: Request<_>| async move {
         Ok(format!(
             "Hi! You reached this app through: {}",
             request.local_addr().unwrap_or("an unknown port")

--- a/examples/cookies.rs
+++ b/examples/cookies.rs
@@ -1,6 +1,5 @@
-use async_std::task;
 use tide::http::Cookie;
-use tide::{Request, StatusCode};
+use tide::{Request, Response, StatusCode};
 
 /// Tide will use the the `Cookies`'s `Extract` implementation to build this parameter.
 ///
@@ -9,26 +8,26 @@ async fn retrieve_cookie(req: Request<()>) -> tide::Result<String> {
 }
 
 async fn insert_cookie(_req: Request<()>) -> tide::Result {
-    let mut res = tide::Response::new(StatusCode::Ok);
+    let mut res = Response::new(StatusCode::Ok);
     res.insert_cookie(Cookie::new("hello", "world"));
     Ok(res)
 }
 
 async fn remove_cookie(_req: Request<()>) -> tide::Result {
-    let mut res = tide::Response::new(StatusCode::Ok);
+    let mut res = Response::new(StatusCode::Ok);
     res.remove_cookie(Cookie::named("hello"));
     Ok(res)
 }
 
-fn main() -> Result<(), std::io::Error> {
-    task::block_on(async {
-        let mut app = tide::new();
+#[async_std::main]
+async fn main() -> Result<(), std::io::Error> {
+    tide::log::start();
+    let mut app = tide::new();
 
-        app.at("/").get(retrieve_cookie);
-        app.at("/set").get(insert_cookie);
-        app.at("/remove").get(remove_cookie);
-        app.listen("127.0.0.1:8080").await?;
+    app.at("/").get(retrieve_cookie);
+    app.at("/set").get(insert_cookie);
+    app.at("/remove").get(remove_cookie);
+    app.listen("127.0.0.1:8080").await?;
 
-        Ok(())
-    })
+    Ok(())
 }

--- a/examples/fib.rs
+++ b/examples/fib.rs
@@ -1,4 +1,3 @@
-use async_std::task;
 use tide::Request;
 
 fn fib(n: usize) -> usize {
@@ -29,11 +28,10 @@ async fn fibsum(req: Request<()>) -> tide::Result<String> {
 // $ curl "http://localhost:8080/fib/42"
 // The fib of 42 is 267914296.
 // It was computed in 2 secs.
-fn main() -> Result<(), std::io::Error> {
-    task::block_on(async {
-        let mut app = tide::new();
-        app.at("/fib/:n").get(fibsum);
-        app.listen("0.0.0.0:8080").await?;
-        Ok(())
-    })
+#[async_std::main]
+async fn main() -> Result<(), std::io::Error> {
+    let mut app = tide::new();
+    app.at("/fib/:n").get(fibsum);
+    app.listen("0.0.0.0:8080").await?;
+    Ok(())
 }

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -1,6 +1,5 @@
-use async_std::task;
 use serde::{Deserialize, Serialize};
-use tide::prelude::*;
+use tide::prelude::*; // Pulls in the json! macro.
 use tide::{Body, Request};
 
 #[derive(Deserialize, Serialize)]
@@ -8,32 +7,32 @@ struct Cat {
     name: String,
 }
 
-fn main() -> tide::Result<()> {
-    task::block_on(async {
-        let mut app = tide::new();
+#[async_std::main]
+async fn main() -> tide::Result<()> {
+    tide::log::start();
+    let mut app = tide::new();
 
-        app.at("/submit").post(|mut req: Request<()>| async move {
-            let cat: Cat = req.body_json().await?;
-            println!("cat name: {}", cat.name);
+    app.at("/submit").post(|mut req: Request<()>| async move {
+        let cat: Cat = req.body_json().await?;
+        println!("cat name: {}", cat.name);
 
-            let cat = Cat {
-                name: "chashu".into(),
-            };
+        let cat = Cat {
+            name: "chashu".into(),
+        };
 
-            Ok(Body::from_json(&cat)?)
-        });
+        Ok(Body::from_json(&cat)?)
+    });
 
-        app.at("/animals").get(|_| async {
-            Ok(json!({
-                "meta": { "count": 2 },
-                "animals": [
-                    { "type": "cat", "name": "chashu" },
-                    { "type": "cat", "name": "nori" }
-                ]
-            }))
-        });
+    app.at("/animals").get(|_| async {
+        Ok(json!({
+            "meta": { "count": 2 },
+            "animals": [
+                { "type": "cat", "name": "chashu" },
+                { "type": "cat", "name": "nori" }
+            ]
+        }))
+    });
 
-        app.listen("127.0.0.1:8080").await?;
-        Ok(())
-    })
+    app.listen("127.0.0.1:8080").await?;
+    Ok(())
 }

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+
 use tide::http::mime;
 use tide::utils::{After, Before};
 use tide::{Middleware, Next, Request, Response, Result, StatusCode};
@@ -42,9 +43,7 @@ fn user_loader<'a>(
     })
 }
 
-//
-//
-// this is an example of middleware that keeps its own state and could
+// This is an example of middleware that keeps its own state and could
 // be provided as a third party crate
 #[derive(Default)]
 struct RequestCounterMiddleware {

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -1,5 +1,6 @@
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
+    tide::log::start();
     let mut app = tide::new();
     app.at("/").get(|_| async { Ok("Root") });
     app.at("/api").nest({

--- a/examples/redirect.rs
+++ b/examples/redirect.rs
@@ -1,7 +1,8 @@
-use tide::{http::StatusCode, Redirect, Response};
+use tide::{Redirect, Response, StatusCode};
 
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
+    tide::log::start();
     let mut app = tide::new();
     app.at("/").get(|_| async { Ok("Root") });
 

--- a/examples/sse.rs
+++ b/examples/sse.rs
@@ -2,6 +2,7 @@ use tide::sse;
 
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
+    tide::log::start();
     let mut app = tide::new();
     app.at("/sse").get(sse::endpoint(|_req, sender| async move {
         sender.send("fruit", "banana", None).await?;

--- a/examples/static_file.rs
+++ b/examples/static_file.rs
@@ -2,7 +2,7 @@
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
     let mut app = tide::new();
-    app.at("/").get(|_| async move { Ok("visit /src/*") });
+    app.at("/").get(|_| async { Ok("visit /src/*") });
     app.at("/src").serve_dir("src/")?;
     app.listen("127.0.0.1:8080").await?;
     Ok(())


### PR DESCRIPTION
This is just a general pass of edits for the examples, for consistency and usability.

- Use `#[async_std::main]`
- Use `tide::log::start();`
- Declare more in `use`.
- Improved `error_handling` example.
- GraphQL example now uses `lazy_static!`

Plus more misc minor nits.