### PR TITLE
Split state into a separate parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ async fn main() -> tide::Result<()> {
     Ok(())
 }
 
-async fn order_shoes(mut req: Request<()>) -> tide::Result {
+async fn order_shoes(mut req: Request, _state: ()) -> tide::Result {
     let Animal { name, legs } = req.body_json().await?;
     Ok(format!("Hello, {}! I've put in an order for {} shoes", name, legs).into())
 }

--- a/examples/catflap.rs
+++ b/examples/catflap.rs
@@ -4,7 +4,7 @@ async fn main() -> Result<(), std::io::Error> {
     use std::{env, net::TcpListener, os::unix::io::FromRawFd};
     tide::log::start();
     let mut app = tide::new();
-    app.at("/").get(|_| async { Ok(CHANGE_THIS_TEXT) });
+    app.at("/").get(|_, _| async { Ok(CHANGE_THIS_TEXT) });
 
     const CHANGE_THIS_TEXT: &str = "hello world!";
 

--- a/examples/chunked.rs
+++ b/examples/chunked.rs
@@ -4,7 +4,7 @@ use tide::Body;
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
     let mut app = tide::new();
-    app.at("/").get(|_| async {
+    app.at("/").get(|_, _| async {
         // File sends are chunked by default.
         Ok(Body::from_file(file!()).await?)
     });

--- a/examples/concurrent_listeners.rs
+++ b/examples/concurrent_listeners.rs
@@ -5,10 +5,10 @@ async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
     let mut app = tide::new();
 
-    app.at("/").get(|request: Request<_>| async move {
+    app.at("/").get(|req: Request, _| async move {
         Ok(format!(
             "Hi! You reached this app through: {}",
-            request.local_addr().unwrap_or("an unknown port")
+            req.local_addr().unwrap_or("an unknown port")
         ))
     });
 

--- a/examples/cookies.rs
+++ b/examples/cookies.rs
@@ -3,17 +3,17 @@ use tide::{Request, Response, StatusCode};
 
 /// Tide will use the the `Cookies`'s `Extract` implementation to build this parameter.
 ///
-async fn retrieve_cookie(req: Request<()>) -> tide::Result<String> {
+async fn retrieve_cookie(req: Request, _state: ()) -> tide::Result<String> {
     Ok(format!("hello cookies: {:?}", req.cookie("hello").unwrap()))
 }
 
-async fn insert_cookie(_req: Request<()>) -> tide::Result {
+async fn insert_cookie(_req: Request, _state: ()) -> tide::Result {
     let mut res = Response::new(StatusCode::Ok);
     res.insert_cookie(Cookie::new("hello", "world"));
     Ok(res)
 }
 
-async fn remove_cookie(_req: Request<()>) -> tide::Result {
+async fn remove_cookie(_req: Request, _state: ()) -> tide::Result {
     let mut res = Response::new(StatusCode::Ok);
     res.remove_cookie(Cookie::named("hello"));
     Ok(res)

--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -1,7 +1,7 @@
 use std::io::ErrorKind;
 
 use tide::utils::After;
-use tide::{Body, Request, Response, Result, StatusCode};
+use tide::{Body, Response, Result, StatusCode};
 
 #[async_std::main]
 async fn main() -> Result<()> {
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
     }));
 
     app.at("/")
-        .get(|_req: Request<_>| async { Ok(Body::from_file("./does-not-exist").await?) });
+        .get(|_, _| async { Ok(Body::from_file("./does-not-exist").await?) });
 
     app.listen("127.0.0.1:8080").await?;
 

--- a/examples/fib.rs
+++ b/examples/fib.rs
@@ -8,7 +8,7 @@ fn fib(n: usize) -> usize {
     }
 }
 
-async fn fibsum(req: Request<()>) -> tide::Result<String> {
+async fn fibsum(req: Request, _state: ()) -> tide::Result<String> {
     use std::time::Instant;
     let n: usize = req.param("n")?.parse().unwrap_or(0);
     // Start a stopwatch

--- a/examples/graphql.rs
+++ b/examples/graphql.rs
@@ -74,9 +74,9 @@ lazy_static! {
     static ref SCHEMA: Schema = Schema::new(QueryRoot {}, MutationRoot {});
 }
 
-async fn handle_graphql(mut request: Request<State>) -> tide::Result {
+async fn handle_graphql(mut request: Request, state: State) -> tide::Result {
     let query: GraphQLRequest = request.body_json().await?;
-    let response = query.execute(&SCHEMA, request.state());
+    let response = query.execute(&SCHEMA, &state);
     let status = if response.is_ok() {
         StatusCode::Ok
     } else {
@@ -88,7 +88,7 @@ async fn handle_graphql(mut request: Request<State>) -> tide::Result {
         .build())
 }
 
-async fn handle_graphiql(_: Request<State>) -> tide::Result<impl Into<Response>> {
+async fn handle_graphiql(_: Request, _state: State) -> tide::Result<impl Into<Response>> {
     Ok(Response::builder(200)
         .body(graphiql::graphiql_source("/graphql"))
         .content_type(mime::HTML))

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -2,7 +2,7 @@
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
     let mut app = tide::new();
-    app.at("/").get(|_| async { Ok("Hello, world!") });
+    app.at("/").get(|_, _| async { Ok("Hello, world!") });
     app.listen("127.0.0.1:8080").await?;
     Ok(())
 }

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -12,7 +12,7 @@ async fn main() -> tide::Result<()> {
     tide::log::start();
     let mut app = tide::new();
 
-    app.at("/submit").post(|mut req: Request<()>| async move {
+    app.at("/submit").post(|mut req: Request, _| async move {
         let cat: Cat = req.body_json().await?;
         println!("cat name: {}", cat.name);
 
@@ -23,7 +23,7 @@ async fn main() -> tide::Result<()> {
         Ok(Body::from_json(&cat)?)
     });
 
-    app.at("/animals").get(|_| async {
+    app.at("/animals").get(|_, _| async {
         Ok(json!({
             "meta": { "count": 2 },
             "animals": [

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -2,11 +2,12 @@
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
     let mut app = tide::new();
-    app.at("/").get(|_| async { Ok("Root") });
+    app.at("/").get(|_, _| async { Ok("Root") });
     app.at("/api").nest({
         let mut api = tide::new();
-        api.at("/hello").get(|_| async { Ok("Hello, world") });
-        api.at("/goodbye").get(|_| async { Ok("Goodbye, world") });
+        api.at("/hello").get(|_, _| async { Ok("Hello, world") });
+        api.at("/goodbye")
+            .get(|_, _| async { Ok("Goodbye, world") });
         api
     });
     app.listen("127.0.0.1:8080").await?;

--- a/examples/redirect.rs
+++ b/examples/redirect.rs
@@ -4,13 +4,13 @@ use tide::{Redirect, Response, StatusCode};
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
     let mut app = tide::new();
-    app.at("/").get(|_| async { Ok("Root") });
+    app.at("/").get(|_, _| async { Ok("Root") });
 
     // Redirect hackers to YouTube.
     app.at("/.env")
         .get(Redirect::new("https://www.youtube.com/watch?v=dQw4w9WgXcQ"));
 
-    app.at("/users-page").get(|_| async {
+    app.at("/users-page").get(|_, _| async {
         Ok(if signed_in() {
             Response::new(StatusCode::Ok)
         } else {

--- a/examples/sessions.rs
+++ b/examples/sessions.rs
@@ -14,21 +14,21 @@ async fn main() -> Result<(), std::io::Error> {
     ));
 
     app.with(tide::utils::Before(
-        |mut request: tide::Request<()>| async move {
-            let session = request.session_mut();
+        |mut req: tide::Request, state| async move {
+            let session = req.session_mut();
             let visits: usize = session.get("visits").unwrap_or_default();
             session.insert("visits", visits + 1).unwrap();
-            request
+            (req, state)
         },
     ));
 
-    app.at("/").get(|req: tide::Request<()>| async move {
+    app.at("/").get(|req: tide::Request, _| async move {
         let visits: usize = req.session().get("visits").unwrap();
         Ok(format!("you have visited this website {} times", visits))
     });
 
     app.at("/reset")
-        .get(|mut req: tide::Request<()>| async move {
+        .get(|mut req: tide::Request, _| async move {
             req.session_mut().destroy();
             Ok(tide::Redirect::new("/"))
         });

--- a/examples/sse.rs
+++ b/examples/sse.rs
@@ -4,11 +4,12 @@ use tide::sse;
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
     let mut app = tide::new();
-    app.at("/sse").get(sse::endpoint(|_req, sender| async move {
-        sender.send("fruit", "banana", None).await?;
-        sender.send("fruit", "apple", None).await?;
-        Ok(())
-    }));
+    app.at("/sse")
+        .get(sse::endpoint(|_req, _state, sender| async move {
+            sender.send("fruit", "banana", None).await?;
+            sender.send("fruit", "apple", None).await?;
+            Ok(())
+        }));
     app.listen("localhost:8080").await?;
     Ok(())
 }

--- a/examples/static_file.rs
+++ b/examples/static_file.rs
@@ -2,7 +2,7 @@
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
     let mut app = tide::new();
-    app.at("/").get(|_| async { Ok("visit /src/*") });
+    app.at("/").get(|_, _| async { Ok("visit /src/*") });
     app.at("/src").serve_dir("src/")?;
     app.listen("127.0.0.1:8080").await?;
     Ok(())

--- a/examples/upload.rs
+++ b/examples/upload.rs
@@ -35,9 +35,9 @@ async fn main() -> Result<(), IoError> {
     // $ curl localhost:8080/README.md # this reads the file from the same temp directory
 
     app.at(":file")
-        .put(|req: Request<TempDirState>| async move {
+        .put(|req: Request, state: TempDirState| async move {
             let path = req.param("file")?;
-            let fs_path = req.state().path().join(path);
+            let fs_path = state.path().join(path);
 
             let file = OpenOptions::new()
                 .create(true)
@@ -54,9 +54,9 @@ async fn main() -> Result<(), IoError> {
 
             Ok(json!({ "bytes": bytes_written }))
         })
-        .get(|req: Request<TempDirState>| async move {
+        .get(|req: Request, state: TempDirState| async move {
             let path = req.param("file")?;
-            let fs_path = req.state().path().join(path);
+            let fs_path = state.path().join(path);
 
             if let Ok(body) = Body::from_file(fs_path).await {
                 Ok(body.into())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //!     Ok(())
 //! }
 //!
-//! async fn order_shoes(mut req: Request<()>) -> tide::Result {
+//! async fn order_shoes(mut req: Request, _state: ()) -> tide::Result {
 //!     let Animal { name, legs } = req.body_json().await?;
 //!     Ok(format!("Hello, {}! I've put in an order for {} shoes", name, legs).into())
 //! }
@@ -108,7 +108,7 @@ pub use http_types::{self as http, Body, Error, Status, StatusCode};
 /// # fn main() -> Result<(), std::io::Error> { block_on(async {
 /// #
 /// let mut app = tide::new();
-/// app.at("/").get(|_| async { Ok("Hello, world!") });
+/// app.at("/").get(|_, _| async { Ok("Hello, world!") });
 /// app.listen("127.0.0.1:8080").await?;
 /// #
 /// # Ok(()) }) }
@@ -143,8 +143,8 @@ pub fn new() -> server::Server<()> {
 ///
 /// // Initialize the application with state.
 /// let mut app = tide::with_state(state);
-/// app.at("/").get(|req: Request<State>| async move {
-///     Ok(format!("Hello, {}!", &req.state().name))
+/// app.at("/").get(|req: Request, state: State| async move {
+///     Ok(format!("Hello, {}!", &state.name))
 /// });
 /// app.listen("127.0.0.1:8080").await?;
 /// #

--- a/src/listener/concurrent_listener.rs
+++ b/src/listener/concurrent_listener.rs
@@ -15,7 +15,7 @@ use futures_util::stream::{futures_unordered::FuturesUnordered, StreamExt};
 ///    async_std::task::block_on(async {
 ///        tide::log::start();
 ///        let mut app = tide::new();
-///        app.at("/").get(|_| async { Ok("Hello, world!") });
+///        app.at("/").get(|_, _| async { Ok("Hello, world!") });
 ///
 ///        let mut listener = tide::listener::ConcurrentListener::new();
 ///        listener.add("127.0.0.1:8000")?;

--- a/src/listener/failover_listener.rs
+++ b/src/listener/failover_listener.rs
@@ -15,7 +15,7 @@ use async_std::io;
 ///    async_std::task::block_on(async {
 ///        tide::log::start();
 ///        let mut app = tide::new();
-///        app.at("/").get(|_| async { Ok("Hello, world!") });
+///        app.at("/").get(|_, _| async { Ok("Hello, world!") });
 ///
 ///        let mut listener = tide::listener::FailoverListener::new();
 ///        listener.add("127.0.0.1:8000")?;

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -9,7 +9,7 @@
 //! use tide::Redirect;
 //!
 //! let mut app = tide::new();
-//! app.at("/").get(|_| async { Ok("meow") });
+//! app.at("/").get(|_, _| async { Ok("meow") });
 //! app.at("/nori").get(Redirect::temporary("/"));
 //! app.listen("127.0.0.1:8080").await?;
 //! #
@@ -28,7 +28,7 @@ use crate::{Endpoint, Request, Response};
 /// # use tide::{Response, Redirect, Request, StatusCode};
 /// # fn next_product() -> Option<String> { None }
 /// # #[allow(dead_code)]
-/// async fn route_handler(request: Request<()>) -> tide::Result {
+/// async fn route_handler(req: Request, state: ()) -> tide::Result {
 ///     if let Some(product_url) = next_product() {
 ///         Ok(Redirect::new(product_url).into())
 ///     } else {
@@ -91,7 +91,7 @@ where
     State: Clone + Send + Sync + 'static,
     T: AsRef<str> + Send + Sync + 'static,
 {
-    async fn call(&self, _req: Request<State>) -> crate::Result<Response> {
+    async fn call(&self, _req: Request, _state: State) -> crate::Result<Response> {
         Ok(self.into())
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -21,22 +21,17 @@ pin_project_lite::pin_project! {
     /// Requests also provide *extensions*, a type map primarily used for low-level
     /// communication between middleware and endpoints.
     #[derive(Debug)]
-    pub struct Request<State> {
-        pub(crate) state: State,
+    pub struct Request {
         #[pin]
         pub(crate) req: http::Request,
         pub(crate) route_params: Vec<Params>,
     }
 }
 
-impl<State> Request<State> {
+impl Request {
     /// Create a new `Request`.
-    pub(crate) fn new(state: State, req: http_types::Request, route_params: Vec<Params>) -> Self {
-        Self {
-            state,
-            req,
-            route_params,
-        }
+    pub(crate) fn new(req: http_types::Request, route_params: Vec<Params>) -> Self {
+        Self { req, route_params }
     }
 
     /// Access the request's HTTP method.
@@ -50,7 +45,7 @@ impl<State> Request<State> {
     /// use tide::Request;
     ///
     /// let mut app = tide::new();
-    /// app.at("/").get(|req: Request<()>| async move {
+    /// app.at("/").get(|req: Request, _| async move {
     ///     assert_eq!(req.method(), http_types::Method::Get);
     ///     Ok("")
     /// });
@@ -74,7 +69,7 @@ impl<State> Request<State> {
     /// use tide::Request;
     ///
     /// let mut app = tide::new();
-    /// app.at("/").get(|req: Request<()>| async move {
+    /// app.at("/").get(|req: Request, _| async move {
     ///     assert_eq!(req.url(), &"/".parse::<tide::http::Url>().unwrap());
     ///     Ok("")
     /// });
@@ -98,7 +93,7 @@ impl<State> Request<State> {
     /// use tide::Request;
     ///
     /// let mut app = tide::new();
-    /// app.at("/").get(|req: Request<()>| async move {
+    /// app.at("/").get(|req: Request, _| async move {
     ///     assert_eq!(req.version(), Some(http_types::Version::Http1_1));
     ///     Ok("")
     /// });
@@ -169,7 +164,7 @@ impl<State> Request<State> {
     /// use tide::Request;
     ///
     /// let mut app = tide::new();
-    /// app.at("/").get(|req: Request<()>| async move {
+    /// app.at("/").get(|req: Request, _| async move {
     ///     assert_eq!(req.header("X-Forwarded-For").unwrap(), "127.0.0.1");
     ///     Ok("")
     /// });
@@ -254,12 +249,6 @@ impl<State> Request<State> {
         self.req.ext_mut().insert(val)
     }
 
-    #[must_use]
-    ///  Access application scoped state.
-    pub fn state(&self) -> &State {
-        &self.state
-    }
-
     /// Extract and parse a route parameter by name.
     ///
     /// Returns the results of parsing the parameter according to the inferred
@@ -280,7 +269,7 @@ impl<State> Request<State> {
     /// #
     /// use tide::{Request, Result};
     ///
-    /// async fn greet(req: Request<()>) -> Result<String> {
+    /// async fn greet(req: Request, _state: ()) -> Result<String> {
     ///     let name = req.param("name").unwrap_or("world");
     ///     Ok(format!("Hello, {}!", name))
     /// }
@@ -322,7 +311,7 @@ impl<State> Request<State> {
     ///         }
     ///     }
     /// }
-    /// app.at("/pages").post(|req: tide::Request<()>| async move {
+    /// app.at("/pages").post(|req: tide::Request, _| async move {
     ///     let page: Page = req.query()?;
     ///     Ok(format!("page {}, with {} items", page.offset, page.size))
     /// });
@@ -386,7 +375,7 @@ impl<State> Request<State> {
     /// use tide::Request;
     ///
     /// let mut app = tide::new();
-    /// app.at("/").get(|mut req: Request<()>| async move {
+    /// app.at("/").get(|mut req: Request, _state |async move {
     ///     let _body: Vec<u8> = req.body_bytes().await.unwrap();
     ///     Ok("")
     /// });
@@ -420,7 +409,7 @@ impl<State> Request<State> {
     /// use tide::Request;
     ///
     /// let mut app = tide::new();
-    /// app.at("/").get(|mut req: Request<()>| async move {
+    /// app.at("/").get(|mut req: Request, _state |async move {
     ///     let _body: String = req.body_string().await.unwrap();
     ///     Ok("")
     /// });
@@ -460,7 +449,7 @@ impl<State> Request<State> {
     ///   legs: u8
     /// }
     ///
-    /// app.at("/").post(|mut req: tide::Request<()>| async move {
+    /// app.at("/").post(|mut req: tide::Request, _| async move {
     ///     let animal: Animal = req.body_form().await?;
     ///     Ok(format!(
     ///         "hello, {}! i've put in an order for {} shoes",
@@ -534,31 +523,31 @@ impl<State> Request<State> {
     }
 }
 
-impl<State> AsRef<http::Request> for Request<State> {
+impl AsRef<http::Request> for Request {
     fn as_ref(&self) -> &http::Request {
         &self.req
     }
 }
 
-impl<State> AsMut<http::Request> for Request<State> {
+impl AsMut<http::Request> for Request {
     fn as_mut(&mut self) -> &mut http::Request {
         &mut self.req
     }
 }
 
-impl<State> AsRef<http::Headers> for Request<State> {
+impl AsRef<http::Headers> for Request {
     fn as_ref(&self) -> &http::Headers {
         self.req.as_ref()
     }
 }
 
-impl<State> AsMut<http::Headers> for Request<State> {
+impl AsMut<http::Headers> for Request {
     fn as_mut(&mut self) -> &mut http::Headers {
         self.req.as_mut()
     }
 }
 
-impl<State> Read for Request<State> {
+impl Read for Request {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -568,21 +557,21 @@ impl<State> Read for Request<State> {
     }
 }
 
-impl<State> Into<http::Request> for Request<State> {
+impl Into<http::Request> for Request {
     fn into(self) -> http::Request {
         self.req
     }
 }
 
-impl<State: Default> Into<Request<State>> for http_types::Request {
-    fn into(self) -> Request<State> {
-        Request::new(State::default(), self, Vec::<Params>::new())
+impl Into<Request> for http_types::Request {
+    fn into(self) -> Request {
+        Request::new(self, vec![])
     }
 }
 
 // NOTE: From cannot be implemented for this conversion because `State` needs to
 // be constrained by a type.
-impl<State: Clone + Send + Sync + 'static> Into<Response> for Request<State> {
+impl Into<Response> for Request {
     fn into(mut self) -> Response {
         let mut res = Response::new(StatusCode::Ok);
         res.set_body(self.take_body());
@@ -590,7 +579,7 @@ impl<State: Clone + Send + Sync + 'static> Into<Response> for Request<State> {
     }
 }
 
-impl<State> IntoIterator for Request<State> {
+impl IntoIterator for Request {
     type Item = (HeaderName, HeaderValues);
     type IntoIter = http_types::headers::IntoIter;
 
@@ -601,7 +590,7 @@ impl<State> IntoIterator for Request<State> {
     }
 }
 
-impl<'a, State> IntoIterator for &'a Request<State> {
+impl<'a> IntoIterator for &'a Request {
     type Item = (&'a HeaderName, &'a HeaderValues);
     type IntoIter = http_types::headers::Iter<'a>;
 
@@ -611,7 +600,7 @@ impl<'a, State> IntoIterator for &'a Request<State> {
     }
 }
 
-impl<'a, State> IntoIterator for &'a mut Request<State> {
+impl<'a> IntoIterator for &'a mut Request {
     type Item = (&'a HeaderName, &'a mut HeaderValues);
     type IntoIter = http_types::headers::IterMut<'a>;
 
@@ -621,7 +610,7 @@ impl<'a, State> IntoIterator for &'a mut Request<State> {
     }
 }
 
-impl<State> Index<HeaderName> for Request<State> {
+impl Index<HeaderName> for Request {
     type Output = HeaderValues;
 
     /// Returns a reference to the value corresponding to the supplied name.
@@ -635,7 +624,7 @@ impl<State> Index<HeaderName> for Request<State> {
     }
 }
 
-impl<State> Index<&str> for Request<State> {
+impl Index<&str> for Request {
     type Output = HeaderValues;
 
     /// Returns a reference to the value corresponding to the supplied name.

--- a/src/route.rs
+++ b/src/route.rs
@@ -282,9 +282,8 @@ where
     State: Clone + Send + Sync + 'static,
     E: Endpoint<State>,
 {
-    async fn call(&self, req: crate::Request<State>) -> crate::Result {
+    async fn call(&self, req: crate::Request, state: State) -> crate::Result {
         let crate::Request {
-            state,
             mut req,
             route_params,
         } = req;
@@ -293,11 +292,7 @@ where
         req.url_mut().set_path(&rest);
 
         self.0
-            .call(crate::Request {
-                state,
-                req,
-                route_params,
-            })
+            .call(crate::Request::new(req, route_params), state)
             .await
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -82,13 +82,15 @@ impl<State: Clone + Send + Sync + 'static> Router<State> {
 }
 
 async fn not_found_endpoint<State: Clone + Send + Sync + 'static>(
-    _req: Request<State>,
+    _req: Request,
+    _: State,
 ) -> crate::Result {
     Ok(Response::new(StatusCode::NotFound))
 }
 
 async fn method_not_allowed<State: Clone + Send + Sync + 'static>(
-    _req: Request<State>,
+    _req: Request,
+    _: State,
 ) -> crate::Result {
     Ok(Response::new(StatusCode::MethodNotAllowed))
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -49,7 +49,7 @@ impl Server<()> {
     /// # fn main() -> Result<(), std::io::Error> { block_on(async {
     /// #
     /// let mut app = tide::new();
-    /// app.at("/").get(|_| async { Ok("Hello, world!") });
+    /// app.at("/").get(|_, _| async { Ok("Hello, world!") });
     /// app.listen("127.0.0.1:8080").await?;
     /// #
     /// # Ok(()) }) }
@@ -92,8 +92,8 @@ impl<State: Clone + Send + Sync + 'static> Server<State> {
     ///
     /// // Initialize the application with state.
     /// let mut app = tide::with_state(state);
-    /// app.at("/").get(|req: Request<State>| async move {
-    ///     Ok(format!("Hello, {}!", &req.state().name))
+    /// app.at("/").get(|req: Request, state: State| async move {
+    ///     Ok(format!("Hello, {}!", &state.name))
     /// });
     /// app.listen("127.0.0.1:8080").await?;
     /// #
@@ -121,7 +121,7 @@ impl<State: Clone + Send + Sync + 'static> Server<State> {
     ///
     /// ```rust,no_run
     /// # let mut app = tide::Server::new();
-    /// app.at("/").get(|_| async { Ok("Hello, world!") });
+    /// app.at("/").get(|_, _| async { Ok("Hello, world!") });
     /// ```
     ///
     /// A path is comprised of zero or many segments, i.e. non-empty strings
@@ -202,7 +202,7 @@ impl<State: Clone + Send + Sync + 'static> Server<State> {
     /// use tide::http::{Url, Method, Request, Response};
     ///
     /// let mut app = tide::new();
-    /// app.at("/").get(|_| async { Ok("hello world") });
+    /// app.at("/").get(|_, _| async { Ok("hello world") });
     ///
     /// let req = Request::new(Method::Get, Url::parse("https://example.com")?);
     /// let res: Response = app.respond(req).await?;
@@ -225,14 +225,14 @@ impl<State: Clone + Send + Sync + 'static> Server<State> {
         let method = req.method().to_owned();
         let Selection { endpoint, params } = router.route(&req.url().path(), method);
         let route_params = vec![params];
-        let req = Request::new(state, req, route_params);
+        let req = Request::new(req, route_params);
 
         let next = Next {
             endpoint,
             next_middleware: &middleware,
         };
 
-        let res = next.run(req).await;
+        let res = next.run(req, state).await;
         let res: http_types::Response = res.into();
         Ok(res.into())
     }
@@ -245,7 +245,7 @@ impl<State: Clone + Send + Sync + 'static> Server<State> {
     /// # #[derive(Clone)] struct SomeAppState;
     /// let mut app = tide::with_state(SomeAppState);
     /// let mut admin = tide::with_state(app.state().clone());
-    /// admin.at("/").get(|_| async { Ok("nested app with cloned state") });
+    /// admin.at("/").get(|_, _| async { Ok("nested app with cloned state") });
     /// app.at("/").nest(admin);
     /// ```
     pub fn state(&self) -> &State {
@@ -273,11 +273,10 @@ impl<State: Clone> Clone for Server<State> {
 impl<State: Clone + Sync + Send + 'static, InnerState: Clone + Sync + Send + 'static>
     Endpoint<State> for Server<InnerState>
 {
-    async fn call(&self, req: Request<State>) -> crate::Result {
+    async fn call(&self, req: Request, _state: State) -> crate::Result {
         let Request {
             req,
             mut route_params,
-            ..
         } = req;
         let path = req.url().path().to_owned();
         let method = req.method().to_owned();
@@ -287,14 +286,14 @@ impl<State: Clone + Sync + Send + 'static, InnerState: Clone + Sync + Send + 'st
 
         let Selection { endpoint, params } = router.route(&path, method);
         route_params.push(params);
-        let req = Request::new(state, req, route_params);
+        let req = Request::new(req, route_params);
 
         let next = Next {
             endpoint,
             next_middleware: &middleware,
         };
 
-        Ok(next.run(req).await)
+        Ok(next.run(req, state).await)
     }
 }
 

--- a/src/sessions/middleware.rs
+++ b/src/sessions/middleware.rs
@@ -27,20 +27,20 @@ const BASE64_DIGEST_LEN: usize = 44;
 ///     b"we recommend you use std::env::var(\"TIDE_SECRET\").unwrap().as_bytes() instead of a fixed value"
 /// ));
 ///
-/// app.with(tide::utils::Before(|mut request: tide::Request<()>| async move {
-///     let session = request.session_mut();
+/// app.with(tide::utils::Before(|mut req: tide::Request, state: ()| async move {
+///     let session = req.session_mut();
 ///     let visits: usize = session.get("visits").unwrap_or_default();
 ///     session.insert("visits", visits + 1).unwrap();
-///     request
+///     (req, state)
 /// }));
 ///
-/// app.at("/").get(|req: tide::Request<()>| async move {
+/// app.at("/").get(|req: tide::Request, _| async move {
 ///     let visits: usize = req.session().get("visits").unwrap();
 ///     Ok(format!("you have visited this website {} times", visits))
 /// });
 ///
 /// app.at("/reset")
-///     .get(|mut req: tide::Request<()>| async move {
+///     .get(|mut req: tide::Request, _| async move {
 ///         req.session_mut().destroy();
 ///         Ok(tide::Redirect::new("/"))
 ///      });
@@ -77,8 +77,8 @@ where
     Store: SessionStore,
     State: Clone + Send + Sync + 'static,
 {
-    async fn handle(&self, mut request: Request<State>, next: Next<'_, State>) -> crate::Result {
-        let cookie = request.cookie(&self.cookie_name);
+    async fn handle(&self, mut req: Request, state: State, next: Next<'_, State>) -> crate::Result {
+        let cookie = req.cookie(&self.cookie_name);
         let cookie_value = cookie
             .clone()
             .and_then(|cookie| self.verify_signature(cookie.value()).ok());
@@ -89,10 +89,10 @@ where
             session.expire_in(ttl);
         }
 
-        let secure_cookie = request.url().scheme() == "https";
-        request.set_ext(session.clone());
+        let secure_cookie = req.url().scheme() == "https";
+        req.set_ext(session.clone());
 
-        let mut response = next.run(request).await;
+        let mut response = next.run(req, state).await;
 
         if session.is_destroyed() {
             if let Err(e) = self.store.destroy_session(session).await {

--- a/src/sse/mod.rs
+++ b/src/sse/mod.rs
@@ -17,7 +17,7 @@
 //! use tide::sse;
 //!
 //! let mut app = tide::new();
-//! app.at("/sse").get(sse::endpoint(|_req, sender| async move {
+//! app.at("/sse").get(sse::endpoint(|_req, _state, sender| async move {
 //!     sender.send("fruit", "banana", None).await?;
 //!     sender.send("fruit", "apple", None).await?;
 //!     Ok(())

--- a/tests/chunked-encode-large.rs
+++ b/tests/chunked-encode-large.rs
@@ -71,7 +71,7 @@ async fn chunked_large() -> Result<(), http_types::Error> {
     let server = task::spawn(async move {
         let mut app = tide::new();
         app.at("/")
-            .get(|_| async { Ok(Body::from_reader(Cursor::new(TEXT), None)) });
+            .get(|_, _| async { Ok(Body::from_reader(Cursor::new(TEXT), None)) });
         app.listen(("localhost", port)).await?;
         Result::<(), http_types::Error>::Ok(())
     });

--- a/tests/chunked-encode-small.rs
+++ b/tests/chunked-encode-small.rs
@@ -20,7 +20,7 @@ async fn chunked_large() -> Result<(), http_types::Error> {
     let server = task::spawn(async move {
         let mut app = tide::new();
         app.at("/")
-            .get(|_| async { Ok(Body::from_reader(Cursor::new(TEXT), None)) });
+            .get(|_, _| async { Ok(Body::from_reader(Cursor::new(TEXT), None)) });
         app.listen(("localhost", port)).await?;
         Result::<(), http_types::Error>::Ok(())
     });

--- a/tests/cookies.rs
+++ b/tests/cookies.rs
@@ -6,7 +6,7 @@ use tide::{Request, Response, Server, StatusCode};
 
 static COOKIE_NAME: &str = "testCookie";
 
-async fn retrieve_cookie(req: Request<()>) -> tide::Result<String> {
+async fn retrieve_cookie(req: Request, _state: ()) -> tide::Result<String> {
     Ok(format!(
         "{} and also {}",
         req.cookie(COOKIE_NAME).unwrap().value(),
@@ -14,19 +14,19 @@ async fn retrieve_cookie(req: Request<()>) -> tide::Result<String> {
     ))
 }
 
-async fn insert_cookie(_req: Request<()>) -> tide::Result {
+async fn insert_cookie(_req: Request, _state: ()) -> tide::Result {
     let mut res = Response::new(StatusCode::Ok);
     res.insert_cookie(Cookie::new(COOKIE_NAME, "NewCookieValue"));
     Ok(res)
 }
 
-async fn remove_cookie(_req: Request<()>) -> tide::Result {
+async fn remove_cookie(_req: Request, _state: ()) -> tide::Result {
     let mut res = Response::new(StatusCode::Ok);
     res.remove_cookie(Cookie::named(COOKIE_NAME));
     Ok(res)
 }
 
-async fn set_multiple_cookie(_req: Request<()>) -> tide::Result {
+async fn set_multiple_cookie(_req: Request, _state: ()) -> tide::Result {
     let mut res = Response::new(StatusCode::Ok);
     res.insert_cookie(Cookie::new("C1", "V1"));
     res.insert_cookie(Cookie::new("C2", "V2"));

--- a/tests/endpoint.rs
+++ b/tests/endpoint.rs
@@ -4,7 +4,7 @@ use tide::Response;
 #[async_std::test]
 async fn should_accept_boxed_endpoints() {
     fn endpoint() -> Box<dyn tide::Endpoint<()>> {
-        Box::new(|_| async { Ok("hello world") })
+        Box::new(|_, _| async { Ok("hello world") })
     }
 
     let mut app = tide::Server::new();

--- a/tests/function_middleware.rs
+++ b/tests/function_middleware.rs
@@ -5,24 +5,25 @@ use tide::http::{self, url::Url, Method};
 mod test_utils;
 
 fn auth_middleware<'a>(
-    request: tide::Request<()>,
+    req: tide::Request,
+    state: (),
     next: tide::Next<'a, ()>,
 ) -> Pin<Box<dyn Future<Output = tide::Result> + 'a + Send>> {
-    let authenticated = match request.header("X-Auth") {
+    let authenticated = match req.header("X-Auth") {
         Some(header) => header == "secret_key",
         None => false,
     };
 
     Box::pin(async move {
         if authenticated {
-            Ok(next.run(request).await)
+            Ok(next.run(req, state).await)
         } else {
             Ok(tide::Response::new(tide::StatusCode::Unauthorized))
         }
     })
 }
 
-async fn echo_path<State>(req: tide::Request<State>) -> tide::Result<String> {
+async fn echo_path<State>(req: tide::Request, _state: State) -> tide::Result<String> {
     Ok(req.url().path().to_string())
 }
 

--- a/tests/log.rs
+++ b/tests/log.rs
@@ -34,7 +34,7 @@ async fn test_only_log_once(logger: &mut logtest::Logger) -> tide::Result<()> {
     let mut app = tide::new();
     app.at("/").nest({
         let mut app = tide::new();
-        app.at("/").get(|_| async { Ok("nested") });
+        app.at("/").get(|_, _| async { Ok("nested") });
         app
     });
     assert!(app.get("/").await?.status().is_success());

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -4,8 +4,8 @@ use test_utils::ServerTestingExt;
 #[async_std::test]
 async fn nested() -> tide::Result<()> {
     let mut inner = tide::new();
-    inner.at("/foo").get(|_| async { Ok("foo") });
-    inner.at("/bar").get(|_| async { Ok("bar") });
+    inner.at("/foo").get(|_, _| async { Ok("foo") });
+    inner.at("/bar").get(|_, _| async { Ok("bar") });
 
     let mut outer = tide::new();
     // Nest the inner app on /foo
@@ -18,7 +18,7 @@ async fn nested() -> tide::Result<()> {
 
 #[async_std::test]
 async fn nested_middleware() -> tide::Result<()> {
-    let echo_path = |req: tide::Request<()>| async move { Ok(req.url().path().to_string()) };
+    let echo_path = |req: tide::Request, _| async move { Ok(req.url().path().to_string()) };
     let mut app = tide::new();
     let mut inner_app = tide::new();
     inner_app.with(tide::utils::After(|mut res: tide::Response| async move {
@@ -52,10 +52,10 @@ async fn nested_with_different_state() -> tide::Result<()> {
     let mut outer = tide::new();
     let mut inner = tide::with_state(42);
     inner.at("/").get(|req: tide::Request<i32>| async move {
-        let num = req.state();
+        let num = state;
         Ok(format!("the number is {}", num))
     });
-    outer.at("/").get(|_| async { Ok("Hello, world!") });
+    outer.at("/").get(|_, _| async { Ok("Hello, world!") });
     outer.at("/foo").nest(inner);
 
     assert_eq!(outer.get("/foo").recv_string().await?, "the number is 42");

--- a/tests/params.rs
+++ b/tests/params.rs
@@ -3,7 +3,7 @@ use tide::{self, Request, Response, Result};
 
 #[async_std::test]
 async fn test_missing_param() -> tide::Result<()> {
-    async fn greet(req: Request<()>) -> Result<Response> {
+    async fn greet(req: Request, _state: ()) -> Result<Response> {
         assert_eq!(req.param("name")?, "Param \"name\" not found");
         Ok(Response::new(200))
     }
@@ -19,7 +19,7 @@ async fn test_missing_param() -> tide::Result<()> {
 
 #[async_std::test]
 async fn hello_world_parametrized() -> Result<()> {
-    async fn greet(req: tide::Request<()>) -> Result<impl Into<Response>> {
+    async fn greet(req: tide::Request, _state: ()) -> Result<impl Into<Response>> {
         let body = format!("{} says hello", req.param("name").unwrap_or("nori"));
         Ok(Response::builder(200).body(body))
     }

--- a/tests/response.rs
+++ b/tests/response.rs
@@ -41,7 +41,7 @@ async fn json_content_type() -> tide::Result<()> {
     use tide::Body;
 
     let mut app = tide::new();
-    app.at("/json_content_type").get(|_| async {
+    app.at("/json_content_type").get(|_, _| async {
         let mut map = BTreeMap::new();
         map.insert(Some("a"), 2);
         map.insert(Some("b"), 4);

--- a/tests/route_middleware.rs
+++ b/tests/route_middleware.rs
@@ -17,16 +17,17 @@ impl TestMiddleware {
 impl<State: Clone + Send + Sync + 'static> Middleware<State> for TestMiddleware {
     async fn handle(
         &self,
-        req: tide::Request<State>,
+        req: tide::Request,
+        state: State,
         next: tide::Next<'_, State>,
     ) -> tide::Result<tide::Response> {
-        let mut res = next.run(req).await;
+        let mut res = next.run(req, state).await;
         res.insert_header(self.0.clone(), self.1);
         Ok(res)
     }
 }
 
-async fn echo_path<State>(req: tide::Request<State>) -> tide::Result<String> {
+async fn echo_path<State>(req: tide::Request, _state: State) -> tide::Result<String> {
     Ok(req.url().path().to_string())
 }
 

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -12,7 +12,7 @@ fn hello_world() -> tide::Result<()> {
         let port = test_utils::find_port().await;
         let server = task::spawn(async move {
             let mut app = tide::new();
-            app.at("/").get(move |mut req: Request<()>| async move {
+            app.at("/").get(move |mut req: Request, _state| async move {
                 assert_eq!(req.body_string().await.unwrap(), "nori".to_string());
                 assert!(req.local_addr().unwrap().contains(&port.to_string()));
                 assert!(req.peer_addr().is_some());
@@ -43,7 +43,7 @@ fn echo_server() -> tide::Result<()> {
         let port = test_utils::find_port().await;
         let server = task::spawn(async move {
             let mut app = tide::new();
-            app.at("/").get(|req| async move { Ok(req) });
+            app.at("/").get(|req, _| async move { Ok(req) });
 
             app.listen(("localhost", port)).await?;
             Result::<(), http_types::Error>::Ok(())
@@ -75,7 +75,7 @@ fn json() -> tide::Result<()> {
         let port = test_utils::find_port().await;
         let server = task::spawn(async move {
             let mut app = tide::new();
-            app.at("/").get(|mut req: Request<()>| async move {
+            app.at("/").get(|mut req: Request, _state| async move {
                 let mut counter: Counter = req.body_json().await.unwrap();
                 assert_eq!(counter.count, 0);
                 counter.count = 1;

--- a/tests/unix.rs
+++ b/tests/unix.rs
@@ -16,7 +16,7 @@ mod unix_tests {
 
             let server = task::spawn(async move {
                 let mut app = tide::new();
-                app.at("/").get(|req: tide::Request<()>| async move {
+                app.at("/").get(|req: tide::Request, _| async move {
                     Ok(req.local_addr().unwrap().to_string())
                 });
                 app.listen(sock_path).await?;

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -2,7 +2,7 @@ mod test_utils;
 use test_utils::ServerTestingExt;
 use tide::{Error, Request, StatusCode};
 
-async fn add_one(req: Request<()>) -> Result<String, tide::Error> {
+async fn add_one(req: Request, _state: ()) -> Result<String, tide::Error> {
     let num: i64 = req
         .param("num")?
         .parse()
@@ -10,7 +10,7 @@ async fn add_one(req: Request<()>) -> Result<String, tide::Error> {
     Ok((num + 1).to_string())
 }
 
-async fn add_two(req: Request<()>) -> Result<String, tide::Error> {
+async fn add_two(req: Request, _state: ()) -> Result<String, tide::Error> {
     let one: i64 = req
         .param("one")?
         .parse()
@@ -22,7 +22,7 @@ async fn add_two(req: Request<()>) -> Result<String, tide::Error> {
     Ok((one + two).to_string())
 }
 
-async fn echo_path(req: Request<()>) -> Result<String, tide::Error> {
+async fn echo_path(req: Request, _state: ()) -> Result<String, tide::Error> {
     match req.param("path") {
         Ok(path) => Ok(path.into()),
         Err(mut err) => {
@@ -109,7 +109,7 @@ async fn invalid_wildcard() -> tide::Result<()> {
 #[async_std::test]
 async fn nameless_wildcard() -> tide::Result<()> {
     let mut app = tide::Server::new();
-    app.at("/echo/:").get(|_| async { Ok("") });
+    app.at("/echo/:").get(|_, _| async { Ok("") });
     assert_eq!(
         app.get("/echo/one/two").await?.status(),
         StatusCode::NotFound
@@ -130,7 +130,7 @@ async fn nameless_internal_wildcard() -> tide::Result<()> {
 #[async_std::test]
 async fn nameless_internal_wildcard2() -> tide::Result<()> {
     let mut app = tide::new();
-    app.at("/echo/:/:path").get(|req: Request<()>| async move {
+    app.at("/echo/:/:path").get(|req: Request, _| async move {
         assert_eq!(req.param("path")?, "two");
         Ok("")
     });
@@ -142,8 +142,8 @@ async fn nameless_internal_wildcard2() -> tide::Result<()> {
 #[async_std::test]
 async fn ambiguous_router_wildcard_vs_star() -> tide::Result<()> {
     let mut app = tide::new();
-    app.at("/:one/:two").get(|_| async { Ok("one/two") });
-    app.at("/posts/*").get(|_| async { Ok("posts/*") });
+    app.at("/:one/:two").get(|_, _| async { Ok("one/two") });
+    app.at("/posts/*").get(|_, _| async { Ok("posts/*") });
     assert_eq!(app.get("/posts/10").recv_string().await?, "posts/*");
     Ok(())
 }


### PR DESCRIPTION
This PR changes the relationship between request and state. Instead of embedding request and state into the same type, it makes them two separate arguments. So `req: Request<State>` becomes `req: Request, state: State`. The idea behind this is that for smaller applications that are only parameterized by a single type calling that type "state" feel somewhat indirect.

Take for example this MongoDB example:

```rust
async fn index(req: Request<Database>) -> tide::Result {
    let coll = req.state().collection("fun_numbers");
    let res = coll.insert_one(doc! { "x": 1 }, None).await?;
    let body = format!("the inserted id was: {:?}", res);
    Ok(Response::builder(200).body(body).into())
}
```

`req.state()` feels like an odd indirection to get to the parameterized type. Instead if the type was a direct input to the function it'd be easier to name and use:


```rust
async fn index(req: Request, db: Database) -> tide::Result {
    let coll = db.collection("fun_numbers");
    let res = coll.insert_one(doc! { "x": 1 }, None).await?;
    let body = format!("the inserted id was: {:?}", res);
    Ok(Response::builder(200).body(body).into())
}
```
This also makes it easier to convert from `http_types::Request` to `tide::Request` since the `State` param does not need to be populated. I don't think this functionally changes much about Tide; except that in some cases it'll just feel that little bit smoother.