### PR TITLE
Fix a broken documentation link

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -321,8 +321,8 @@ impl<State> Request<State> {
             .and_then(|param| param.parse().map_err(ParamError::ParsingError))
     }
 
-    /// Parse the URL query component into a struct, using [serde_qs](serde_qs). To get the entire
-    /// query as an unparsed string, use `request.url().query()`
+    /// Parse the URL query component into a struct, using [serde_qs](https://docs.rs/serde_qs). To
+    /// get the entire query as an unparsed string, use `request.url().query()`
     ///
     /// ```rust
     /// # fn main() -> Result<(), std::io::Error> { async_std::task::block_on(async {


### PR DESCRIPTION
Fix a broken documentation link that should point to `serde_qs` so that
users do not have to search themselves.

## Description

Simply fix a broken documentation link referring to the external `serde_qs` crate so that users can click it on `docs.rs` instead of searching for the crate themselves.

## Motivation and Context

This allows the documentation to be followed slightly more easily and means `cargo doc` produces no warnings (other than those created by [this issue](https://github.com/rust-lang/cargo/issues/6313)).

## How Has This Been Tested?

This affects no tests and makes no changes to the functionality, so the unit tests pass before and after the change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
