### PR TITLE
Fix missing as_ref that caused boxed endpoints to enter an infinite loop

### DIFF
--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -122,6 +122,6 @@ where
 #[async_trait]
 impl<State: Clone + Send + Sync + 'static> Endpoint<State> for Box<dyn Endpoint<State>> {
     async fn call(&self, request: Request<State>) -> crate::Result {
-        self.call(request).await
+        self.as_ref().call(request).await
     }
 }

--- a/tests/endpoint.rs
+++ b/tests/endpoint.rs
@@ -1,0 +1,25 @@
+use tide::http::{Method, Request, Url};
+use tide::Response;
+
+#[async_std::test]
+async fn should_accept_boxed_endpoints() {
+    fn endpoint() -> Box<dyn tide::Endpoint<()>> {
+        Box::new(|_| async { Ok("hello world") })
+    }
+
+    let mut app = tide::Server::new();
+    app.at("/").get(endpoint());
+
+    let mut response: Response = app
+        .respond(Request::new(
+            Method::Get,
+            Url::parse("http://example.com/").unwrap(),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.take_body().into_string().await.unwrap(),
+        "hello world"
+    );
+}


### PR DESCRIPTION
This pr fixes the Endpoint implementation for boxed endpoints. And adds a test for this fix.

In the previous implementation the call method for the boxed endpoint just called itself and not the call method of the endpoint inside the box. This caused an infinite loop.