### PR TITLE
implement Endpoint trait for Box<dyn Endpoint>

### DIFF
--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -118,3 +118,10 @@ where
         Ok(next.run(req).await)
     }
 }
+
+#[async_trait]
+impl<State: Clone + Send + Sync + 'static> Endpoint<State> for Box<dyn Endpoint<State>> {
+    async fn call(&self, request: Request<State>) -> crate::Result {
+        self.call(request).await
+    }
+}


### PR DESCRIPTION
Right now adding endpoints dynamically is difficult because only types that implement the Endpoint trait directly can be added. When you don't know in advance which endpoint you want to add in a certain situation it can be useful to be able to add boxed endpoints. This implementation makes this possible.

I did not add any tests for this. It seems like a trivial piece of code where the test will probably be more fragile than the code itself.