### PR TITLE
Refactor duplicate code

### DIFF
--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -96,10 +96,17 @@ where
     State: Clone + Send + Sync + 'static,
     E: Endpoint<State>,
 {
-    pub(crate) fn wrap_with_middleware(ep: E, middleware: &[Arc<dyn Middleware<State>>]) -> Self {
-        Self {
-            endpoint: ep,
-            middleware: middleware.to_vec(),
+    pub(crate) fn wrap_with_middleware(
+        ep: E,
+        middleware: &[Arc<dyn Middleware<State>>],
+    ) -> Box<dyn Endpoint<State> + Send + Sync + 'static> {
+        if middleware.is_empty() {
+            Box::new(ep)
+        } else {
+            Box::new(Self {
+                endpoint: ep,
+                middleware: middleware.to_vec(),
+            })
         }
     }
 }


### PR DESCRIPTION
## Description
I refactored away some duplicate code in how middleware is added to endpoints. There is still some duplicate code left between the `Route::method` and `'Route::all` but factoring this out will probably require some lambda magic and will not improve readablilty.

## Motivation and Context
A check to see if there was middleware present was done in the same way in several places. This small refactoring moves
that check into the code that adds middleware onto an endpoint. This reduces code duplication and improves readability

## How Has This Been Tested?
Middleware has decent test coverage. The tests that touch this piece of code still succeed. This code does not add any functionality so no additional tests should be neccesary.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
