### PR TITLE
Bugfix, route prefix was always set to false after calling nest

### DIFF
--- a/src/route.rs
+++ b/src/route.rs
@@ -104,9 +104,12 @@ impl<'a, State: Clone + Send + Sync + 'static> Route<'a, State> {
         State: Clone + Send + Sync + 'static,
         InnerState: Clone + Send + Sync + 'static,
     {
+        let prefix = self.prefix;
+
         self.prefix = true;
         self.all(service);
-        self.prefix = false;
+        self.prefix = prefix;
+
         self
     }
 


### PR DESCRIPTION
## Description
I found this method in route.rs:
```rust
    pub fn nest<InnerState>(&mut self, service: crate::Server<InnerState>) -> &mut Self
    where
        State: Clone + Send + Sync + 'static,
        InnerState: Clone + Send + Sync + 'static,
    {
        self.prefix = true;
        self.all(service);
        self.prefix = false;
        self
    }
```
I'm not sure if this is expected behavior but I assume that if self.prefix was set to true before calling `nest` it should stay true.

## How Has This Been Tested?
This is a trivial code change, all tests still pass, however I could try to add a regression test for this. Let me know if this is required

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

This does introduce a small change in behavior but it only impacts code that uses the unstable `strip-prefix` method

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](https://github.com/rustasync/tide/blob/master/.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
