### PR TITLE
Rename .middleware to .with

### DIFF
--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -8,7 +8,7 @@ async fn main() -> Result<()> {
     tide::log::start();
     let mut app = tide::new();
 
-    app.middleware(After(|mut res: Response| async {
+    app.with(After(|mut res: Response| async {
         if let Some(err) = res.downcast_error::<async_std::io::Error>() {
             if let ErrorKind::NotFound = err.kind() {
                 let msg = err.to_string();

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -94,7 +94,7 @@ async fn main() -> Result<()> {
     tide::log::start();
     let mut app = tide::with_state(UserDatabase::default());
 
-    app.middleware(After(|response: Response| async move {
+    app.with(After(|response: Response| async move {
         let response = match response.status() {
             StatusCode::NotFound => Response::builder(404)
                 .content_type(mime::HTML)
@@ -112,9 +112,9 @@ async fn main() -> Result<()> {
         Ok(response)
     }));
 
-    app.middleware(user_loader);
-    app.middleware(RequestCounterMiddleware::new(0));
-    app.middleware(Before(|mut request: Request<UserDatabase>| async move {
+    app.with(user_loader);
+    app.with(RequestCounterMiddleware::new(0));
+    app.with(Before(|mut request: Request<UserDatabase>| async move {
         request.set_ext(std::time::Instant::now());
         request
     }));

--- a/examples/sessions.rs
+++ b/examples/sessions.rs
@@ -3,7 +3,7 @@ async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
     let mut app = tide::new();
 
-    app.middleware(tide::sessions::SessionMiddleware::new(
+    app.with(tide::sessions::SessionMiddleware::new(
         tide::sessions::MemoryStore::new(),
         std::env::var("TIDE_SECRET")
             .expect(
@@ -13,7 +13,7 @@ async fn main() -> Result<(), std::io::Error> {
             .as_bytes(),
     ));
 
-    app.middleware(tide::utils::Before(
+    app.with(tide::utils::Before(
         |mut request: tide::Request<()>| async move {
             let session = request.session_mut();
             let visits: usize = session.get("visits").unwrap_or_default();

--- a/src/log/middleware.rs
+++ b/src/log/middleware.rs
@@ -9,7 +9,7 @@ use crate::{Middleware, Next, Request};
 ///
 /// ```
 /// let mut app = tide::Server::new();
-/// app.middleware(tide::log::LogMiddleware::new());
+/// app.with(tide::log::LogMiddleware::new());
 /// ```
 #[derive(Debug, Default, Clone)]
 pub struct LogMiddleware {

--- a/src/route.rs
+++ b/src/route.rs
@@ -77,7 +77,7 @@ impl<'a, State: Clone + Send + Sync + 'static> Route<'a, State> {
     }
 
     /// Apply the given middleware to the current route.
-    pub fn middleware<M>(&mut self, middleware: M) -> &mut Self
+    pub fn with<M>(&mut self, middleware: M) -> &mut Self
     where
         M: Middleware<State>,
     {

--- a/src/security/cors.rs
+++ b/src/security/cors.rs
@@ -265,7 +265,7 @@ mod test {
     #[async_std::test]
     async fn preflight_request() {
         let mut app = app();
-        app.middleware(
+        app.with(
             CorsMiddleware::new()
                 .allow_origin(Origin::from(ALLOW_ORIGIN))
                 .allow_methods(ALLOW_METHODS.parse::<HeaderValue>().unwrap())
@@ -290,7 +290,7 @@ mod test {
     #[async_std::test]
     async fn default_cors_middleware() {
         let mut app = app();
-        app.middleware(CorsMiddleware::new());
+        app.with(CorsMiddleware::new());
         let res: crate::http::Response = app.respond(request()).await.unwrap();
 
         assert_eq!(res.status(), 200);
@@ -300,7 +300,7 @@ mod test {
     #[async_std::test]
     async fn custom_cors_middleware() {
         let mut app = app();
-        app.middleware(
+        app.with(
             CorsMiddleware::new()
                 .allow_origin(Origin::from(ALLOW_ORIGIN))
                 .allow_credentials(false)
@@ -316,7 +316,7 @@ mod test {
     #[async_std::test]
     async fn credentials_true() {
         let mut app = app();
-        app.middleware(CorsMiddleware::new().allow_credentials(true));
+        app.with(CorsMiddleware::new().allow_credentials(true));
         let res: crate::http::Response = app.respond(request()).await.unwrap();
 
         assert_eq!(res.status(), 200);
@@ -327,7 +327,7 @@ mod test {
     async fn set_allow_origin_list() {
         let mut app = app();
         let origins = vec![ALLOW_ORIGIN, "foo.com", "bar.com"];
-        app.middleware(CorsMiddleware::new().allow_origin(origins.clone()));
+        app.with(CorsMiddleware::new().allow_origin(origins.clone()));
 
         for origin in origins {
             let mut req = http_types::Request::new(http_types::Method::Get, endpoint_url());
@@ -343,7 +343,7 @@ mod test {
     #[async_std::test]
     async fn not_set_origin_header() {
         let mut app = app();
-        app.middleware(CorsMiddleware::new().allow_origin(ALLOW_ORIGIN));
+        app.with(CorsMiddleware::new().allow_origin(ALLOW_ORIGIN));
 
         let req = crate::http::Request::new(http_types::Method::Get, endpoint_url());
         let res: crate::http::Response = app.respond(req).await.unwrap();
@@ -354,7 +354,7 @@ mod test {
     #[async_std::test]
     async fn unauthorized_origin() {
         let mut app = app();
-        app.middleware(CorsMiddleware::new().allow_origin(ALLOW_ORIGIN));
+        app.with(CorsMiddleware::new().allow_origin(ALLOW_ORIGIN));
 
         let mut req = http_types::Request::new(http_types::Method::Get, endpoint_url());
         req.insert_header(http_types::headers::ORIGIN, "unauthorize-origin.net");
@@ -366,7 +366,7 @@ mod test {
     #[async_std::test]
     async fn retain_cookies() {
         let mut app = crate::Server::new();
-        app.middleware(CorsMiddleware::new().allow_origin(ALLOW_ORIGIN));
+        app.with(CorsMiddleware::new().allow_origin(ALLOW_ORIGIN));
         app.at(ENDPOINT).get(|_| async {
             let mut res = crate::Response::new(http_types::StatusCode::Ok);
             res.insert_cookie(http_types::Cookie::new("foo", "bar"));
@@ -389,7 +389,7 @@ mod test {
                 "bad request",
             ))
         });
-        app.middleware(CorsMiddleware::new().allow_origin(Origin::from(ALLOW_ORIGIN)));
+        app.with(CorsMiddleware::new().allow_origin(Origin::from(ALLOW_ORIGIN)));
 
         let res: crate::http::Response = app.respond(request()).await.unwrap();
         assert_eq!(res.status(), 400);

--- a/src/server.rs
+++ b/src/server.rs
@@ -97,9 +97,9 @@ impl<State: Clone + Send + Sync + 'static> Server<State> {
             middleware: Arc::new(vec![]),
             state,
         };
-        server.middleware(cookies::CookiesMiddleware::new());
+        server.with(cookies::CookiesMiddleware::new());
         #[cfg(feature = "logger")]
-        server.middleware(log::LogMiddleware::new());
+        server.with(log::LogMiddleware::new());
         server
     }
 
@@ -164,7 +164,7 @@ impl<State: Clone + Send + Sync + 'static> Server<State> {
     ///
     /// Middleware can only be added at the "top level" of an application, and is processed in the
     /// order in which it is applied.
-    pub fn middleware<M>(&mut self, middleware: M) -> &mut Self
+    pub fn with<M>(&mut self, middleware: M) -> &mut Self
     where
         M: Middleware<State>,
     {

--- a/src/sessions/middleware.rs
+++ b/src/sessions/middleware.rs
@@ -22,12 +22,12 @@ const BASE64_DIGEST_LEN: usize = 44;
 /// # async_std::task::block_on(async {
 /// let mut app = tide::new();
 ///
-/// app.middleware(tide::sessions::SessionMiddleware::new(
+/// app.with(tide::sessions::SessionMiddleware::new(
 ///     tide::sessions::MemoryStore::new(),
 ///     b"we recommend you use std::env::var(\"TIDE_SECRET\").unwrap().as_bytes() instead of a fixed value"
 /// ));
 ///
-/// app.middleware(tide::utils::Before(|mut request: tide::Request<()>| async move {
+/// app.with(tide::utils::Before(|mut request: tide::Request<()>| async move {
 ///     let session = request.session_mut();
 ///     let visits: usize = session.get("visits").unwrap_or_default();
 ///     session.insert("visits", visits + 1).unwrap();
@@ -153,7 +153,7 @@ impl<Store: SessionStore> SessionMiddleware<Store> {
     /// # use std::time::Duration;
     /// # use tide::sessions::{SessionMiddleware, MemoryStore};
     /// let mut app = tide::new();
-    /// app.middleware(
+    /// app.with(
     ///     SessionMiddleware::new(MemoryStore::new(), b"please do not hardcode your secret")
     ///         .with_cookie_name("custom.cookie.name")
     ///         .with_cookie_path("/some/path")

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,7 +16,7 @@ use std::future::Future;
 /// use std::time::Instant;
 ///
 /// let mut app = tide::new();
-/// app.middleware(utils::Before(|mut request: Request<()>| async move {
+/// app.with(utils::Before(|mut request: Request<()>| async move {
 ///     request.set_ext(Instant::now());
 ///     request
 /// }));
@@ -48,7 +48,7 @@ where
 /// use tide::{utils, http, Response};
 ///
 /// let mut app = tide::new();
-/// app.middleware(utils::After(|res: Response| async move {
+/// app.with(utils::After(|res: Response| async move {
 ///     match res.status() {
 ///         http::StatusCode::NotFound => Ok("Page not found".into()),
 ///         http::StatusCode::InternalServerError => Ok("Something went wrong".into()),

--- a/tests/function_middleware.rs
+++ b/tests/function_middleware.rs
@@ -29,9 +29,7 @@ async fn echo_path<State>(req: tide::Request<State>) -> tide::Result<String> {
 #[async_std::test]
 async fn route_middleware() {
     let mut app = tide::new();
-    app.at("/protected")
-        .with(auth_middleware)
-        .get(echo_path);
+    app.at("/protected").with(auth_middleware).get(echo_path);
     app.at("/unprotected").get(echo_path);
 
     // Protected

--- a/tests/function_middleware.rs
+++ b/tests/function_middleware.rs
@@ -30,7 +30,7 @@ async fn echo_path<State>(req: tide::Request<State>) -> tide::Result<String> {
 async fn route_middleware() {
     let mut app = tide::new();
     app.at("/protected")
-        .middleware(auth_middleware)
+        .with(auth_middleware)
         .get(echo_path);
     app.at("/unprotected").get(echo_path);
 
@@ -70,7 +70,7 @@ async fn route_middleware() {
 #[async_std::test]
 async fn app_middleware() {
     let mut app = tide::new();
-    app.middleware(auth_middleware);
+    app.with(auth_middleware);
     app.at("/foo").get(echo_path);
 
     // Foo

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -20,7 +20,7 @@ async fn nested_middleware() {
     let echo_path = |req: tide::Request<()>| async move { Ok(req.url().path().to_string()) };
     let mut app = tide::new();
     let mut inner_app = tide::new();
-    inner_app.middleware(tide::utils::After(|mut res: tide::Response| async move {
+    inner_app.with(tide::utils::After(|mut res: tide::Response| async move {
         res.insert_header("x-tide-test", "1");
         Ok(res)
     }));

--- a/tests/route_middleware.rs
+++ b/tests/route_middleware.rs
@@ -35,11 +35,11 @@ async fn route_middleware() {
     let mut app = tide::new();
     let mut foo_route = app.at("/foo");
     foo_route // /foo
-        .middleware(TestMiddleware::with_header_name("X-Foo", "foo"))
+        .with(TestMiddleware::with_header_name("X-Foo", "foo"))
         .get(echo_path);
     foo_route
         .at("/bar") // nested, /foo/bar
-        .middleware(TestMiddleware::with_header_name("X-Bar", "bar"))
+        .with(TestMiddleware::with_header_name("X-Bar", "bar"))
         .get(echo_path);
     foo_route // /foo
         .post(echo_path)
@@ -58,12 +58,12 @@ async fn route_middleware() {
 #[async_std::test]
 async fn app_and_route_middleware() {
     let mut app = tide::new();
-    app.middleware(TestMiddleware::with_header_name("X-Root", "root"));
+    app.with(TestMiddleware::with_header_name("X-Root", "root"));
     app.at("/foo")
-        .middleware(TestMiddleware::with_header_name("X-Foo", "foo"))
+        .with(TestMiddleware::with_header_name("X-Foo", "foo"))
         .get(echo_path);
     app.at("/bar")
-        .middleware(TestMiddleware::with_header_name("X-Bar", "bar"))
+        .with(TestMiddleware::with_header_name("X-Bar", "bar"))
         .get(echo_path);
 
     let res = app.get("/foo").await;
@@ -80,19 +80,19 @@ async fn app_and_route_middleware() {
 #[async_std::test]
 async fn nested_app_with_route_middleware() {
     let mut inner = tide::new();
-    inner.middleware(TestMiddleware::with_header_name("X-Inner", "inner"));
+    inner.with(TestMiddleware::with_header_name("X-Inner", "inner"));
     inner
         .at("/baz")
-        .middleware(TestMiddleware::with_header_name("X-Baz", "baz"))
+        .with(TestMiddleware::with_header_name("X-Baz", "baz"))
         .get(echo_path);
 
     let mut app = tide::new();
-    app.middleware(TestMiddleware::with_header_name("X-Root", "root"));
+    app.with(TestMiddleware::with_header_name("X-Root", "root"));
     app.at("/foo")
-        .middleware(TestMiddleware::with_header_name("X-Foo", "foo"))
+        .with(TestMiddleware::with_header_name("X-Foo", "foo"))
         .get(echo_path);
     app.at("/bar")
-        .middleware(TestMiddleware::with_header_name("X-Bar", "bar"))
+        .with(TestMiddleware::with_header_name("X-Bar", "bar"))
         .nest(inner);
 
     let res = app.get("/foo").await;
@@ -114,10 +114,10 @@ async fn nested_app_with_route_middleware() {
 async fn subroute_not_nested() {
     let mut app = tide::new();
     app.at("/parent") // /parent
-        .middleware(TestMiddleware::with_header_name("X-Parent", "Parent"))
+        .with(TestMiddleware::with_header_name("X-Parent", "Parent"))
         .get(echo_path);
     app.at("/parent/child") // /parent/child, not nested
-        .middleware(TestMiddleware::with_header_name("X-Child", "child"))
+        .with(TestMiddleware::with_header_name("X-Child", "child"))
         .get(echo_path);
 
     let res = app.get("/parent/child").await;

--- a/tests/sessions.rs
+++ b/tests/sessions.rs
@@ -21,12 +21,12 @@ struct SessionData {
 #[async_std::test]
 async fn test_basic_sessions() {
     let mut app = tide::new();
-    app.middleware(SessionMiddleware::new(
+    app.with(SessionMiddleware::new(
         MemoryStore::new(),
         b"12345678901234567890123456789012345",
     ));
 
-    app.middleware(Before(|mut request: tide::Request<()>| async move {
+    app.with(Before(|mut request: tide::Request<()>| async move {
         let visits: usize = request.session().get("visits").unwrap_or_default();
         request.session_mut().insert("visits", visits + 1).unwrap();
         request
@@ -62,7 +62,7 @@ async fn test_basic_sessions() {
 #[async_std::test]
 async fn test_customized_sessions() {
     let mut app = tide::new();
-    app.middleware(
+    app.with(
         SessionMiddleware::new(MemoryStore::new(), b"12345678901234567890123456789012345")
             .with_cookie_name("custom.cookie.name")
             .with_cookie_path("/nested")
@@ -129,12 +129,12 @@ async fn test_customized_sessions() {
 #[async_std::test]
 async fn test_session_destruction() {
     let mut app = tide::new();
-    app.middleware(SessionMiddleware::new(
+    app.with(SessionMiddleware::new(
         MemoryStore::new(),
         b"12345678901234567890123456789012345",
     ));
 
-    app.middleware(Before(|mut request: tide::Request<()>| async move {
+    app.with(Before(|mut request: tide::Request<()>| async move {
         let visits: usize = request.session().get("visits").unwrap_or_default();
         request.session_mut().insert("visits", visits + 1).unwrap();
         request


### PR DESCRIPTION
Renames `{Route, Server}::middleware` to `{Route, Server}::with`. Closes #665. 