### PR TITLE
enable clippy for tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,7 @@ jobs:
         rustc --version
 
     - name: clippy
-      run: cargo clippy -- -D warnings
+      run: cargo clippy --tests --examples -- -D warnings
 
     - name: fmt
       run: cargo fmt --all -- --check

--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -10,15 +10,12 @@ async fn main() -> Result<()> {
 
     app.middleware(After(|mut res: Response| async {
         if let Some(err) = res.downcast_error::<async_std::io::Error>() {
-            match err.kind() {
-                ErrorKind::NotFound => {
-                    let msg = err.to_string().to_owned();
-                    res.set_status(StatusCode::NotFound);
+            if let ErrorKind::NotFound = err.kind() {
+                let msg = err.to_string();
+                res.set_status(StatusCode::NotFound);
 
-                    // NOTE: You may want to avoid sending error messages in a production server.
-                    res.set_body(format!("Error: {}", msg));
-                }
-                _ => (), // Some default behavior if you like.
+                // NOTE: You may want to avoid sending error messages in a production server.
+                res.set_body(format!("Error: {}", msg));
             }
         }
         Ok(res)

--- a/examples/graphql.rs
+++ b/examples/graphql.rs
@@ -30,10 +30,10 @@ struct NewUser {
 }
 
 impl NewUser {
-    fn to_internal(self) -> User {
+    fn into_internal(self) -> User {
         User {
             id: None,
-            first_name: self.first_name.to_owned(),
+            first_name: self.first_name,
         }
     }
 }
@@ -51,7 +51,7 @@ impl QueryRoot {
     #[graphql(description = "Get all Users")]
     fn users(context: &State) -> Vec<User> {
         let users = context.users.read().unwrap();
-        users.iter().map(|u| u.clone()).collect()
+        users.iter().cloned().collect()
     }
 }
 
@@ -62,7 +62,7 @@ impl MutationRoot {
     #[graphql(description = "Add new user")]
     fn add_user(context: &State, user: NewUser) -> User {
         let mut users = context.users.write().unwrap();
-        let mut user = user.to_internal();
+        let mut user = user.into_internal();
         user.id = Some((users.len() + 1) as u16);
         users.push(user.clone());
         user

--- a/tests/chunked-encode-large.rs
+++ b/tests/chunked-encode-large.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use tide::Body;
 
-const TEXT: &'static str = concat![
+const TEXT: &str = concat![
     "Et provident reprehenderit accusamus dolores et voluptates sed quia. Repellendus odit porro ut et hic molestiae. Sit autem reiciendis animi fugiat deleniti vel iste. Laborum id odio ullam ut impedit dolores. Vel aperiam dolorem voluptatibus dignissimos maxime.",
     "Qui cumque autem debitis consequatur aliquam impedit id nostrum. Placeat error temporibus quos sed vel rerum. Fugit perferendis enim voluptatem rerum vitae dolor distinctio. Quia iusto ex enim voluptatum omnis. Nam et aperiam asperiores nesciunt eos magnam quidem et.",
     "Beatae et sit iure eum voluptatem accusantium quia optio. Tempora et rerum blanditiis repellendus qui est dolorem. Blanditiis deserunt qui dignissimos ad eligendi. Qui quia sequi et. Ipsa error quia quo ducimus et. Asperiores accusantium eius possimus dolore vitae iusto.",

--- a/tests/chunked-encode-small.rs
+++ b/tests/chunked-encode-small.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use tide::Body;
 
-const TEXT: &'static str = concat![
+const TEXT: &str = concat![
     "Eveniet delectus voluptatem in placeat modi. Qui nulla sunt aut non voluptas temporibus accusamus rem. Qui soluta nisi qui accusantium excepturi voluptatem. Ab rerum maiores neque ut expedita rem.",
     "Et neque praesentium eligendi quaerat consequatur asperiores dolorem. Pariatur tempore quidem animi consequuntur voluptatem quos. Porro quo ipsa quae suscipit. Doloribus est qui facilis ratione. Delectus ex perspiciatis ab alias et quisquam non est.",
     "Id dolorum distinctio distinctio quos est facilis commodi velit. Ex repudiandae aliquam eos voluptatum et. Provident qui molestiae molestiae nostrum voluptatum aperiam ut. Quis repellendus quidem mollitia aut recusandae laboriosam.",

--- a/tests/log.rs
+++ b/tests/log.rs
@@ -5,7 +5,7 @@ mod test_utils;
 
 #[async_std::test]
 async fn start_server_log() {
-    let logger = logtest::start();
+    let mut logger = logtest::start();
 
     let port = test_utils::find_port().await;
     let app = tide::new();
@@ -16,8 +16,7 @@ async fn start_server_log() {
     assert!(res.is_err());
 
     let record = logger
-        .filter(|rec| rec.args().starts_with("Server listening"))
-        .next()
+        .find(|rec| rec.args().starts_with("Server listening"))
         .unwrap();
     assert_eq!(
         record.args(),

--- a/tests/params.rs
+++ b/tests/params.rs
@@ -43,7 +43,7 @@ async fn test_missing_param() {
 #[async_std::test]
 async fn hello_world_parametrized() {
     async fn greet(req: tide::Request<()>) -> Result<Response> {
-        let name = req.param("name").unwrap_or("nori".to_owned());
+        let name = req.param("name").unwrap_or_else(|_| "nori".to_owned());
         let mut response = tide::Response::new(StatusCode::Ok);
         response.set_body(format!("{} says hello", name));
         Ok(response)

--- a/tests/response.rs
+++ b/tests/response.rs
@@ -8,8 +8,8 @@ async fn test_status() {
     let mut resp = Response::new(StatusCode::NotFound);
     resp.set_body("foo");
     assert_eq!(resp.status(), StatusCode::NotFound);
-    let foo = resp.take_body().into_string().await.unwrap();
-    assert_eq!(foo.as_bytes(), b"foo");
+    let body = resp.take_body().into_string().await.unwrap();
+    assert_eq!(body.as_bytes(), b"foo");
 }
 
 #[async_std::test]
@@ -21,8 +21,8 @@ async fn byte_vec_content_type() {
     resp.set_body(Body::from_reader(Cursor::new("foo"), None));
 
     assert_eq!(resp[headers::CONTENT_TYPE], mime::BYTE_STREAM.to_string());
-    let foo = resp.take_body().into_bytes().await.unwrap();
-    assert_eq!(foo, b"foo");
+    let body = resp.take_body().into_bytes().await.unwrap();
+    assert_eq!(body, b"foo");
 }
 
 #[async_std::test]
@@ -31,8 +31,8 @@ async fn string_content_type() {
     resp.set_body("foo");
 
     assert_eq!(resp[headers::CONTENT_TYPE], mime::PLAIN.to_string());
-    let foo = resp.take_body().into_string().await.unwrap();
-    assert_eq!(foo, "foo");
+    let body = resp.take_body().into_string().await.unwrap();
+    assert_eq!(body, "foo");
 }
 
 #[async_std::test]


### PR DESCRIPTION
This PR enables clippy checks for tests and examples during CI.

## Description
Clippy is valuable for tests and examples too, it can spot some mistakes that would make a test wrong.

## Motivation and Context
Having zero Clippy errors after the first clone/fork improves the contributor experience.

## How Has This Been Tested?
`cargo test --all --features unstable`
`cargo clippy --tests --examples`

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
