### PR TITLE
lib, Server: move defaults to default()

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ async-std = { version = "1.6.0", features = ["attributes"] }
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
-    let mut app = tide::new();
+    let mut app = tide::default();
     app.at("/").get(|_| async { Ok("Hello, world!") });
     app.listen("127.0.0.1:8080").await?;
     Ok(())

--- a/examples/catflap.rs
+++ b/examples/catflap.rs
@@ -3,7 +3,7 @@
 async fn main() -> Result<(), std::io::Error> {
     use std::{env, net::TcpListener, os::unix::io::FromRawFd};
     tide::log::start();
-    let mut app = tide::new();
+    let mut app = tide::default();
     app.at("/").get(|_| async { Ok(CHANGE_THIS_TEXT) });
 
     const CHANGE_THIS_TEXT: &str = "hello world!";

--- a/examples/chunked.rs
+++ b/examples/chunked.rs
@@ -3,7 +3,7 @@ use tide::Body;
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
-    let mut app = tide::new();
+    let mut app = tide::default();
     app.at("/").get(|_| async {
         // File sends are chunked by default.
         Ok(Body::from_file(file!()).await?)

--- a/examples/concurrent_listeners.rs
+++ b/examples/concurrent_listeners.rs
@@ -3,7 +3,7 @@ use tide::Request;
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
-    let mut app = tide::new();
+    let mut app = tide::default();
 
     app.at("/").get(|request: Request<_>| async move {
         Ok(format!(

--- a/examples/cookies.rs
+++ b/examples/cookies.rs
@@ -22,7 +22,7 @@ async fn remove_cookie(_req: Request<()>) -> tide::Result {
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
-    let mut app = tide::new();
+    let mut app = tide::default();
 
     app.at("/").get(retrieve_cookie);
     app.at("/set").get(insert_cookie);

--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -6,7 +6,7 @@ use tide::{Body, Request, Response, Result, StatusCode};
 #[async_std::main]
 async fn main() -> Result<()> {
     tide::log::start();
-    let mut app = tide::new();
+    let mut app = tide::default();
 
     app.middleware(After(|mut res: Response| async {
         if let Some(err) = res.downcast_error::<async_std::io::Error>() {

--- a/examples/fib.rs
+++ b/examples/fib.rs
@@ -30,7 +30,7 @@ async fn fibsum(req: Request<()>) -> tide::Result<String> {
 // It was computed in 2 secs.
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
-    let mut app = tide::new();
+    let mut app = tide::default();
     app.at("/fib/:n").get(fibsum);
     app.listen("0.0.0.0:8080").await?;
     Ok(())

--- a/examples/graphql.rs
+++ b/examples/graphql.rs
@@ -96,7 +96,7 @@ async fn handle_graphiql(_: Request<State>) -> tide::Result<impl Into<Response>>
 
 #[async_std::main]
 async fn main() -> std::io::Result<()> {
-    let mut app = Server::with_state(State {
+    let mut app = Server::default_with_state(State {
         users: Arc::new(RwLock::new(Vec::new())),
     });
     app.at("/").get(Redirect::permanent("/graphiql"));

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,7 +1,7 @@
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
-    let mut app = tide::new();
+    let mut app = tide::default();
     app.at("/").get(|_| async { Ok("Hello, world!") });
     app.listen("127.0.0.1:8080").await?;
     Ok(())

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -10,7 +10,7 @@ struct Cat {
 #[async_std::main]
 async fn main() -> tide::Result<()> {
     tide::log::start();
-    let mut app = tide::new();
+    let mut app = tide::default();
 
     app.at("/submit").post(|mut req: Request<()>| async move {
         let cat: Cat = req.body_json().await?;

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -92,7 +92,7 @@ const INTERNAL_SERVER_ERROR_HTML_PAGE: &str = "<html><body>
 #[async_std::main]
 async fn main() -> Result<()> {
     tide::log::start();
-    let mut app = tide::with_state(UserDatabase::default());
+    let mut app = tide::default_with_state(UserDatabase::default());
 
     app.middleware(After(|response: Response| async move {
         let response = match response.status() {

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -1,7 +1,7 @@
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
-    let mut app = tide::new();
+    let mut app = tide::default();
     app.at("/").get(|_| async { Ok("Root") });
     app.at("/api").nest({
         let mut api = tide::new();

--- a/examples/redirect.rs
+++ b/examples/redirect.rs
@@ -3,7 +3,7 @@ use tide::{Redirect, Response, StatusCode};
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
-    let mut app = tide::new();
+    let mut app = tide::default();
     app.at("/").get(|_| async { Ok("Root") });
 
     // Redirect hackers to YouTube.

--- a/examples/sse.rs
+++ b/examples/sse.rs
@@ -3,7 +3,7 @@ use tide::sse;
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
-    let mut app = tide::new();
+    let mut app = tide::default();
     app.at("/sse").get(sse::endpoint(|_req, sender| async move {
         sender.send("fruit", "banana", None).await?;
         sender.send("fruit", "apple", None).await?;

--- a/examples/static_file.rs
+++ b/examples/static_file.rs
@@ -1,7 +1,7 @@
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
-    let mut app = tide::new();
+    let mut app = tide::default();
     app.at("/").get(|_| async { Ok("visit /src/*") });
     app.at("/src").serve_dir("src/")?;
     app.listen("127.0.0.1:8080").await?;

--- a/examples/upload.rs
+++ b/examples/upload.rs
@@ -27,7 +27,7 @@ impl TempDirState {
 #[async_std::main]
 async fn main() -> Result<(), IoError> {
     tide::log::start();
-    let mut app = tide::with_state(TempDirState::try_new()?);
+    let mut app = tide::default_with_state(TempDirState::try_new()?);
 
     // To test this example:
     // $ cargo run --example upload

--- a/src/cookies/middleware.rs
+++ b/src/cookies/middleware.rs
@@ -25,7 +25,7 @@ use std::sync::{Arc, RwLock};
 /// });
 /// ```
 #[derive(Debug, Clone, Default)]
-pub(crate) struct CookiesMiddleware;
+pub struct CookiesMiddleware;
 
 impl CookiesMiddleware {
     /// Creates a new `CookiesMiddleware`.

--- a/src/cookies/mod.rs
+++ b/src/cookies/mod.rs
@@ -2,4 +2,5 @@
 
 mod middleware;
 
-pub(crate) use middleware::{CookieData, CookiesMiddleware};
+pub(crate) use middleware::CookieData;
+pub use middleware::CookiesMiddleware;

--- a/src/security/cors.rs
+++ b/src/security/cors.rs
@@ -250,7 +250,7 @@ mod test {
     }
 
     fn app() -> crate::Server<()> {
-        let mut app = crate::Server::new();
+        let mut app = crate::Server::default();
         app.at(ENDPOINT).get(|_| async { Ok("Hello World") });
 
         app
@@ -365,7 +365,7 @@ mod test {
 
     #[async_std::test]
     async fn retain_cookies() {
-        let mut app = crate::Server::new();
+        let mut app = crate::Server::default();
         app.middleware(CorsMiddleware::new().allow_origin(ALLOW_ORIGIN));
         app.at(ENDPOINT).get(|_| async {
             let mut res = crate::Response::new(http_types::StatusCode::Ok);
@@ -382,7 +382,7 @@ mod test {
 
     #[async_std::test]
     async fn set_cors_headers_to_error_responses() {
-        let mut app = crate::Server::new();
+        let mut app = crate::Server::default();
         app.at(ENDPOINT).get(|_| async {
             Err::<&str, _>(crate::Error::from_str(
                 StatusCode::BadRequest,

--- a/tests/cookies.rs
+++ b/tests/cookies.rs
@@ -35,6 +35,7 @@ async fn set_multiple_cookie(_req: Request<()>) -> tide::Result {
 
 fn app() -> crate::Server<()> {
     let mut app = tide::new();
+    app.middleware(tide::cookies::CookiesMiddleware);
 
     app.at("/get").get(retrieve_cookie);
     app.at("/set").get(insert_cookie);


### PR DESCRIPTION
This moves the default enabled built-in middleware to `tide::default()`,
and makes `tide::new()` return a plain `Server`.

Refs: https://github.com/http-rs/tide/issues/548
Fixes: https://github.com/http-rs/tide/issues/476

Or at least, this is one possible solution...

Alternatively: `new()` and `new_blank()` or something?