### PR TITLE
log: display client error messages when possible as warnings

### DIFF
--- a/src/log/middleware.rs
+++ b/src/log/middleware.rs
@@ -65,12 +65,22 @@ impl LogMiddleware {
                 });
             }
         } else if status.is_client_error() {
-            log::warn!("--> Response sent", {
-                method: method,
-                path: path,
-                status: status as u16,
-                duration: format!("{:?}", start.elapsed()),
-            });
+            if let Some(error) = response.error() {
+                log::warn!("Client error --> Response sent", {
+                    message: error.to_string(),
+                    method: method,
+                    path: path,
+                    status: status as u16,
+                    duration: format!("{:?}", start.elapsed()),
+                });
+            } else {
+                log::warn!("Client error --> Response sent", {
+                    method: method,
+                    path: path,
+                    status: status as u16,
+                    duration: format!("{:?}", start.elapsed()),
+                });
+            }
         } else {
             log::info!("--> Response sent", {
                 method: method,

--- a/src/log/middleware.rs
+++ b/src/log/middleware.rs
@@ -50,34 +50,34 @@ impl LogMiddleware {
         if status.is_server_error() {
             if let Some(error) = response.error() {
                 log::error!("Internal error --> Response sent", {
-                    message: error.to_string(),
+                    message: format!("\"{}\"", error.to_string()),
                     method: method,
                     path: path,
-                    status: status as u16,
+                    status: format!("{} - {}", status as u16, status.canonical_reason()),
                     duration: format!("{:?}", start.elapsed()),
                 });
             } else {
                 log::error!("Internal error --> Response sent", {
                     method: method,
                     path: path,
-                    status: status as u16,
+                    status: format!("{} - {}", status as u16, status.canonical_reason()),
                     duration: format!("{:?}", start.elapsed()),
                 });
             }
         } else if status.is_client_error() {
             if let Some(error) = response.error() {
                 log::warn!("Client error --> Response sent", {
-                    message: error.to_string(),
+                    message: format!("\"{}\"", error.to_string()),
                     method: method,
                     path: path,
-                    status: status as u16,
+                    status: format!("{} - {}", status as u16, status.canonical_reason()),
                     duration: format!("{:?}", start.elapsed()),
                 });
             } else {
                 log::warn!("Client error --> Response sent", {
                     method: method,
                     path: path,
-                    status: status as u16,
+                    status: format!("{} - {}", status as u16, status.canonical_reason()),
                     duration: format!("{:?}", start.elapsed()),
                 });
             }
@@ -85,7 +85,7 @@ impl LogMiddleware {
             log::info!("--> Response sent", {
                 method: method,
                 path: path,
-                status: status as u16,
+                status: format!("{} - {}", status as u16, status.canonical_reason()),
                 duration: format!("{:?}", start.elapsed()),
             });
         }


### PR DESCRIPTION
This should help demystify some cases when client errors are determined by parsing and propagated via `?`.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Makes the logger display an associated error message when this warning occurs, if possible.

Also clarified that a client error occured.

## Motivation and Context

For never users some cases of client errors being caused by e.g. body parsing and then propgated via `?` may be unobvious. This helps demystify that.

## How Has This Been Tested?

Manual curl to the json example. Output:
```
tide::log::middleware Client error --> Response sent
    message missing field `name` at line 1 column 2
    method POST
    path /submit
    status 422
    duration 73.9µs
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [x] All new and existing tests passed.
