### PR TITLE
expose server state

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -228,6 +228,21 @@ impl<State: Clone + Send + Sync + 'static> Server<State> {
         let res: http_types::Response = res.into();
         Ok(res.into())
     }
+
+    /// Gets a reference to the server's state. This is useful for testing and nesting:
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # #[derive(Clone)] struct SomeAppState;
+    /// let mut app = tide::with_state(SomeAppState);
+    /// let mut admin = tide::with_state(app.state().clone());
+    /// admin.at("/").get(|_| async { Ok("nested app with cloned state") });
+    /// app.at("/").nest(admin);
+    /// ```
+    pub fn state(&self) -> &State {
+        &self.state
+    }
 }
 
 impl<State: Clone> Clone for Server<State> {


### PR DESCRIPTION
Currently there's no way to get access to the state on a Server.

I ran into this trying to test an app with a database pool in the State. I had a reference to a Server and wanted to execute statements against the database, but there was no way of doing so.

## How Has This Been Tested?
doctest

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
