### PR TITLE
src: feature-flag default logger, start/with_level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,9 @@ features = ["docs"]
 rustdoc-args = ["--cfg", "feature=\"docs\""]
 
 [features]
-default = ["h1-server"]
+default = ["h1-server", "logger"]
 h1-server = ["async-h1"]
+logger = []
 docs = ["unstable"]
 unstable = []
 # DO NOT USE. Only exists to expose internals so they can be benchmarked.

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -25,12 +25,14 @@ pub use femme::LevelFilter;
 pub use middleware::LogMiddleware;
 
 /// Start logging.
+#[cfg(feature = "logger")]
 pub fn start() {
     femme::start();
     crate::log::info!("Logger started", { level: "Info" });
 }
 
 /// Start logging with a log level.
+#[cfg(feature = "logger")]
 pub fn with_level(level: LevelFilter) {
     femme::with_level(level);
     crate::log::info!("Logger started", { level: format!("{}", level) });

--- a/src/server.rs
+++ b/src/server.rs
@@ -98,6 +98,7 @@ impl<State: Clone + Send + Sync + 'static> Server<State> {
             state,
         };
         server.middleware(cookies::CookiesMiddleware::new());
+        #[cfg(feature = "logger")]
         server.middleware(log::LogMiddleware::new());
         server
     }


### PR DESCRIPTION
Refs: https://github.com/http-rs/tide/issues/548

The easier to fix that and related issues.

This doesn't tackle `CookiesMiddleware` because it's practically necessary, I think?