### PR TITLE
Tide testing trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ logger = []
 docs = ["unstable"]
 sessions = ["async-session"]
 unstable = []
+testing = ["surf"]
 # DO NOT USE. Only exists to expose internals so they can be benchmarked.
 __internal__bench = []
 
@@ -47,7 +48,7 @@ pin-project-lite = "0.1.7"
 route-recognizer = "0.2.0"
 serde = "1.0.102"
 serde_json = "1.0.41"
-http-client = {version = "4.0.0", default-features = false }
+surf = { version = "2.0.0-alpha.5", default-features = false, optional = true, features = ["h1-client"] } # TODO(jbr): remove this feature when surf can build without default features
 
 [dev-dependencies]
 async-std = { version = "1.6.0", features = ["unstable", "attributes"] }
@@ -59,6 +60,7 @@ portpicker = "0.1.0"
 serde = { version = "1.0.102", features = ["derive"] }
 surf = { version = "2.0.0-alpha.5", default-features = false, features = ["h1-client"] }
 tempfile = "3.1.0"
+tide = { path = ".", features = ["testing"] }
 
 [[test]]
 name = "nested"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ pin-project-lite = "0.1.7"
 route-recognizer = "0.2.0"
 serde = "1.0.102"
 serde_json = "1.0.41"
+http-client = {version = "4.0.0", default-features = false }
 
 [dev-dependencies]
 async-std = { version = "1.6.0", features = ["unstable", "attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ lazy_static = "1.4.0"
 logtest = "2.0.0"
 portpicker = "0.1.0"
 serde = { version = "1.0.102", features = ["derive"] }
-surf = { version = "2.0.0-alpha.3", default-features = false, features = ["h1-client"] }
+surf = { version = "2.0.0-alpha.5", default-features = false, features = ["h1-client"] }
 tempfile = "3.1.0"
 
 [[test]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,6 +227,8 @@ pub mod utils;
 
 #[cfg(feature = "sessions")]
 pub mod sessions;
+#[cfg(any(test, feature = "testing"))]
+pub mod testing;
 
 pub use endpoint::Endpoint;
 pub use middleware::{Middleware, Next};

--- a/src/server.rs
+++ b/src/server.rs
@@ -251,7 +251,6 @@ impl<State: Send + Sync + 'static> std::fmt::Debug for Server<State> {
     }
 }
 
-
 impl<State: Clone> Clone for Server<State> {
     fn clone(&self) -> Self {
         Self {

--- a/src/server.rs
+++ b/src/server.rs
@@ -251,16 +251,6 @@ impl<State: Send + Sync + 'static> std::fmt::Debug for Server<State> {
     }
 }
 
-impl<State: Clone + Send + Sync + Unpin + 'static> http_client::HttpClient for Server<State> {
-    fn send(
-        &self,
-        req: http_client::Request,
-    ) -> futures_util::future::BoxFuture<'static, Result<http_client::Response, http_client::Error>>
-    {
-        let self_cloned = self.clone();
-        Box::pin(async move { self_cloned.respond(req).await })
-    }
-}
 
 impl<State: Clone> Clone for Server<State> {
     fn clone(&self) -> Self {

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,0 +1,71 @@
+use crate::http::{Request, Response, Result, Url};
+use crate::Server;
+use futures_util::future::BoxFuture;
+use std::sync::Arc;
+use surf::{Client, HttpClient, RequestBuilder};
+
+/// Trait that adds test request capabilities to tide [`Server`]s
+pub trait TestingExt {
+    /// Construct a new surf Client
+    fn client(&self) -> Client;
+
+    /// Builds a `CONNECT` request.
+    fn connect(&self, path: &str) -> RequestBuilder {
+        self.client().connect(path)
+    }
+
+    /// Builds a `DELETE` request.
+    fn delete(&self, path: &str) -> RequestBuilder {
+        self.client().delete(path)
+    }
+
+    /// Builds a `GET` request.
+    fn get(&self, path: &str) -> RequestBuilder {
+        self.client().get(path)
+    }
+
+    /// Builds a `HEAD` request.
+    fn head(&self, path: &str) -> RequestBuilder {
+        self.client().head(path)
+    }
+
+    /// Builds an `OPTIONS` request.
+    fn options(&self, path: &str) -> RequestBuilder {
+        self.client().options(path)
+    }
+
+    /// Builds a `PATCH` request.
+    fn patch(&self, path: &str) -> RequestBuilder {
+        self.client().patch(path)
+    }
+
+    /// Builds a `POST` request.
+    fn post(&self, path: &str) -> RequestBuilder {
+        self.client().post(path)
+    }
+
+    /// Builds a `PUT` request.
+    fn put(&self, path: &str) -> RequestBuilder {
+        self.client().put(path)
+    }
+
+    /// Builds a `TRACE` request.
+    fn trace(&self, path: &str) -> RequestBuilder {
+        self.client().trace(path)
+    }
+}
+
+impl<State: Clone + Send + Sync + Unpin + 'static> TestingExt for Server<State> {
+    fn client(&self) -> Client {
+        let mut client = Client::with_http_client(Arc::new(self.clone()));
+        client.set_base_url(Url::parse("http://example.com").unwrap());
+        client
+    }
+}
+
+impl<State: Clone + Send + Sync + Unpin + 'static> HttpClient for Server<State> {
+    fn send(&self, req: Request) -> BoxFuture<'static, Result<Response>> {
+        let self_cloned = self.clone();
+        Box::pin(async move { self_cloned.respond(req).await })
+    }
+}

