### PR TITLE
Serve content with support for HTTP conditionals and range requests

### DIFF
--- a/src/utils/middleware.rs
+++ b/src/utils/middleware.rs
@@ -1,7 +1,7 @@
-//! Miscellaneous utilities.
+//! Miscellaneous middleware utilities.
 
+use crate::utils::async_trait;
 use crate::{Middleware, Next, Request, Response};
-pub use async_trait::async_trait;
 use std::future::Future;
 
 /// Define a middleware that operates on incoming requests.

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,8 @@
 //! Miscellaneous utilities.
 
 mod middleware;
+mod serve_content;
 
 pub use async_trait::async_trait;
 pub use middleware::{After, Before};
+pub use serve_content::{serve_content, serve_content_with, ModState};

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,6 @@
+//! Miscellaneous utilities.
+
+mod middleware;
+
+pub use async_trait::async_trait;
+pub use middleware::{After, Before};

--- a/src/utils/serve_content.rs
+++ b/src/utils/serve_content.rs
@@ -1,0 +1,98 @@
+//! Content serving utilities with support for conditional requests
+//! as defined in [RFC 7232](https://tools.ietf.org/html/rfc7232)
+
+use async_std::io::{BufRead as AsyncBufRead, Read as AsyncRead, Seek as AsyncSeek};
+
+use crate::{Request, Response, Result, StatusCode};
+
+/// A HTTP ressource modification state.
+///
+/// The modification state can be verified
+/// against a `Request` with conditional headers to eventually serve a
+/// `304 Not modified` or `206 Partial Content` response.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ModState {
+    /// The ressource has been modified.
+    Modified,
+    /// The ressource last modification date.
+    /// Used with `If-Modified-since`, `If-Unmodified-Since`
+    /// and `If-Range` conditional headers.
+    ///
+    /// It is considered as a strong validator for `If-Range` requests.
+    Date(http_types::utils::HttpDate),
+    /// A ressource's version identifier.
+    /// Used with `If-None-Match`, `If-Match` and `If-Range` conditional headers.
+    Etag(http_types::conditional::ETag),
+}
+
+/// Serve content according to its modification state and the request's conditional headers:
+/// If-Match, If-None-Match, If-Modified-Since, If-Unmodified-Since, Range, If-Range.
+///
+/// The few first bytes of the content is read to guess the MIME Type.
+///
+/// # Examples
+///
+/// Serve a static file returning `304 Not Modified` if the file's modification date
+/// is earlier than the request's `If-Modified-Since` header.
+///
+/// ```
+/// # #[allow(dead_code)]
+/// async fn route_handler(request: tide::Request<()>) -> tide::Result {
+///     use async_std::io::BufReader;
+///     use async_std::fs::File;
+///     use tide::utils::{serve_content, ModState};
+///     
+///     let file = File::open("/foo/bar").await?;
+///     let metadata = file.metadata().await?;
+///     let mod_time = metadata.modified()?;
+///     let content = BufReader::new(file);
+///
+///     serve_content(request, content, ModState::from(mod_time)).await
+/// }
+/// ```
+pub async fn serve_content<S, T>(req: Request<S>, content: T, mod_state: ModState) -> Result
+where
+    T: AsyncRead + AsyncBufRead + AsyncSeek + Send + Sync + Unpin + 'static,
+{
+    let res = Response::new(StatusCode::Ok);
+    serve_content_with(req, res, content, mod_state).await
+}
+
+/// Similar than `serve_content` but allows to use a predefined `Response`.
+///
+/// `serve_content_with` only modifies the response content, status and headers
+/// related to conditional requests. The MIME type is not guessed from the content data.
+///
+/// # Examples
+///
+/// Serve a static file returning `304 Not Modified` if the file's modification date
+/// is earlier than the request's `If-Modified-Since` header, with HTML MIME type.
+///
+/// ```
+/// # use tide::{Response, Redirect, Request, StatusCode};
+/// # use async_std::io::BufReader;
+/// # #[allow(dead_code)]
+/// async fn route_handler(request: Request<()>) -> tide::Result {
+///     use tide::utils::{serve_content, ModState};
+///     
+///     let file = async_std::fs::File::open("/foo/bar").await?;
+///     let metadata = file.metadata().await?;
+///     let mod_time = metadata.modified()?;
+///     let content = BufReader::new(file);
+///
+///     let response = tide::Response::builder(200).content_type(tide::mime::HTML);
+///
+///     serve_content_with(request, response, content, ModState::from(mod_time)).await
+/// }
+/// ```
+pub async fn serve_content_with<S, T>(
+    req: Request<S>,
+    res: Response,
+    content: T,
+    mod_state: ModState,
+) -> Result
+where
+    T: AsyncRead + AsyncBufRead + AsyncSeek + Send + Sync + Unpin + 'static,
+{
+    todo!();
+}


### PR DESCRIPTION
This PR introduces new utilities to serve content with support for HTTP conditionals as defined in [RFC7232](https://tools.ietf.org/html/rfc7232). It will allow to return `304 Not Modified` (for instance) and handle HTTP Range requests ([RFC7233](https://tools.ietf.org/html/rfc7233)) transparently.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Implementing RFC7232 and RFC7233 is not trivial: I believe it should be implemented at `Tide` level instead of leaving the users implementing it themselves. At the time I checked a few weeks ago `Rocket`, `warp` and `actix` all had limited (if any) support for such conditional requests (this might have changed). Support for conditional requests is provided by Go's standard http library.

This will help closing #63. Also the current implementation of `tide::Route::serve_dir` could benefit from it to handle last modification date and range requests.

I am already running a full implementation *in production* to serve a bunch of video files for internal use (building a media center for home).

This draft PR depends on changes that are not yet released (some not even merged) in [http-types](https://github.com/http-rs/http-types), see dependencies section below. I will update this PR as much as the situation evolves on `http-types` side. I will then commit the implementation, testing and more documentation.

Finally i will move out of draft status once everything is released on `http-types` side and implementation, tests and docs completed.

For now I am requesting comments for interest in such feature within `Tide` or if you prefer that I release this in an external crate. Also I would like you comments on the API, please.

Thanks in advance !
Cheers.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Dependencies:
- [x] http-rs/http-types#211 to be released
- [x] http-rs/http-types#222 to be merged
- [x] http-rs/http-types#224 to be merged
- [ ] http-rs/http-types#180 to be merged
