### PR TITLE
Bump version number in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A modular web framework built around async/await
 Add two dependencies to your project's `Cargo.toml` file: `tide` itself, and `async-std` with the feature `attributes` enabled:
 ```toml
 # Example, use the version numbers you need
-tide = "0.12.0"
+tide = "0.13.0"
 async-std = { version = "1.6.0", features = ["attributes"] }
 ```
 


### PR DESCRIPTION
Update README.md to use the new `0.13` version

## Description
Updated the `Cargo.toml` example in the README.md to use the new `0.13` version

## Motivation and Context
Make sure people get the newest version when they copy the example lines from the README.md file

## How Has This Been Tested?
Ran the tests and they're all fine, and it's a simple documentation change so did not feel the need to do further testing.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
