### PR TITLE
add a http_client::HttpClient implementation for tide::Server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,10 @@ async-std = { version = "1.6.0", features = ["unstable"] }
 async-trait = "0.1.36"
 femme = { version = "2.0.1", optional = true }
 futures-util = "0.3.5"
-log = { version = "0.4.8", features = ["std"] }
+http-client = { version = "6.0.0", default-features = false }
 http-types = "2.2.1"
 kv-log-macro = "1.0.4"
+log = { version = "0.4.8", features = ["std"] }
 pin-project-lite = "0.1.7"
 route-recognizer = "0.2.0"
 serde = "1.0.102"
@@ -57,7 +58,7 @@ lazy_static = "1.4.0"
 logtest = "2.0.0"
 portpicker = "0.1.0"
 serde = { version = "1.0.102", features = ["derive"] }
-surf = { version = "2.0.0-alpha.3", default-features = false, features = ["h1-client"] }
+surf = { version = "2.0.0-alpha.7", default-features = false, features = ["h1-client"] }
 tempfile = "3.1.0"
 
 [[test]]

--- a/tests/response.rs
+++ b/tests/response.rs
@@ -36,7 +36,7 @@ async fn string_content_type() {
 }
 
 #[async_std::test]
-async fn json_content_type() {
+async fn json_content_type() -> tide::Result<()> {
     use std::collections::BTreeMap;
     use tide::Body;
 
@@ -51,7 +51,7 @@ async fn json_content_type() {
         Ok(resp)
     });
 
-    let mut resp = app.get("/json_content_type").await;
+    let mut resp = app.get("/json_content_type").await?;
     assert_eq!(resp.status(), StatusCode::InternalServerError);
     assert_eq!(resp.body_string().await.unwrap(), "");
 
@@ -68,6 +68,8 @@ async fn json_content_type() {
     assert_eq!(resp.status(), StatusCode::Ok);
     let body = resp.take_body().into_bytes().await.unwrap();
     assert_eq!(body, br##"{"a":2,"b":4,"c":6}"##);
+
+    Ok(())
 }
 
 #[test]

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use tide::{Body, Request};
 
 #[test]
-fn hello_world() -> Result<(), http_types::Error> {
+fn hello_world() -> tide::Result<()> {
     task::block_on(async {
         let port = test_utils::find_port().await;
         let server = task::spawn(async move {
@@ -25,7 +25,7 @@ fn hello_world() -> Result<(), http_types::Error> {
         let client = task::spawn(async move {
             task::sleep(Duration::from_millis(100)).await;
             let string = surf::get(format!("http://localhost:{}", port))
-                .body("nori".to_string())
+                .body(Body::from_string("nori".to_string()))
                 .recv_string()
                 .await
                 .unwrap();
@@ -38,7 +38,7 @@ fn hello_world() -> Result<(), http_types::Error> {
 }
 
 #[test]
-fn echo_server() -> Result<(), http_types::Error> {
+fn echo_server() -> tide::Result<()> {
     task::block_on(async {
         let port = test_utils::find_port().await;
         let server = task::spawn(async move {
@@ -52,7 +52,7 @@ fn echo_server() -> Result<(), http_types::Error> {
         let client = task::spawn(async move {
             task::sleep(Duration::from_millis(100)).await;
             let string = surf::get(format!("http://localhost:{}", port))
-                .body("chashu".to_string())
+                .body(Body::from_string("chashu".to_string()))
                 .recv_string()
                 .await
                 .unwrap();
@@ -65,7 +65,7 @@ fn echo_server() -> Result<(), http_types::Error> {
 }
 
 #[test]
-fn json() -> Result<(), http_types::Error> {
+fn json() -> tide::Result<()> {
     #[derive(Deserialize, Serialize)]
     struct Counter {
         count: usize,

--- a/tests/sessions.rs
+++ b/tests/sessions.rs
@@ -2,14 +2,10 @@ mod test_utils;
 use test_utils::ServerTestingExt;
 
 use cookie::SameSite;
+use http_types::headers::SET_COOKIE;
 use std::time::Duration;
 use tide::{
-    http::{
-        cookies as cookie,
-        headers::HeaderValue,
-        Method::{Get, Post},
-        Request, Response, Url,
-    },
+    http::{cookies as cookie, headers::HeaderValue, Response},
     sessions::{MemoryStore, SessionMiddleware},
     utils::Before,
 };
@@ -19,7 +15,7 @@ struct SessionData {
 }
 
 #[async_std::test]
-async fn test_basic_sessions() {
+async fn test_basic_sessions() -> tide::Result<()> {
     let mut app = tide::new();
     app.with(SessionMiddleware::new(
         MemoryStore::new(),
@@ -37,7 +33,7 @@ async fn test_basic_sessions() {
         Ok(format!("you have visited this website {} times", visits))
     });
 
-    let response = app.get("/").await;
+    let response = app.get("/").await?;
     let cookies = Cookies::from_response(&response);
     let cookie = &cookies["tide.sid"];
     assert_eq!(cookie.name(), "tide.sid");
@@ -46,21 +42,21 @@ async fn test_basic_sessions() {
     assert_eq!(cookie.secure(), None); // this request was http://
     assert_eq!(cookie.path(), Some("/"));
 
-    let mut second_request = Request::new(Get, Url::parse("https://whatever/").unwrap());
-    second_request.insert_header("Cookie", &cookies);
-    let mut second_response: Response = app.respond(second_request).await.unwrap();
-    let body = second_response.body_string().await.unwrap();
+    let mut second_response = app.get("/").header("Cookie", &cookies).await?;
+
+    let body = second_response.body_string().await?;
     assert_eq!("you have visited this website 2 times", body);
     assert!(second_response.header("Set-Cookie").is_none());
 
-    let response = app.get("https://secure/").await;
+    let response = app.get("https://secure/").await?;
     let cookies = Cookies::from_response(&response);
     let cookie = &cookies["tide.sid"];
     assert_eq!(cookie.secure(), Some(true));
+    Ok(())
 }
 
 #[async_std::test]
-async fn test_customized_sessions() {
+async fn test_customized_sessions() -> tide::Result<()> {
     let mut app = tide::new();
     app.with(
         SessionMiddleware::new(MemoryStore::new(), b"12345678901234567890123456789012345")
@@ -82,20 +78,20 @@ async fn test_customized_sessions() {
         .get(|mut req: tide::Request<()>| async move {
             let mut visits: usize = req.session().get("visits").unwrap_or_default();
             visits += 1;
-            req.session_mut().insert("visits", visits).unwrap();
+            req.session_mut().insert("visits", visits)?;
             Ok(format!("/nested/incr {}", visits))
         });
 
-    let response = app.get("/").await;
+    let response = app.get("/").await?;
     assert_eq!(Cookies::from_response(&response).len(), 0);
 
-    let mut response = app.get("/nested").await;
+    let mut response = app.get("/nested").await?;
     assert_eq!(Cookies::from_response(&response).len(), 0);
-    assert_eq!(response.body_string().await.unwrap(), "/nested 0");
+    assert_eq!(response.body_string().await?, "/nested 0");
 
-    let mut response = app.get("/nested/incr").await;
+    let mut response = app.get("/nested/incr").await?;
     let cookies = Cookies::from_response(&response);
-    assert_eq!(response.body_string().await.unwrap(), "/nested/incr 1");
+    assert_eq!(response.body_string().await?, "/nested/incr 1");
 
     assert_eq!(cookies.len(), 1);
     assert!(cookies.get("tide.sid").is_none());
@@ -105,29 +101,31 @@ async fn test_customized_sessions() {
     assert_eq!(cookie.path(), Some("/nested"));
     let cookie_value = cookie.value().to_string();
 
-    let mut second_request = Request::new(Get, Url::parse("https://whatever/nested/incr").unwrap());
-    second_request.insert_header("Cookie", &cookies);
-    let mut second_response: Response = app.respond(second_request).await.unwrap();
-    let body = second_response.body_string().await.unwrap();
+    let mut second_response = app
+        .get("https://whatever/nested/incr")
+        .header("Cookie", &cookies)
+        .await?;
+    let body = second_response.body_string().await?;
     assert_eq!("/nested/incr 2", body);
     assert!(second_response.header("Set-Cookie").is_none());
 
     async_std::task::sleep(Duration::from_secs(5)).await; // wait for expiration
 
-    let mut expired_request =
-        Request::new(Get, Url::parse("https://whatever/nested/incr").unwrap());
-    expired_request.insert_header("Cookie", &cookies);
-    let mut expired_response: Response = app.respond(expired_request).await.unwrap();
+    let mut expired_response = app
+        .get("https://whatever/nested/incr")
+        .header("Cookie", &cookies)
+        .await?;
     let cookies = Cookies::from_response(&expired_response);
     assert_eq!(cookies.len(), 1);
     assert!(cookies["custom.cookie.name"].value() != cookie_value);
 
-    let body = expired_response.body_string().await.unwrap();
+    let body = expired_response.body_string().await?;
     assert_eq!("/nested/incr 1", body);
+    Ok(())
 }
 
 #[async_std::test]
-async fn test_session_destruction() {
+async fn test_session_destruction() -> tide::Result<()> {
     let mut app = tide::new();
     app.with(SessionMiddleware::new(
         MemoryStore::new(),
@@ -151,15 +149,17 @@ async fn test_session_destruction() {
             Ok(Response::new(200))
         });
 
-    let response = app.get("/").await;
+    let response = app.get("/").await?;
     let cookies = Cookies::from_response(&response);
 
-    let mut second_request = Request::new(Post, Url::parse("https://whatever/logout").unwrap());
-    second_request.insert_header("Cookie", &cookies);
-    let second_response: Response = app.respond(second_request).await.unwrap();
+    let second_response = app
+        .post("https://whatever/logout")
+        .header("Cookie", &cookies)
+        .await?;
     let cookies = Cookies::from_response(&second_response);
     assert_eq!(cookies["tide.sid"].value(), "");
     assert_eq!(cookies.len(), 1);
+    Ok(())
 }
 
 #[derive(Debug, Clone)]
@@ -169,9 +169,10 @@ impl Cookies {
         self.0.len()
     }
 
-    fn from_response(response: &http_types::Response) -> Self {
+    fn from_response(response: &impl AsRef<http_types::Response>) -> Self {
         response
-            .header("Set-Cookie")
+            .as_ref()
+            .header(SET_COOKIE)
             .map(|hv| hv.to_string())
             .unwrap_or_else(|| "[]".into())
             .parse()

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -1,6 +1,4 @@
 use portpicker::pick_unused_port;
-use tide::http::{self, url::Url, Method};
-use tide::Server;
 
 /// Find an unused port.
 #[allow(dead_code)]
@@ -8,53 +6,63 @@ pub async fn find_port() -> u16 {
     pick_unused_port().expect("No ports free")
 }
 
-#[async_trait::async_trait]
+use surf::{Client, RequestBuilder};
+
+/// Trait that adds test request capabilities to tide [`Server`]s
 pub trait ServerTestingExt {
-    async fn request(&self, method: Method, path: &str) -> http::Response;
-    async fn request_body(&self, method: Method, path: &str) -> String;
-    async fn get(&self, path: &str) -> http::Response;
-    async fn get_body(&self, path: &str) -> String;
-    async fn post(&self, path: &str) -> http::Response;
-    async fn put(&self, path: &str) -> http::Response;
+    /// Construct a new surf Client
+    fn client(&self) -> Client;
+
+    /// Builds a `CONNECT` request.
+    fn connect(&self, uri: &str) -> RequestBuilder {
+        self.client().connect(uri)
+    }
+
+    /// Builds a `DELETE` request.
+    fn delete(&self, uri: &str) -> RequestBuilder {
+        self.client().delete(uri)
+    }
+
+    /// Builds a `GET` request.
+    fn get(&self, uri: &str) -> RequestBuilder {
+        self.client().get(uri)
+    }
+
+    /// Builds a `HEAD` request.
+    fn head(&self, uri: &str) -> RequestBuilder {
+        self.client().head(uri)
+    }
+
+    /// Builds an `OPTIONS` request.
+    fn options(&self, uri: &str) -> RequestBuilder {
+        self.client().options(uri)
+    }
+
+    /// Builds a `PATCH` request.
+    fn patch(&self, uri: &str) -> RequestBuilder {
+        self.client().patch(uri)
+    }
+
+    /// Builds a `POST` request.
+    fn post(&self, uri: &str) -> RequestBuilder {
+        self.client().post(uri)
+    }
+
+    /// Builds a `PUT` request.
+    fn put(&self, uri: &str) -> RequestBuilder {
+        self.client().put(uri)
+    }
+
+    /// Builds a `TRACE` request.
+    fn trace(&self, uri: &str) -> RequestBuilder {
+        self.client().trace(uri)
+    }
 }
 
-#[async_trait::async_trait]
-impl<State> ServerTestingExt for Server<State>
-where
-    State: Clone + Send + Sync + 'static,
-{
-    async fn request(&self, method: Method, path: &str) -> http::Response {
-        let url = if path.starts_with("http:") || path.starts_with("https:") {
-            Url::parse(path).unwrap()
-        } else {
-            Url::parse("http://example.com/")
-                .unwrap()
-                .join(path)
-                .unwrap()
-        };
-
-        let request = http::Request::new(method, url);
-        self.respond(request).await.unwrap()
-    }
-
-    async fn request_body(&self, method: Method, path: &str) -> String {
-        let mut response = self.request(method, path).await;
-        response.body_string().await.unwrap()
-    }
-
-    async fn get(&self, path: &str) -> http::Response {
-        self.request(Method::Get, path).await
-    }
-
-    async fn get_body(&self, path: &str) -> String {
-        self.request_body(Method::Get, path).await
-    }
-
-    async fn post(&self, path: &str) -> http::Response {
-        self.request(Method::Post, path).await
-    }
-
-    async fn put(&self, path: &str) -> http::Response {
-        self.request(Method::Put, path).await
+impl<State: Clone + Send + Sync + Unpin + 'static> ServerTestingExt for tide::Server<State> {
+    fn client(&self) -> Client {
+        let mut client = Client::with_http_client(self.clone());
+        client.set_base_url(tide::http::Url::parse("http://example.com").unwrap());
+        client
     }
 }

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -26,100 +26,117 @@ async fn echo_path(req: Request<()>) -> Result<String, tide::Error> {
 }
 
 #[async_std::test]
-async fn wildcard() {
+async fn wildcard() -> tide::Result<()> {
     let mut app = tide::Server::new();
     app.at("/add_one/:num").get(add_one);
-    assert_eq!(app.get_body("/add_one/3").await, "4");
-    assert_eq!(app.get_body("/add_one/-7").await, "-6");
+    assert_eq!(app.get("/add_one/3").recv_string().await?, "4");
+    assert_eq!(app.get("/add_one/-7").recv_string().await?, "-6");
+    Ok(())
 }
 
 #[async_std::test]
-async fn invalid_segment_error() {
+async fn invalid_segment_error() -> tide::Result<()> {
     let mut app = tide::new();
     app.at("/add_one/:num").get(add_one);
-    assert_eq!(app.get("/add_one/a").await.status(), StatusCode::BadRequest);
+    assert_eq!(
+        app.get("/add_one/a").await?.status(),
+        StatusCode::BadRequest
+    );
+    Ok(())
 }
 
 #[async_std::test]
-async fn not_found_error() {
+async fn not_found_error() -> tide::Result<()> {
     let mut app = tide::new();
     app.at("/add_one/:num").get(add_one);
-    assert_eq!(app.get("/add_one/").await.status(), StatusCode::NotFound);
+    assert_eq!(app.get("/add_one/").await?.status(), StatusCode::NotFound);
+    Ok(())
 }
 
 #[async_std::test]
-async fn wild_path() {
+async fn wild_path() -> tide::Result<()> {
     let mut app = tide::new();
     app.at("/echo/*path").get(echo_path);
-    assert_eq!(app.get_body("/echo/some_path").await, "some_path");
+    assert_eq!(app.get("/echo/some_path").recv_string().await?, "some_path");
     assert_eq!(
-        app.get_body("/echo/multi/segment/path").await,
+        app.get("/echo/multi/segment/path").recv_string().await?,
         "multi/segment/path"
     );
-    assert_eq!(app.get("/echo/").await.status(), StatusCode::NotFound);
+    assert_eq!(app.get("/echo/").await?.status(), StatusCode::NotFound);
+    Ok(())
 }
 
 #[async_std::test]
-async fn multi_wildcard() {
+async fn multi_wildcard() -> tide::Result<()> {
     let mut app = tide::new();
     app.at("/add_two/:one/:two/").get(add_two);
-    assert_eq!(app.get_body("/add_two/1/2/").await, "3");
-    assert_eq!(app.get_body("/add_two/-1/2/").await, "1");
-    assert_eq!(app.get("/add_two/1").await.status(), StatusCode::NotFound);
+    assert_eq!(app.get("/add_two/1/2/").recv_string().await?, "3");
+    assert_eq!(app.get("/add_two/-1/2/").recv_string().await?, "1");
+    assert_eq!(app.get("/add_two/1").await?.status(), StatusCode::NotFound);
+    Ok(())
 }
 
 #[async_std::test]
-async fn wild_last_segment() {
+async fn wild_last_segment() -> tide::Result<()> {
     let mut app = tide::new();
     app.at("/echo/:path/*").get(echo_path);
-    assert_eq!(app.get_body("/echo/one/two").await, "one");
-    assert_eq!(app.get_body("/echo/one/two/three/four").await, "one");
+    assert_eq!(app.get("/echo/one/two").recv_string().await?, "one");
+    assert_eq!(
+        app.get("/echo/one/two/three/four").recv_string().await?,
+        "one"
+    );
+    Ok(())
 }
 
 #[async_std::test]
-async fn invalid_wildcard() {
+async fn invalid_wildcard() -> tide::Result<()> {
     let mut app = tide::new();
     app.at("/echo/*path/:one/").get(echo_path);
     assert_eq!(
-        app.get("/echo/one/two").await.status(),
+        app.get("/echo/one/two").await?.status(),
         StatusCode::NotFound
     );
+    Ok(())
 }
 
 #[async_std::test]
-async fn nameless_wildcard() {
+async fn nameless_wildcard() -> tide::Result<()> {
     let mut app = tide::Server::new();
     app.at("/echo/:").get(|_| async { Ok("") });
     assert_eq!(
-        app.get("/echo/one/two").await.status(),
+        app.get("/echo/one/two").await?.status(),
         StatusCode::NotFound
     );
-    assert_eq!(app.get("/echo/one").await.status(), StatusCode::Ok);
+    assert_eq!(app.get("/echo/one").await?.status(), StatusCode::Ok);
+    Ok(())
 }
 
 #[async_std::test]
-async fn nameless_internal_wildcard() {
+async fn nameless_internal_wildcard() -> tide::Result<()> {
     let mut app = tide::new();
     app.at("/echo/:/:path").get(echo_path);
-    assert_eq!(app.get("/echo/one").await.status(), StatusCode::NotFound);
-    assert_eq!(app.get_body("/echo/one/two").await, "two");
+    assert_eq!(app.get("/echo/one").await?.status(), StatusCode::NotFound);
+    assert_eq!(app.get("/echo/one/two").recv_string().await?, "two");
+    Ok(())
 }
 
 #[async_std::test]
-async fn nameless_internal_wildcard2() {
+async fn nameless_internal_wildcard2() -> tide::Result<()> {
     let mut app = tide::new();
     app.at("/echo/:/:path").get(|req: Request<()>| async move {
         assert_eq!(req.param::<String>("path")?, "two");
         Ok("")
     });
 
-    app.get("/echo/one/two").await;
+    assert!(app.get("/echo/one/two").await?.status().is_success());
+    Ok(())
 }
 
 #[async_std::test]
-async fn ambiguous_router_wildcard_vs_star() {
+async fn ambiguous_router_wildcard_vs_star() -> tide::Result<()> {
     let mut app = tide::new();
     app.at("/:one/:two").get(|_| async { Ok("one/two") });
     app.at("/posts/*").get(|_| async { Ok("posts/*") });
-    assert_eq!(app.get_body("/posts/10").await, "posts/*");
+    assert_eq!(app.get("/posts/10").recv_string().await?, "posts/*");
+    Ok(())
 }


### PR DESCRIPTION
In order to facilitate testing, it is convenient for tide::Server to implement http_client::HttpClient.  This allows surf to be used for testing, with only the following shim:

```rust
#[cfg(test)]
mod tests {
    use super::*;

    pub fn test_client<State>(server: Server<State>) -> Client
    where
        State: Debug + Unpin + Sync + Send + Clone + 'static,
    {
        let mut client = Client::with_http_client(Arc::new(server));
        client.set_base_url(Url::parse("http://example.com/").unwrap());
        client
    }

    #[async_std::test]
    async fn test() -> tide::Result<()> {
        let app = build_app().await;
        let body = test_client(app).get("/").recv_string().await?;
        Ok(())
    }
}
```

If http-rs/surf#229 is merged, this would allow:
```rust
let app = tide::new();
use surf::ClientExt;
app.get("http://example.com/").recv_string()?;
```

this is tested by using it throughout the tide testing suite as the basis for test_utils::ServerTesting

## Drawbacks/Limitations

This adds a dependency on http-client, but that should be pretty lightweight without default features.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
