### PR TITLE
Only run the log middleware once per request

### DIFF
--- a/src/log/middleware.rs
+++ b/src/log/middleware.rs
@@ -3,7 +3,9 @@ use crate::{Middleware, Next, Request};
 
 /// Log all incoming requests and responses.
 ///
-/// This middleware is enabled by default in Tide.
+/// This middleware is enabled by default in Tide. In the case of
+/// nested applications, this middleware will only run once for each
+/// request.
 ///
 /// # Examples
 ///
@@ -16,6 +18,8 @@ pub struct LogMiddleware {
     _priv: (),
 }
 
+struct LogMiddlewareHasBeenRun;
+
 impl LogMiddleware {
     /// Create a new instance of `LogMiddleware`.
     #[must_use]
@@ -26,17 +30,22 @@ impl LogMiddleware {
     /// Log a request and a response.
     async fn log<'a, State: Clone + Send + Sync + 'static>(
         &'a self,
-        ctx: Request<State>,
+        mut req: Request<State>,
         next: Next<'a, State>,
     ) -> crate::Result {
-        let path = ctx.url().path().to_owned();
-        let method = ctx.method().to_string();
+        if req.ext::<LogMiddlewareHasBeenRun>().is_some() {
+            return Ok(next.run(req).await);
+        }
+        req.set_ext(LogMiddlewareHasBeenRun);
+
+        let path = req.url().path().to_owned();
+        let method = req.method().to_string();
         log::info!("<-- Request received", {
             method: method,
             path: path,
         });
         let start = std::time::Instant::now();
-        let response = next.run(ctx).await;
+        let response = next.run(req).await;
         let status = response.status();
         if status.is_server_error() {
             if let Some(error) = response.error() {

--- a/tests/log.rs
+++ b/tests/log.rs
@@ -2,11 +2,16 @@ use async_std::prelude::*;
 use std::time::Duration;
 
 mod test_utils;
+use test_utils::ServerTestingExt;
 
 #[async_std::test]
-async fn start_server_log() {
+async fn log_tests() {
     let mut logger = logtest::start();
+    test_server_listen(&mut logger).await;
+    test_only_log_once(&mut logger).await;
+}
 
+async fn test_server_listen(logger: &mut logtest::Logger) {
     let port = test_utils::find_port().await;
     let app = tide::new();
     let res = app
@@ -21,5 +26,33 @@ async fn start_server_log() {
     assert_eq!(
         record.args(),
         format!("Server listening on http://[::1]:{}", port)
+    );
+}
+
+async fn test_only_log_once(logger: &mut logtest::Logger) {
+    let mut app = tide::new();
+    app.at("/").nest({
+        let mut app = tide::new();
+        app.at("/").get(|_| async { Ok("nested") });
+        app
+    });
+    app.get("/").await;
+
+    let entries: Vec<_> = logger.collect();
+
+    assert_eq!(
+        1,
+        entries
+            .iter()
+            .filter(|entry| entry.args() == "<-- Request received")
+            .count()
+    );
+
+    assert_eq!(
+        1,
+        entries
+            .iter()
+            .filter(|entry| entry.args() == "--> Response sent")
+            .count()
     );
 }


### PR DESCRIPTION
Currently, nested applications like
```rust
async fn main() -> Result<(), std::io::Error> {
    tide::log::start();
    let mut app = tide::new();
    app.at("/").nest({
        let mut api = tide::new();
        api.at("/").get(|_| async { Ok("Hello, world") });
        api
    });
    app.listen("127.0.0.1:8080").await?;
    Ok(())
}
```
will log twice. This provides a simple mechanism to ensure that a particular middleware is only run once per request. This approach also supports reentrant routing. This approach also requires no sweeping changes to the tide middleware system to ensure only-once middleware behavior, and also allows the middleware to define the desired behavior if it has already run once for the request.  For example, a more complex logging middleware might record the time spent in each nested application but only emit that aggregated information once per request

## Description
Introduces a private unit struct which is added to request extensions.

## How Has This Been Tested?
added a test in tests/log.rs that uses logtest to assert that only one request received log entry is emitted, and only one response sent message is emitted per request/response cycle, even with a nested app. this test previously failed

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

closes: #551

This same pattern should be applied to the cookie middleware as well if this is merged