### PR TITLE
Make `femme` dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rustdoc-args = ["--cfg", "feature=\"docs\""]
 [features]
 default = ["h1-server", "logger", "sessions"]
 h1-server = ["async-h1"]
-logger = []
+logger = ["femme"]
 docs = ["unstable"]
 sessions = ["async-session"]
 unstable = []
@@ -39,8 +39,9 @@ async-session  = { version = "2.0.0", optional = true }
 async-sse = "4.0.0"
 async-std = { version = "1.6.0", features = ["unstable"] }
 async-trait = "0.1.36"
-femme = "2.0.1"
+femme = { version = "2.0.1", optional = true }
 futures-util = "0.3.5"
+log = { version = "0.4.8", features = ["std"] }
 http-types = "2.2.1"
 kv-log-macro = "1.0.4"
 pin-project-lite = "0.1.7"

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -21,7 +21,9 @@ pub use kv_log_macro::{max_level, Level};
 
 mod middleware;
 
+#[cfg(feature = "logger")]
 pub use femme::LevelFilter;
+
 pub use middleware::LogMiddleware;
 
 /// Start logging.


### PR DESCRIPTION
## Description

Make the `femme` dependency optional, enabled via the `logger` feature.

## Motivation and Context

Allows you to use a different log crate and `femme` doesn't have to be installed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
      Technically speaking this is a breaking change in the case where someone removed the `logger` feature and still used `tide::log::LevelFilter`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
