### PR TITLE
src, utils: add TideState alias

### DIFF
--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use tide::http::mime;
-use tide::utils::{After, Before};
+use tide::utils::{After, Before, TideState};
 use tide::{Middleware, Next, Request, Response, Result, StatusCode};
 
 #[derive(Debug)]
@@ -61,7 +61,7 @@ impl RequestCounterMiddleware {
 struct RequestCount(usize);
 
 #[tide::utils::async_trait]
-impl<State: Clone + Send + Sync + 'static> Middleware<State> for RequestCounterMiddleware {
+impl<State: TideState> Middleware<State> for RequestCounterMiddleware {
     async fn handle(&self, mut req: Request<State>, next: Next<'_, State>) -> Result {
         let count = self.requests_counted.fetch_add(1, Ordering::Relaxed);
         tide::log::trace!("request counter", { count: count });

--- a/src/cookies/middleware.rs
+++ b/src/cookies/middleware.rs
@@ -1,4 +1,5 @@
 use crate::response::CookieEvent;
+use crate::utils::TideState;
 use crate::{Middleware, Next, Request};
 use async_trait::async_trait;
 
@@ -35,7 +36,7 @@ impl CookiesMiddleware {
 }
 
 #[async_trait]
-impl<State: Clone + Send + Sync + 'static> Middleware<State> for CookiesMiddleware {
+impl<State: TideState> Middleware<State> for CookiesMiddleware {
     async fn handle(&self, mut ctx: Request<State>, next: Next<'_, State>) -> crate::Result {
         let cookie_jar = if let Some(cookie_data) = ctx.ext::<CookieData>() {
             cookie_data.content.clone()

--- a/src/fs/serve_dir.rs
+++ b/src/fs/serve_dir.rs
@@ -1,4 +1,5 @@
 use crate::log;
+use crate::utils::TideState;
 use crate::{Body, Endpoint, Request, Response, Result, StatusCode};
 
 use async_std::path::PathBuf as AsyncPathBuf;
@@ -21,7 +22,7 @@ impl ServeDir {
 #[async_trait::async_trait]
 impl<State> Endpoint<State> for ServeDir
 where
-    State: Clone + Send + Sync + 'static,
+    State: TideState,
 {
     async fn call(&self, req: Request<State>) -> Result {
         let path = req.url().path();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,6 +227,8 @@ pub use server::Server;
 #[doc(inline)]
 pub use http_types::{self as http, Body, Error, Status, StatusCode};
 
+use utils::TideState;
+
 /// Create a new Tide server.
 ///
 /// # Examples
@@ -280,7 +282,7 @@ pub fn new() -> server::Server<()> {
 /// ```
 pub fn with_state<State>(state: State) -> server::Server<State>
 where
-    State: Clone + Send + Sync + 'static,
+    State: TideState,
 {
     Server::with_state(state)
 }

--- a/src/listener/concurrent_listener.rs
+++ b/src/listener/concurrent_listener.rs
@@ -1,4 +1,5 @@
 use crate::listener::{Listener, ToListener};
+use crate::utils::TideState;
 use crate::Server;
 
 use std::fmt::{self, Debug, Display, Formatter};
@@ -35,7 +36,7 @@ use futures_util::stream::{futures_unordered::FuturesUnordered, StreamExt};
 #[derive(Default)]
 pub struct ConcurrentListener<State>(Vec<Box<dyn Listener<State>>>);
 
-impl<State: Clone + Send + Sync + 'static> ConcurrentListener<State> {
+impl<State: TideState> ConcurrentListener<State> {
     /// creates a new ConcurrentListener
     pub fn new() -> Self {
         Self(vec![])
@@ -78,7 +79,7 @@ impl<State: Clone + Send + Sync + 'static> ConcurrentListener<State> {
 }
 
 #[async_trait::async_trait]
-impl<State: Clone + Send + Sync + 'static> Listener<State> for ConcurrentListener<State> {
+impl<State: TideState> Listener<State> for ConcurrentListener<State> {
     async fn listen(&mut self, app: Server<State>) -> io::Result<()> {
         let mut futures_unordered = FuturesUnordered::new();
 

--- a/src/listener/failover_listener.rs
+++ b/src/listener/failover_listener.rs
@@ -1,4 +1,5 @@
 use crate::listener::{Listener, ToListener};
+use crate::utils::TideState;
 use crate::Server;
 
 use std::fmt::{self, Debug, Display, Formatter};
@@ -35,7 +36,7 @@ use async_std::io;
 #[derive(Default)]
 pub struct FailoverListener<State>(Vec<Box<dyn Listener<State>>>);
 
-impl<State: Clone + Send + Sync + 'static> FailoverListener<State> {
+impl<State: TideState> FailoverListener<State> {
     /// creates a new FailoverListener
     pub fn new() -> Self {
         Self(vec![])
@@ -80,7 +81,7 @@ impl<State: Clone + Send + Sync + 'static> FailoverListener<State> {
 }
 
 #[async_trait::async_trait]
-impl<State: Clone + Send + Sync + 'static> Listener<State> for FailoverListener<State> {
+impl<State: TideState> Listener<State> for FailoverListener<State> {
     async fn listen(&mut self, app: Server<State>) -> io::Result<()> {
         for listener in self.0.iter_mut() {
             let app = app.clone();

--- a/src/listener/parsed_listener.rs
+++ b/src/listener/parsed_listener.rs
@@ -1,6 +1,7 @@
 #[cfg(unix)]
 use super::UnixListener;
 use super::{Listener, TcpListener};
+use crate::utils::TideState;
 use crate::Server;
 
 use async_std::io;
@@ -31,7 +32,7 @@ impl Display for ParsedListener {
 }
 
 #[async_trait::async_trait]
-impl<State: Clone + Send + Sync + 'static> Listener<State> for ParsedListener {
+impl<State: TideState> Listener<State> for ParsedListener {
     async fn listen(&mut self, app: Server<State>) -> io::Result<()> {
         match self {
             #[cfg(unix)]

--- a/src/listener/tcp_listener.rs
+++ b/src/listener/tcp_listener.rs
@@ -1,6 +1,7 @@
 use super::is_transient_error;
 
 use crate::listener::Listener;
+use crate::utils::TideState;
 use crate::{log, Server};
 
 use std::fmt::{self, Display, Formatter};
@@ -51,7 +52,7 @@ impl TcpListener {
     }
 }
 
-fn handle_tcp<State: Clone + Send + Sync + 'static>(app: Server<State>, stream: TcpStream) {
+fn handle_tcp<State: TideState>(app: Server<State>, stream: TcpStream) {
     task::spawn(async move {
         let local_addr = stream.local_addr().ok();
         let peer_addr = stream.peer_addr().ok();
@@ -69,7 +70,7 @@ fn handle_tcp<State: Clone + Send + Sync + 'static>(app: Server<State>, stream: 
 }
 
 #[async_trait::async_trait]
-impl<State: Clone + Send + Sync + 'static> Listener<State> for TcpListener {
+impl<State: TideState> Listener<State> for TcpListener {
     async fn listen(&mut self, app: Server<State>) -> io::Result<()> {
         self.connect().await?;
         let listener = self.listener()?;

--- a/src/listener/to_listener.rs
+++ b/src/listener/to_listener.rs
@@ -2,6 +2,7 @@
 use super::UnixListener;
 use super::{ConcurrentListener, FailoverListener, Listener, ParsedListener, TcpListener};
 use crate::http::url::Url;
+use crate::utils::TideState;
 use async_std::io;
 use std::net::ToSocketAddrs;
 
@@ -52,7 +53,7 @@ use std::net::ToSocketAddrs;
 /// # Other implementations
 /// See below for additional provided implementations of ToListener.
 
-pub trait ToListener<State: Clone + Send + Sync + 'static> {
+pub trait ToListener<State: TideState> {
     type Listener: Listener<State>;
     /// Transform self into a
     /// [`Listener`](crate::listener::Listener). Unless self is
@@ -63,7 +64,7 @@ pub trait ToListener<State: Clone + Send + Sync + 'static> {
     fn to_listener(self) -> io::Result<Self::Listener>;
 }
 
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for Url {
+impl<State: TideState> ToListener<State> for Url {
     type Listener = ParsedListener;
 
     fn to_listener(self) -> io::Result<Self::Listener> {
@@ -106,14 +107,14 @@ impl<State: Clone + Send + Sync + 'static> ToListener<State> for Url {
     }
 }
 
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for String {
+impl<State: TideState> ToListener<State> for String {
     type Listener = ParsedListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
         ToListener::<State>::to_listener(self.as_str())
     }
 }
 
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for &str {
+impl<State: TideState> ToListener<State> for &str {
     type Listener = ParsedListener;
 
     fn to_listener(self) -> io::Result<Self::Listener> {
@@ -133,7 +134,7 @@ impl<State: Clone + Send + Sync + 'static> ToListener<State> for &str {
 }
 
 #[cfg(unix)]
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for async_std::path::PathBuf {
+impl<State: TideState> ToListener<State> for async_std::path::PathBuf {
     type Listener = UnixListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(UnixListener::from_path(self))
@@ -141,28 +142,28 @@ impl<State: Clone + Send + Sync + 'static> ToListener<State> for async_std::path
 }
 
 #[cfg(unix)]
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for std::path::PathBuf {
+impl<State: TideState> ToListener<State> for std::path::PathBuf {
     type Listener = UnixListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(UnixListener::from_path(self))
     }
 }
 
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for async_std::net::TcpListener {
+impl<State: TideState> ToListener<State> for async_std::net::TcpListener {
     type Listener = TcpListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(TcpListener::from_listener(self))
     }
 }
 
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for std::net::TcpListener {
+impl<State: TideState> ToListener<State> for std::net::TcpListener {
     type Listener = TcpListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(TcpListener::from_listener(self))
     }
 }
 
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for (&str, u16) {
+impl<State: TideState> ToListener<State> for (&str, u16) {
     type Listener = TcpListener;
 
     fn to_listener(self) -> io::Result<Self::Listener> {
@@ -171,9 +172,7 @@ impl<State: Clone + Send + Sync + 'static> ToListener<State> for (&str, u16) {
 }
 
 #[cfg(unix)]
-impl<State: Clone + Send + Sync + 'static> ToListener<State>
-    for async_std::os::unix::net::UnixListener
-{
+impl<State: TideState> ToListener<State> for async_std::os::unix::net::UnixListener {
     type Listener = UnixListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(UnixListener::from_listener(self))
@@ -181,14 +180,14 @@ impl<State: Clone + Send + Sync + 'static> ToListener<State>
 }
 
 #[cfg(unix)]
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for std::os::unix::net::UnixListener {
+impl<State: TideState> ToListener<State> for std::os::unix::net::UnixListener {
     type Listener = UnixListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(UnixListener::from_listener(self))
     }
 }
 
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for TcpListener {
+impl<State: TideState> ToListener<State> for TcpListener {
     type Listener = Self;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(self)
@@ -196,42 +195,42 @@ impl<State: Clone + Send + Sync + 'static> ToListener<State> for TcpListener {
 }
 
 #[cfg(unix)]
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for UnixListener {
+impl<State: TideState> ToListener<State> for UnixListener {
     type Listener = Self;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(self)
     }
 }
 
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for ConcurrentListener<State> {
+impl<State: TideState> ToListener<State> for ConcurrentListener<State> {
     type Listener = Self;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(self)
     }
 }
 
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for ParsedListener {
+impl<State: TideState> ToListener<State> for ParsedListener {
     type Listener = Self;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(self)
     }
 }
 
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for FailoverListener<State> {
+impl<State: TideState> ToListener<State> for FailoverListener<State> {
     type Listener = Self;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(self)
     }
 }
 
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for std::net::SocketAddr {
+impl<State: TideState> ToListener<State> for std::net::SocketAddr {
     type Listener = TcpListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(TcpListener::from_addrs(vec![self]))
     }
 }
 
-impl<TL: ToListener<State>, State: Clone + Send + Sync + 'static> ToListener<State> for Vec<TL> {
+impl<TL: ToListener<State>, State: TideState> ToListener<State> for Vec<TL> {
     type Listener = ConcurrentListener<State>;
     fn to_listener(self) -> io::Result<Self::Listener> {
         let mut concurrent_listener = ConcurrentListener::new();

--- a/src/listener/unix_listener.rs
+++ b/src/listener/unix_listener.rs
@@ -1,6 +1,7 @@
 use super::is_transient_error;
 
 use crate::listener::Listener;
+use crate::utils::TideState;
 use crate::{log, Server};
 
 use std::fmt::{self, Display, Formatter};
@@ -64,7 +65,7 @@ fn unix_socket_addr_to_string(result: io::Result<SocketAddr>) -> Option<String> 
     })
 }
 
-fn handle_unix<State: Clone + Send + Sync + 'static>(app: Server<State>, stream: UnixStream) {
+fn handle_unix<State: TideState>(app: Server<State>, stream: UnixStream) {
     task::spawn(async move {
         let local_addr = unix_socket_addr_to_string(stream.local_addr());
         let peer_addr = unix_socket_addr_to_string(stream.peer_addr());
@@ -82,7 +83,7 @@ fn handle_unix<State: Clone + Send + Sync + 'static>(app: Server<State>, stream:
 }
 
 #[async_trait::async_trait]
-impl<State: Clone + Send + Sync + 'static> Listener<State> for UnixListener {
+impl<State: TideState> Listener<State> for UnixListener {
     async fn listen(&mut self, app: Server<State>) -> io::Result<()> {
         self.connect().await?;
         crate::log::info!("Server listening on {}", self);

--- a/src/log/middleware.rs
+++ b/src/log/middleware.rs
@@ -1,4 +1,5 @@
 use crate::log;
+use crate::utils::TideState;
 use crate::{Middleware, Next, Request};
 
 /// Log all incoming requests and responses.
@@ -24,7 +25,7 @@ impl LogMiddleware {
     }
 
     /// Log a request and a response.
-    async fn log<'a, State: Clone + Send + Sync + 'static>(
+    async fn log<'a, State: TideState>(
         &'a self,
         ctx: Request<State>,
         next: Next<'a, State>,
@@ -75,7 +76,7 @@ impl LogMiddleware {
 }
 
 #[async_trait::async_trait]
-impl<State: Clone + Send + Sync + 'static> Middleware<State> for LogMiddleware {
+impl<State: TideState> Middleware<State> for LogMiddleware {
     async fn handle(&self, req: Request<State>, next: Next<'_, State>) -> crate::Result {
         self.log(req, next).await
     }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use crate::endpoint::DynEndpoint;
+use crate::utils::TideState;
 use crate::{Request, Response};
 use async_trait::async_trait;
 use std::future::Future;
@@ -23,7 +24,7 @@ pub trait Middleware<State>: Send + Sync + 'static {
 #[async_trait]
 impl<State, F> Middleware<State> for F
 where
-    State: Clone + Send + Sync + 'static,
+    State: TideState,
     F: Send
         + Sync
         + 'static
@@ -44,7 +45,7 @@ pub struct Next<'a, State> {
     pub(crate) next_middleware: &'a [Arc<dyn Middleware<State>>],
 }
 
-impl<State: Clone + Send + Sync + 'static> Next<'_, State> {
+impl<State: TideState> Next<'_, State> {
     /// Asynchronously execute the remaining middleware chain.
     pub async fn run(mut self, req: Request<State>) -> Response {
         if let Some((current, next)) = self.next_middleware.split_first() {

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -17,6 +17,7 @@
 //! ```
 
 use crate::http::headers::LOCATION;
+use crate::utils::TideState;
 use crate::StatusCode;
 use crate::{Endpoint, Request, Response};
 
@@ -88,7 +89,7 @@ impl<T: AsRef<str>> Redirect<T> {
 #[async_trait::async_trait]
 impl<State, T> Endpoint<State> for Redirect<T>
 where
-    State: Clone + Send + Sync + 'static,
+    State: TideState,
     T: AsRef<str> + Send + Sync + 'static,
 {
     async fn call(&self, _req: Request<State>) -> crate::Result<Response> {

--- a/src/request.rs
+++ b/src/request.rs
@@ -10,6 +10,7 @@ use crate::cookies::CookieData;
 use crate::http::cookies::Cookie;
 use crate::http::headers::{self, HeaderName, HeaderValues, ToHeaderValues};
 use crate::http::{self, Body, Method, Mime, StatusCode, Url, Version};
+use crate::utils::TideState;
 use crate::Response;
 
 pin_project_lite::pin_project! {
@@ -565,7 +566,7 @@ impl<State> Into<http::Request> for Request<State> {
 
 // NOTE: From cannot be implemented for this conversion because `State` needs to
 // be constrained by a type.
-impl<State: Clone + Send + Sync + 'static> Into<Response> for Request<State> {
+impl<State: TideState> Into<Response> for Request<State> {
     fn into(mut self) -> Response {
         let mut res = Response::new(StatusCode::Ok);
         res.set_body(self.take_body());

--- a/src/route.rs
+++ b/src/route.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use crate::endpoint::MiddlewareEndpoint;
 use crate::fs::ServeDir;
 use crate::log;
+use crate::utils::TideState;
 use crate::{router::Router, Endpoint, Middleware};
 
 /// A handle to a route.
@@ -28,7 +29,7 @@ pub struct Route<'a, State> {
     prefix: bool,
 }
 
-impl<'a, State: Clone + Send + Sync + 'static> Route<'a, State> {
+impl<'a, State: TideState> Route<'a, State> {
     pub(crate) fn new(router: &'a mut Router<State>, path: String) -> Route<'a, State> {
         Route {
             router,
@@ -101,8 +102,8 @@ impl<'a, State: Clone + Send + Sync + 'static> Route<'a, State> {
     /// [`Server`]: struct.Server.html
     pub fn nest<InnerState>(&mut self, service: crate::Server<InnerState>) -> &mut Self
     where
-        State: Clone + Send + Sync + 'static,
-        InnerState: Clone + Send + Sync + 'static,
+        State: TideState,
+        InnerState: TideState,
     {
         self.prefix = true;
         self.all(service);
@@ -276,7 +277,7 @@ impl<E> Clone for StripPrefixEndpoint<E> {
 #[async_trait::async_trait]
 impl<State, E> Endpoint<State> for StripPrefixEndpoint<E>
 where
-    State: Clone + Send + Sync + 'static,
+    State: TideState,
     E: Endpoint<State>,
 {
     async fn call(&self, req: crate::Request<State>) -> crate::Result {

--- a/src/router.rs
+++ b/src/router.rs
@@ -2,6 +2,7 @@ use route_recognizer::{Match, Params, Router as MethodRouter};
 use std::collections::HashMap;
 
 use crate::endpoint::DynEndpoint;
+use crate::utils::TideState;
 use crate::{Request, Response, StatusCode};
 
 /// The routing table used by `Server`
@@ -21,7 +22,7 @@ pub struct Selection<'a, State> {
     pub(crate) params: Params,
 }
 
-impl<State: Clone + Send + Sync + 'static> Router<State> {
+impl<State: TideState> Router<State> {
     pub fn new() -> Self {
         Router {
             method_map: HashMap::default(),
@@ -81,14 +82,10 @@ impl<State: Clone + Send + Sync + 'static> Router<State> {
     }
 }
 
-async fn not_found_endpoint<State: Clone + Send + Sync + 'static>(
-    _req: Request<State>,
-) -> crate::Result {
+async fn not_found_endpoint<State: TideState>(_req: Request<State>) -> crate::Result {
     Ok(Response::new(StatusCode::NotFound))
 }
 
-async fn method_not_allowed<State: Clone + Send + Sync + 'static>(
-    _req: Request<State>,
-) -> crate::Result {
+async fn method_not_allowed<State: TideState>(_req: Request<State>) -> crate::Result {
     Ok(Response::new(StatusCode::MethodNotAllowed))
 }

--- a/src/security/cors.rs
+++ b/src/security/cors.rs
@@ -2,6 +2,7 @@ use http_types::headers::{HeaderValue, HeaderValues};
 use http_types::{headers, Method, StatusCode};
 
 use crate::middleware::{Middleware, Next};
+use crate::utils::TideState;
 use crate::{Request, Result};
 
 /// Middleware for CORS
@@ -133,7 +134,7 @@ impl CorsMiddleware {
 }
 
 #[async_trait::async_trait]
-impl<State: Clone + Send + Sync + 'static> Middleware<State> for CorsMiddleware {
+impl<State: TideState> Middleware<State> for CorsMiddleware {
     async fn handle(&self, req: Request<State>, next: Next<'_, State>) -> Result {
         // TODO: how should multiple origin values be handled?
         let origins = req.header(&headers::ORIGIN).cloned();

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,6 +8,7 @@ use crate::listener::{Listener, ToListener};
 use crate::log;
 use crate::middleware::{Middleware, Next};
 use crate::router::{Router, Selection};
+use crate::utils::TideState;
 use crate::{Endpoint, Request, Route};
 /// An HTTP server.
 ///
@@ -58,7 +59,7 @@ impl Default for Server<()> {
     }
 }
 
-impl<State: Clone + Send + Sync + 'static> Server<State> {
+impl<State: TideState> Server<State> {
     /// Create a new Tide server with shared application scoped state.
     ///
     /// Application scoped state is useful for storing items

--- a/src/sse/endpoint.rs
+++ b/src/sse/endpoint.rs
@@ -1,6 +1,7 @@
 use crate::http::{mime, Body, StatusCode};
 use crate::log;
 use crate::sse::Sender;
+use crate::utils::TideState;
 use crate::{Endpoint, Request, Response, Result};
 
 use async_std::future::Future;
@@ -13,7 +14,7 @@ use std::sync::Arc;
 /// Create an endpoint that can handle SSE connections.
 pub fn endpoint<F, Fut, State>(handler: F) -> SseEndpoint<F, Fut, State>
 where
-    State: Clone + Send + Sync + 'static,
+    State: TideState,
     F: Fn(Request<State>, Sender) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<()>> + Send + Sync + 'static,
 {
@@ -28,7 +29,7 @@ where
 #[derive(Debug)]
 pub struct SseEndpoint<F, Fut, State>
 where
-    State: Clone + Send + Sync + 'static,
+    State: TideState,
     F: Fn(Request<State>, Sender) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<()>> + Send + Sync + 'static,
 {
@@ -40,7 +41,7 @@ where
 #[async_trait::async_trait]
 impl<F, Fut, State> Endpoint<State> for SseEndpoint<F, Fut, State>
 where
-    State: Clone + Send + Sync + 'static,
+    State: TideState,
     F: Fn(Request<State>, Sender) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<()>> + Send + Sync + 'static,
 {

--- a/src/sse/upgrade.rs
+++ b/src/sse/upgrade.rs
@@ -1,5 +1,6 @@
 use crate::http::{mime, Body, StatusCode};
 use crate::log;
+use crate::utils::TideState;
 use crate::{Request, Response, Result};
 
 use super::Sender;
@@ -11,7 +12,7 @@ use async_std::task;
 /// Upgrade an existing HTTP connection to an SSE connection.
 pub fn upgrade<F, Fut, State>(req: Request<State>, handler: F) -> Response
 where
-    State: Clone + Send + Sync + 'static,
+    State: TideState,
     F: Fn(Request<State>, Sender) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<()>> + Send + Sync + 'static,
 {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,6 +4,10 @@ use crate::{Middleware, Next, Request, Response};
 pub use async_trait::async_trait;
 use std::future::Future;
 
+/// A shortcut for Tide's State trait bounds: `Clone + Send + Sync + 'static`.
+pub trait TideState: Clone + Send + Sync + 'static {}
+impl<T: Clone + Send + Sync + 'static> TideState for T {}
+
 /// Define a middleware that operates on incoming requests.
 ///
 /// This middleware is useful because it is not possible in Rust yet to use
@@ -27,7 +31,7 @@ pub struct Before<F>(pub F);
 #[async_trait]
 impl<State, F, Fut> Middleware<State> for Before<F>
 where
-    State: Clone + Send + Sync + 'static,
+    State: TideState,
     F: Fn(Request<State>) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Request<State>> + Send + Sync + 'static,
 {
@@ -61,7 +65,7 @@ pub struct After<F>(pub F);
 #[async_trait]
 impl<State, F, Fut> Middleware<State> for After<F>
 where
-    State: Clone + Send + Sync + 'static,
+    State: TideState,
     F: Fn(Response) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = crate::Result> + Send + Sync + 'static,
 {

--- a/tests/route_middleware.rs
+++ b/tests/route_middleware.rs
@@ -2,6 +2,7 @@ mod test_utils;
 use http_types::headers::HeaderName;
 use std::convert::TryInto;
 use test_utils::ServerTestingExt;
+use tide::utils::TideState;
 use tide::Middleware;
 
 #[derive(Debug)]
@@ -14,7 +15,7 @@ impl TestMiddleware {
 }
 
 #[async_trait::async_trait]
-impl<State: Clone + Send + Sync + 'static> Middleware<State> for TestMiddleware {
+impl<State: TideState> Middleware<State> for TestMiddleware {
     async fn handle(
         &self,
         req: tide::Request<State>,

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -1,5 +1,6 @@
 use portpicker::pick_unused_port;
 use tide::http::{self, url::Url, Method};
+use tide::utils::TideState;
 use tide::Server;
 
 /// Find an unused port.
@@ -21,7 +22,7 @@ pub trait ServerTestingExt {
 #[async_trait::async_trait]
 impl<State> ServerTestingExt for Server<State>
 where
-    State: Clone + Send + Sync + 'static,
+    State: TideState,
 {
     async fn request(&self, method: Method, path: &str) -> http::Response {
         let url = if path.starts_with("http:") {


### PR DESCRIPTION
This replaces `State: Clone + Send + Sync + 'static` uses with
`State: TideState`, a trait alias for the same thing.

The goal is to make it so that any future changes to these bounds
needn't be directly modified in every instance of the `State` generic,
both in Tide and also for external middleware.

I suppose this maybe could be called `ThreadSafeClone` but that isn't as flexible for the future.
I do wonder if a `ThreadSafe` wouldn't be nice for all the other internal `Send + Sync + 'static` though.