### PR TITLE
Remove parsing from `Request::param`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ async-std = { version = "1.6.0", features = ["unstable"] }
 async-trait = "0.1.36"
 femme = "2.0.1"
 futures-util = "0.3.5"
-http-types = "2.2.1"
+http-types = "2.4.0"
 kv-log-macro = "1.0.4"
 pin-project-lite = "0.1.7"
 route-recognizer = "0.2.0"

--- a/examples/fib.rs
+++ b/examples/fib.rs
@@ -10,7 +10,7 @@ fn fib(n: usize) -> usize {
 
 async fn fibsum(req: Request<()>) -> tide::Result<String> {
     use std::time::Instant;
-    let n: usize = req.param("n").unwrap_or(0);
+    let n: usize = req.param("n")?.parse().unwrap_or(0);
     // Start a stopwatch
     let start = Instant::now();
     // Compute the nth number in the fibonacci sequence

--- a/examples/upload.rs
+++ b/examples/upload.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), IoError> {
 
     app.at(":file")
         .put(|req: Request<TempDirState>| async move {
-            let path: String = req.param("file")?;
+            let path = req.param("file")?;
             let fs_path = req.state().path().join(path);
 
             let file = OpenOptions::new()
@@ -55,7 +55,7 @@ async fn main() -> Result<(), IoError> {
             Ok(json!({ "bytes": bytes_written }))
         })
         .get(|req: Request<TempDirState>| async move {
-            let path: String = req.param("file")?;
+            let path = req.param("file")?;
             let fs_path = req.state().path().join(path);
 
             if let Ok(body) = Body::from_file(fs_path).await {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,7 @@ pub mod sessions;
 pub use endpoint::Endpoint;
 pub use middleware::{Middleware, Next};
 pub use redirect::Redirect;
-pub use request::{ParamError, Request};
+pub use request::Request;
 pub use response::Response;
 pub use response_builder::ResponseBuilder;
 pub use route::Route;

--- a/tests/params.rs
+++ b/tests/params.rs
@@ -1,69 +1,39 @@
 use http_types::{self, Method, Url};
-use tide::{self, Request, Response, Result, StatusCode};
+use tide::{self, Request, Response, Result};
 
 #[async_std::test]
-async fn test_param_invalid_type() {
-    async fn get_by_id(req: Request<()>) -> Result<Response> {
-        assert_eq!(
-            req.param::<i32>("id").unwrap_err().to_string(),
-            "Param failed to parse: invalid digit found in string"
-        );
-        let _ = req.param::<i32>("id")?;
-        Result::Ok(Response::new(StatusCode::Ok))
-    }
-    let mut server = tide::new();
-    server.at("/by_id/:id").get(get_by_id);
-
-    let req = http_types::Request::new(
-        Method::Get,
-        Url::parse("http://example.com/by_id/wrong").unwrap(),
-    );
-    let res: http_types::Response = server.respond(req).await.unwrap();
-    assert_eq!(res.status(), StatusCode::InternalServerError);
-}
-
-#[async_std::test]
-async fn test_missing_param() {
+async fn test_missing_param() -> tide::Result<()> {
     async fn greet(req: Request<()>) -> Result<Response> {
-        assert_eq!(
-            req.param::<String>("name").unwrap_err().to_string(),
-            "Param \"name\" not found!"
-        );
-        let _: String = req.param("name")?;
-        Result::Ok(Response::new(StatusCode::Ok))
+        assert_eq!(req.param("name")?, "Param \"name\" not found");
+        Ok(Response::new(200))
     }
+
     let mut server = tide::new();
     server.at("/").get(greet);
 
-    let req = http_types::Request::new(Method::Get, Url::parse("http://example.com/").unwrap());
-    let res: http_types::Response = server.respond(req).await.unwrap();
-    assert_eq!(res.status(), StatusCode::InternalServerError);
+    let req = http_types::Request::new(Method::Get, Url::parse("http://example.com/")?);
+    let res: http_types::Response = server.respond(req).await?;
+    assert_eq!(res.status(), 500);
+    Ok(())
 }
 
 #[async_std::test]
-async fn hello_world_parametrized() {
-    async fn greet(req: tide::Request<()>) -> Result<Response> {
-        let name = req.param("name").unwrap_or_else(|_| "nori".to_owned());
-        let mut response = tide::Response::new(StatusCode::Ok);
-        response.set_body(format!("{} says hello", name));
-        Ok(response)
+async fn hello_world_parametrized() -> Result<()> {
+    async fn greet(req: tide::Request<()>) -> Result<impl Into<Response>> {
+        let body = format!("{} says hello", req.param("name").unwrap_or("nori"));
+        Ok(Response::builder(200).body(body))
     }
 
     let mut server = tide::new();
     server.at("/").get(greet);
     server.at("/:name").get(greet);
 
-    let req = http_types::Request::new(Method::Get, Url::parse("http://example.com/").unwrap());
-    let mut res: http_types::Response = server.respond(req).await.unwrap();
-    assert_eq!(
-        res.body_string().await.unwrap(),
-        "nori says hello".to_string()
-    );
+    let req = http_types::Request::new(Method::Get, Url::parse("http://example.com/")?);
+    let mut res: http_types::Response = server.respond(req).await?;
+    assert_eq!(res.body_string().await?, "nori says hello");
 
-    let req = http_types::Request::new(Method::Get, Url::parse("http://example.com/iron").unwrap());
-    let mut res: http_types::Response = server.respond(req).await.unwrap();
-    assert_eq!(
-        res.body_string().await.unwrap(),
-        "iron says hello".to_string()
-    );
+    let req = http_types::Request::new(Method::Get, Url::parse("http://example.com/iron")?);
+    let mut res: http_types::Response = server.respond(req).await?;
+    assert_eq!(res.body_string().await?, "iron says hello");
+    Ok(())
 }


### PR DESCRIPTION
This PR removes the `parse` portion of `Request::param`, making that an explicit step that needs to be called by end-users. This was inspired by my analysis in https://github.com/rust-lang/rust/pull/75435#issuecomment-695805123 on similar ergonomics issues for a stdlib API. As a result many of our tests that want to extract a `&str` or `String` from the params are more intuitive.