--- a/tests/log.rs
+++ b/tests/log.rs
@@ -1,8 +1,7 @@
 use async_std::prelude::*;
 use std::time::Duration;
-
+use tide::testing::TestingExt;
 mod test_utils;
-use test_utils::ServerTestingExt;
 
 #[async_std::test]
 async fn log_tests() -> tide::Result<()> {

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -1,5 +1,4 @@
-mod test_utils;
-use test_utils::ServerTestingExt;
+use tide::testing::TestingExt;
 
 #[async_std::test]
 async fn nested() -> tide::Result<()> {

--- a/tests/response.rs
+++ b/tests/response.rs
@@ -36,7 +36,7 @@ async fn string_content_type() {
 }
 
 #[async_std::test]
-async fn json_content_type() {
+async fn json_content_type() -> tide::Result<()> {
     use std::collections::BTreeMap;
     use tide::Body;
 
@@ -51,7 +51,7 @@ async fn json_content_type() {
         Ok(resp)
     });
 
-    let mut resp = app.get("/json_content_type").await;
+    let mut resp = app.get("/json_content_type").await?;
     assert_eq!(resp.status(), StatusCode::InternalServerError);
     assert_eq!(resp.body_string().await.unwrap(), "");
 
@@ -68,6 +68,8 @@ async fn json_content_type() {
     assert_eq!(resp.status(), StatusCode::Ok);
     let body = resp.take_body().into_bytes().await.unwrap();
     assert_eq!(body, br##"{"a":2,"b":4,"c":6}"##);
+
+    Ok(())
 }
 
 #[test]

--- a/tests/response.rs
+++ b/tests/response.rs
@@ -1,7 +1,5 @@
-mod test_utils;
-use test_utils::ServerTestingExt;
 use tide::http::{headers, mime};
-use tide::{Response, StatusCode};
+use tide::{testing::TestingExt, Response, StatusCode};
 
 #[async_std::test]
 async fn test_status() {

--- a/tests/route_middleware.rs
+++ b/tests/route_middleware.rs
@@ -1,8 +1,6 @@
-mod test_utils;
 use http_types::headers::HeaderName;
 use std::convert::TryInto;
-use test_utils::ServerTestingExt;
-use tide::Middleware;
+use tide::{testing::TestingExt, Middleware};
 
 #[derive(Debug)]
 struct TestMiddleware(HeaderName, &'static str);

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use tide::{Body, Request};
 
 #[test]
-fn hello_world() -> Result<(), http_types::Error> {
+fn hello_world() -> tide::Result<()> {
     task::block_on(async {
         let port = test_utils::find_port().await;
         let server = task::spawn(async move {
@@ -25,7 +25,7 @@ fn hello_world() -> Result<(), http_types::Error> {
         let client = task::spawn(async move {
             task::sleep(Duration::from_millis(100)).await;
             let string = surf::get(format!("http://localhost:{}", port))
-                .body_string("nori".to_string())
+                .body(Body::from_string("nori".to_string()))
                 .recv_string()
                 .await
                 .unwrap();
@@ -38,7 +38,7 @@ fn hello_world() -> Result<(), http_types::Error> {
 }
 
 #[test]
-fn echo_server() -> Result<(), http_types::Error> {
+fn echo_server() -> tide::Result<()> {
     task::block_on(async {
         let port = test_utils::find_port().await;
         let server = task::spawn(async move {
@@ -52,7 +52,7 @@ fn echo_server() -> Result<(), http_types::Error> {
         let client = task::spawn(async move {
             task::sleep(Duration::from_millis(100)).await;
             let string = surf::get(format!("http://localhost:{}", port))
-                .body_string("chashu".to_string())
+                .body(Body::from_string("chashu".to_string()))
                 .recv_string()
                 .await
                 .unwrap();
@@ -65,7 +65,7 @@ fn echo_server() -> Result<(), http_types::Error> {
 }
 
 #[test]
-fn json() -> Result<(), http_types::Error> {
+fn json() -> tide::Result<()> {
     #[derive(Deserialize, Serialize)]
     struct Counter {
         count: usize,
@@ -88,7 +88,7 @@ fn json() -> Result<(), http_types::Error> {
         let client = task::spawn(async move {
             task::sleep(Duration::from_millis(100)).await;
             let counter: Counter = surf::get(format!("http://localhost:{}", &port))
-                .body_json(&Counter { count: 0 })?
+                .body(Body::from_json(&Counter { count: 0 })?)
                 .recv_json()
                 .await
                 .unwrap();

--- a/tests/sessions.rs
+++ b/tests/sessions.rs
@@ -1,12 +1,10 @@
-mod test_utils;
-use http_types::headers::SET_COOKIE;
-use test_utils::ServerTestingExt;
-
 use cookie::SameSite;
+use http_types::headers::SET_COOKIE;
 use std::time::Duration;
 use tide::{
     http::{cookies as cookie, headers::HeaderValue, Response},
     sessions::{MemoryStore, SessionMiddleware},
+    testing::TestingExt,
     utils::Before,
 };
 #[derive(Clone, Debug, Default, PartialEq)]

--- a/tests/sessions.rs
+++ b/tests/sessions.rs
@@ -1,15 +1,11 @@
 mod test_utils;
+use http_types::headers::SET_COOKIE;
 use test_utils::ServerTestingExt;
 
 use cookie::SameSite;
 use std::time::Duration;
 use tide::{
-    http::{
-        cookies as cookie,
-        headers::HeaderValue,
-        Method::{Get, Post},
-        Request, Response, Url,
-    },
+    http::{cookies as cookie, headers::HeaderValue, Response},
     sessions::{MemoryStore, SessionMiddleware},
     utils::Before,
 };
@@ -19,7 +15,7 @@ struct SessionData {
 }
 
 #[async_std::test]
-async fn test_basic_sessions() {
+async fn test_basic_sessions() -> tide::Result<()> {
     let mut app = tide::new();
     app.with(SessionMiddleware::new(
         MemoryStore::new(),
@@ -37,7 +33,7 @@ async fn test_basic_sessions() {
         Ok(format!("you have visited this website {} times", visits))
     });
 
-    let response = app.get("/").await;
+    let response = app.get("/").await?;
     let cookies = Cookies::from_response(&response);
     let cookie = &cookies["tide.sid"];
     assert_eq!(cookie.name(), "tide.sid");
@@ -46,21 +42,21 @@ async fn test_basic_sessions() {
     assert_eq!(cookie.secure(), None); // this request was http://
     assert_eq!(cookie.path(), Some("/"));
 
-    let mut second_request = Request::new(Get, Url::parse("https://whatever/").unwrap());
-    second_request.insert_header("Cookie", &cookies);
-    let mut second_response: Response = app.respond(second_request).await.unwrap();
-    let body = second_response.body_string().await.unwrap();
+    let mut second_response = app.get("/").header("Cookie", &cookies).await?;
+
+    let body = second_response.body_string().await?;
     assert_eq!("you have visited this website 2 times", body);
     assert!(second_response.header("Set-Cookie").is_none());
 
-    let response = app.get("https://secure/").await;
+    let response = app.get("https://secure/").await?;
     let cookies = Cookies::from_response(&response);
     let cookie = &cookies["tide.sid"];
     assert_eq!(cookie.secure(), Some(true));
+    Ok(())
 }
 
 #[async_std::test]
-async fn test_customized_sessions() {
+async fn test_customized_sessions() -> tide::Result<()> {
     let mut app = tide::new();
     app.with(
         SessionMiddleware::new(MemoryStore::new(), b"12345678901234567890123456789012345")
@@ -82,20 +78,20 @@ async fn test_customized_sessions() {
         .get(|mut req: tide::Request<()>| async move {
             let mut visits: usize = req.session().get("visits").unwrap_or_default();
             visits += 1;
-            req.session_mut().insert("visits", visits).unwrap();
+            req.session_mut().insert("visits", visits)?;
             Ok(format!("/nested/incr {}", visits))
         });
 
-    let response = app.get("/").await;
+    let response = app.get("/").await?;
     assert_eq!(Cookies::from_response(&response).len(), 0);
 
-    let mut response = app.get("/nested").await;
+    let mut response = app.get("/nested").await?;
     assert_eq!(Cookies::from_response(&response).len(), 0);
-    assert_eq!(response.body_string().await.unwrap(), "/nested 0");
+    assert_eq!(response.body_string().await?, "/nested 0");
 
-    let mut response = app.get("/nested/incr").await;
+    let mut response = app.get("/nested/incr").await?;
     let cookies = Cookies::from_response(&response);
-    assert_eq!(response.body_string().await.unwrap(), "/nested/incr 1");
+    assert_eq!(response.body_string().await?, "/nested/incr 1");
 
     assert_eq!(cookies.len(), 1);
     assert!(cookies.get("tide.sid").is_none());
@@ -105,29 +101,31 @@ async fn test_customized_sessions() {
     assert_eq!(cookie.path(), Some("/nested"));
     let cookie_value = cookie.value().to_string();
 
-    let mut second_request = Request::new(Get, Url::parse("https://whatever/nested/incr").unwrap());
-    second_request.insert_header("Cookie", &cookies);
-    let mut second_response: Response = app.respond(second_request).await.unwrap();
-    let body = second_response.body_string().await.unwrap();
+    let mut second_response = app
+        .get("https://whatever/nested/incr")
+        .header("Cookie", &cookies)
+        .await?;
+    let body = second_response.body_string().await?;
     assert_eq!("/nested/incr 2", body);
     assert!(second_response.header("Set-Cookie").is_none());
 
     async_std::task::sleep(Duration::from_secs(5)).await; // wait for expiration
 
-    let mut expired_request =
-        Request::new(Get, Url::parse("https://whatever/nested/incr").unwrap());
-    expired_request.insert_header("Cookie", &cookies);
-    let mut expired_response: Response = app.respond(expired_request).await.unwrap();
+    let mut expired_response = app
+        .get("https://whatever/nested/incr")
+        .header("Cookie", &cookies)
+        .await?;
     let cookies = Cookies::from_response(&expired_response);
     assert_eq!(cookies.len(), 1);
     assert!(cookies["custom.cookie.name"].value() != cookie_value);
 
-    let body = expired_response.body_string().await.unwrap();
+    let body = expired_response.body_string().await?;
     assert_eq!("/nested/incr 1", body);
+    Ok(())
 }
 
 #[async_std::test]
-async fn test_session_destruction() {
+async fn test_session_destruction() -> tide::Result<()> {
     let mut app = tide::new();
     app.with(SessionMiddleware::new(
         MemoryStore::new(),
@@ -151,15 +149,17 @@ async fn test_session_destruction() {
             Ok(Response::new(200))
         });
 
-    let response = app.get("/").await;
+    let response = app.get("/").await?;
     let cookies = Cookies::from_response(&response);
 
-    let mut second_request = Request::new(Post, Url::parse("https://whatever/logout").unwrap());
-    second_request.insert_header("Cookie", &cookies);
-    let second_response: Response = app.respond(second_request).await.unwrap();
+    let second_response = app
+        .post("https://whatever/logout")
+        .header("Cookie", &cookies)
+        .await?;
     let cookies = Cookies::from_response(&second_response);
     assert_eq!(cookies["tide.sid"].value(), "");
     assert_eq!(cookies.len(), 1);
+    Ok(())
 }
 
 #[derive(Debug, Clone)]
@@ -169,9 +169,10 @@ impl Cookies {
         self.0.len()
     }
 
-    fn from_response(response: &http_types::Response) -> Self {
+    fn from_response(response: &impl AsRef<http_types::Response>) -> Self {
         response
-            .header("Set-Cookie")
+            .as_ref()
+            .header(SET_COOKIE)
             .map(|hv| hv.to_string())
             .unwrap_or_else(|| "[]".into())
             .parse()

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -11,7 +11,6 @@ pub async fn find_port() -> u16 {
     pick_unused_port().expect("No ports free")
 }
 
-#[async_trait::async_trait]
 pub trait ServerTestingExt {
     fn client(&self) -> Client;
     fn connect(&self, path: &str) -> RequestBuilder;
@@ -25,7 +24,6 @@ pub trait ServerTestingExt {
     fn trace(&self, path: &str) -> RequestBuilder;
 }
 
-#[async_trait::async_trait]
 impl<State> ServerTestingExt for Server<State>
 where
     State: Unpin + Clone + Send + Sync + 'static,

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -1,64 +1,7 @@
-use std::sync::Arc;
-
 use portpicker::pick_unused_port;
-use surf::{Client, RequestBuilder};
-use tide::http::url::Url;
-use tide::Server;
 
 /// Find an unused port.
 #[allow(dead_code)]
 pub async fn find_port() -> u16 {
     pick_unused_port().expect("No ports free")
-}
-
-pub trait ServerTestingExt {
-    fn client(&self) -> Client;
-    fn connect(&self, path: &str) -> RequestBuilder;
-    fn delete(&self, path: &str) -> RequestBuilder;
-    fn get(&self, path: &str) -> RequestBuilder;
-    fn head(&self, path: &str) -> RequestBuilder;
-    fn options(&self, path: &str) -> RequestBuilder;
-    fn patch(&self, path: &str) -> RequestBuilder;
-    fn post(&self, path: &str) -> RequestBuilder;
-    fn put(&self, path: &str) -> RequestBuilder;
-    fn trace(&self, path: &str) -> RequestBuilder;
-}
-
-impl<State> ServerTestingExt for Server<State>
-where
-    State: Unpin + Clone + Send + Sync + 'static,
-{
-    fn client(&self) -> Client {
-        let mut client = Client::with_http_client(Arc::new(self.clone()));
-        client.set_base_url(Url::parse("http://example.com").unwrap());
-        client
-    }
-
-    fn connect(&self, path: &str) -> RequestBuilder {
-        self.client().connect(path)
-    }
-    fn delete(&self, path: &str) -> RequestBuilder {
-        self.client().delete(path)
-    }
-    fn get(&self, path: &str) -> RequestBuilder {
-        self.client().get(path)
-    }
-    fn head(&self, path: &str) -> RequestBuilder {
-        self.client().head(path)
-    }
-    fn options(&self, path: &str) -> RequestBuilder {
-        self.client().options(path)
-    }
-    fn patch(&self, path: &str) -> RequestBuilder {
-        self.client().patch(path)
-    }
-    fn post(&self, path: &str) -> RequestBuilder {
-        self.client().post(path)
-    }
-    fn put(&self, path: &str) -> RequestBuilder {
-        self.client().put(path)
-    }
-    fn trace(&self, path: &str) -> RequestBuilder {
-        self.client().trace(path)
-    }
 }

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -1,6 +1,4 @@
-mod test_utils;
-use test_utils::ServerTestingExt;
-use tide::{Request, StatusCode};
+use tide::{testing::TestingExt, Request, StatusCode};
 async fn add_one(req: Request<()>) -> Result<String, tide::Error> {
     match req.param::<i64>("num") {
         Ok(num) => Ok((num + 1).to_string()),

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -26,100 +26,117 @@ async fn echo_path(req: Request<()>) -> Result<String, tide::Error> {
 }
 
 #[async_std::test]
-async fn wildcard() {
+async fn wildcard() -> tide::Result<()> {
     let mut app = tide::Server::new();
     app.at("/add_one/:num").get(add_one);
-    assert_eq!(app.get_body("/add_one/3").await, "4");
-    assert_eq!(app.get_body("/add_one/-7").await, "-6");
+    assert_eq!(app.get("/add_one/3").recv_string().await?, "4");
+    assert_eq!(app.get("/add_one/-7").recv_string().await?, "-6");
+    Ok(())
 }
 
 #[async_std::test]
-async fn invalid_segment_error() {
+async fn invalid_segment_error() -> tide::Result<()> {
     let mut app = tide::new();
     app.at("/add_one/:num").get(add_one);
-    assert_eq!(app.get("/add_one/a").await.status(), StatusCode::BadRequest);
+    assert_eq!(
+        app.get("/add_one/a").await?.status(),
+        StatusCode::BadRequest
+    );
+    Ok(())
 }
 
 #[async_std::test]
-async fn not_found_error() {
+async fn not_found_error() -> tide::Result<()> {
     let mut app = tide::new();
     app.at("/add_one/:num").get(add_one);
-    assert_eq!(app.get("/add_one/").await.status(), StatusCode::NotFound);
+    assert_eq!(app.get("/add_one/").await?.status(), StatusCode::NotFound);
+    Ok(())
 }
 
 #[async_std::test]
-async fn wild_path() {
+async fn wild_path() -> tide::Result<()> {
     let mut app = tide::new();
     app.at("/echo/*path").get(echo_path);
-    assert_eq!(app.get_body("/echo/some_path").await, "some_path");
+    assert_eq!(app.get("/echo/some_path").recv_string().await?, "some_path");
     assert_eq!(
-        app.get_body("/echo/multi/segment/path").await,
+        app.get("/echo/multi/segment/path").recv_string().await?,
         "multi/segment/path"
     );
-    assert_eq!(app.get("/echo/").await.status(), StatusCode::NotFound);
+    assert_eq!(app.get("/echo/").await?.status(), StatusCode::NotFound);
+    Ok(())
 }
 
 #[async_std::test]
-async fn multi_wildcard() {
+async fn multi_wildcard() -> tide::Result<()> {
     let mut app = tide::new();
     app.at("/add_two/:one/:two/").get(add_two);
-    assert_eq!(app.get_body("/add_two/1/2/").await, "3");
-    assert_eq!(app.get_body("/add_two/-1/2/").await, "1");
-    assert_eq!(app.get("/add_two/1").await.status(), StatusCode::NotFound);
+    assert_eq!(app.get("/add_two/1/2/").recv_string().await?, "3");
+    assert_eq!(app.get("/add_two/-1/2/").recv_string().await?, "1");
+    assert_eq!(app.get("/add_two/1").await?.status(), StatusCode::NotFound);
+    Ok(())
 }
 
 #[async_std::test]
-async fn wild_last_segment() {
+async fn wild_last_segment() -> tide::Result<()> {
     let mut app = tide::new();
     app.at("/echo/:path/*").get(echo_path);
-    assert_eq!(app.get_body("/echo/one/two").await, "one");
-    assert_eq!(app.get_body("/echo/one/two/three/four").await, "one");
+    assert_eq!(app.get("/echo/one/two").recv_string().await?, "one");
+    assert_eq!(
+        app.get("/echo/one/two/three/four").recv_string().await?,
+        "one"
+    );
+    Ok(())
 }
 
 #[async_std::test]
-async fn invalid_wildcard() {
+async fn invalid_wildcard() -> tide::Result<()> {
     let mut app = tide::new();
     app.at("/echo/*path/:one/").get(echo_path);
     assert_eq!(
-        app.get("/echo/one/two").await.status(),
+        app.get("/echo/one/two").await?.status(),
         StatusCode::NotFound
     );
+    Ok(())
 }
 
 #[async_std::test]
-async fn nameless_wildcard() {
+async fn nameless_wildcard() -> tide::Result<()> {
     let mut app = tide::Server::new();
     app.at("/echo/:").get(|_| async { Ok("") });
     assert_eq!(
-        app.get("/echo/one/two").await.status(),
+        app.get("/echo/one/two").await?.status(),
         StatusCode::NotFound
     );
-    assert_eq!(app.get("/echo/one").await.status(), StatusCode::Ok);
+    assert_eq!(app.get("/echo/one").await?.status(), StatusCode::Ok);
+    Ok(())
 }
 
 #[async_std::test]
-async fn nameless_internal_wildcard() {
+async fn nameless_internal_wildcard() -> tide::Result<()> {
     let mut app = tide::new();
     app.at("/echo/:/:path").get(echo_path);
-    assert_eq!(app.get("/echo/one").await.status(), StatusCode::NotFound);
-    assert_eq!(app.get_body("/echo/one/two").await, "two");
+    assert_eq!(app.get("/echo/one").await?.status(), StatusCode::NotFound);
+    assert_eq!(app.get("/echo/one/two").recv_string().await?, "two");
+    Ok(())
 }
 
 #[async_std::test]
-async fn nameless_internal_wildcard2() {
+async fn nameless_internal_wildcard2() -> tide::Result<()> {
     let mut app = tide::new();
     app.at("/echo/:/:path").get(|req: Request<()>| async move {
         assert_eq!(req.param::<String>("path")?, "two");
         Ok("")
     });
 
-    app.get("/echo/one/two").await;
+    assert!(app.get("/echo/one/two").await?.status().is_success());
+    Ok(())
 }
 
 #[async_std::test]
-async fn ambiguous_router_wildcard_vs_star() {
+async fn ambiguous_router_wildcard_vs_star() -> tide::Result<()> {
     let mut app = tide::new();
     app.at("/:one/:two").get(|_| async { Ok("one/two") });
     app.at("/posts/*").get(|_| async { Ok("posts/*") });
-    assert_eq!(app.get_body("/posts/10").await, "posts/*");
+    assert_eq!(app.get("/posts/10").recv_string().await?, "posts/*");
+    Ok(())
 }


### PR DESCRIPTION
This approach is mutually exclusive with #697 (although it happens to be rebased on it) and http-rs/surf#229.
Instead of pulling in surf::Methods, a tide application would do the following:

```rust
// add a dev dep on tide with the feature "testing", then
let app = tide::new();
use tide::testing::TestingExt;
let body = app.get("/path").recv_string().await?;
```

In order to use this to test tide itself, we add a dev dep to `.` with the testing feature enabled. I was surprised that this works.

This includes a line that should be removed when https://github.com/http-rs/surf/pull/236 is merged and published: https://github.com/http-rs/tide/compare/main...jbr:tide-testing-trait?expand=1#diff-80398c5faae3c069e4e6aa2ed11b28c0R52 — There's no reason that enabling the tide testing trait should need to pull in a client backend for surf, but until http-rs/surf#236 is merged, it's mandatory to do so.

This also provides a starting place for future testing utilities to exist