### PR TITLE
Add built-in validation for input types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ pin-project-lite = "0.1.7"
 route-recognizer = "0.2.0"
 serde = "1.0.102"
 serde_json = "1.0.41"
+validator = { version = "0.11", features = ["derive"] }
 
 [dev-dependencies]
 async-std = { version = "1.6.0", features = ["unstable", "attributes"] }

--- a/examples/graphql.rs
+++ b/examples/graphql.rs
@@ -75,7 +75,8 @@ lazy_static! {
 }
 
 async fn handle_graphql(mut request: Request<State>) -> tide::Result {
-    let query: GraphQLRequest = request.body_json().await?;
+    let body = request.take_body();
+    let query: GraphQLRequest = body.into_json().await?;
     let response = query.execute(&SCHEMA, request.state());
     let status = if response.is_ok() {
         StatusCode::Ok

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use tide::prelude::*; // Pulls in the json! macro.
 use tide::{Body, Request};
 
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Validate)]
 struct Cat {
     name: String,
 }

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,4 +1,77 @@
 //! Traits for conversions between types.
+//!
+//! # Examples
+//!
+//! ```no_run
+//! use tide::Request;
+//! use tide::prelude::*;
+//!
+//! #[derive(Debug, Deserialize, Validate)]
+//! struct Animal {
+//!     #[validate(length(min = 4))]
+//!     name: String,
+//!     #[validate(range(max = 12))]
+//!     legs: u8,
+//! }
+//!
+//! #[async_std::main]
+//! async fn main() -> tide::Result<()> {
+//!     let mut app = tide::new();
+//!     app.at("/orders/shoes").post(order_shoes);
+//!     app.listen("127.0.0.1:8080").await?;
+//!     Ok(())
+//! }
+//!
+//! async fn order_shoes(mut req: Request<()>) -> tide::Result {
+//!     let animal: Animal = req.body_json().await?;
+//!     animal.validate().status(400)?;
+//!     let msg = format!("Hello, {}! I've put in an order for {} shoes", animal.name, animal.legs);
+//!     Ok(msg.into())
+//! }
+//! ```
 
 #[doc(inline)]
 pub use http_types::convert::*;
+
+/// Validate a type.
+pub use validator::Validate;
+
+/// A list of validation errors.
+pub use validator::ValidationErrors;
+
+/// A single validation error.
+pub use validator::ValidationError;
+
+/// The kind of errors returned by validating.
+pub use validator::ValidationErrorsKind;
+
+#[cfg(test)]
+mod test {
+    pub use super::*;
+
+    #[derive(Debug, Deserialize, Validate)]
+    struct PersonInput {
+        #[validate(length(min = 4))]
+        name: String,
+        #[validate(email)]
+        email: String,
+    }
+
+    #[test]
+    fn validate() -> crate::Result<()> {
+        let cat = PersonInput {
+            name: "chashu".into(),
+            email: "cute@cat.cafe".into(),
+        };
+        cat.validate()?;
+        Ok(())
+    }
+
+    #[test]
+    fn parse_validate() -> crate::Result<()> {
+        let input = r#"{ "name": "chashu", "email": "cute@cat.cafe" }"#;
+        let cat: PersonInput = serde_json::from_str(input)?;
+        cat.validate()?;
+        Ok(())
+    }
+}

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -23,10 +23,8 @@
 //! }
 //!
 //! async fn order_shoes(mut req: Request<()>) -> tide::Result {
-//!     let animal: Animal = req.body_json().await?;
-//!     animal.validate().status(400)?;
-//!     let msg = format!("Hello, {}! I've put in an order for {} shoes", animal.name, animal.legs);
-//!     Ok(msg.into())
+//!     let Animal { name, legs } = req.body_json().await?;
+//!     Ok(format!("Hello, {}! I've put in an order for {} shoes", name, legs).into())
 //! }
 //! ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //! use tide::Request;
 //! use tide::prelude::*;
 //!
-//! #[derive(Debug, Deserialize)]
+//! #[derive(Debug, Deserialize, Validate)]
 //! struct Animal {
 //!     name: String,
 //!     legs: u8,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,12 +69,12 @@ mod request;
 mod response;
 mod response_builder;
 mod route;
+mod server;
 
 #[cfg(not(feature = "__internal__bench"))]
 mod router;
 #[cfg(feature = "__internal__bench")]
 pub mod router;
-mod server;
 
 pub mod convert;
 pub mod listener;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,3 +1,3 @@
 //! The Tide prelude.
-pub use crate::convert::{json, Deserialize, Serialize};
+pub use crate::convert::{json, Deserialize, Serialize, Validate};
 pub use http_types::Status;

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -3,7 +3,7 @@ use async_std::prelude::*;
 use async_std::task;
 use std::time::Duration;
 
-use serde::{Deserialize, Serialize};
+use tide::prelude::*;
 use tide::{Body, Request};
 
 #[test]
@@ -66,7 +66,7 @@ fn echo_server() -> tide::Result<()> {
 
 #[test]
 fn json() -> tide::Result<()> {
-    #[derive(Deserialize, Serialize)]
+    #[derive(Deserialize, Serialize, Validate)]
     struct Counter {
         count: usize,
     }


### PR DESCRIPTION
This adds the `Validate` trait as part of the `convert` and `prelude` submodules. This enables manually calling `.validate` on types, and integrates it directly into `Request::body_json` and `Request::body_form`. This makes it easy to define validation bounds beyond just types on structs.

Overall this should make it easier to define input types for REST APIs in Tide, reducing boilerplate needed. In particular the automatic validation in `Request::body_json` I think will come in useful; converting data into a struct will always check all rules it can, and prevents easy mistakes such as forgetting to call `.validate`.

This is powered by the `validator` crate. While we may want to replace it eventually; it does a really good job at providing the basics, and certainly a good starting point to better understand what else we may want from validation in Tide.

I hope this makes sense. Thanks!

## Examples

```rust
use tide::Request;
use tide::prelude::*;

#[derive(Debug, Deserialize, Validate)]
struct Animal {
    #[validate(length(min = 4))]
    name: String,
    #[validate(range(max = 12))]
    legs: u8,
}

#[async_std::main]
async fn main() -> tide::Result<()> {
    let mut app = tide::new();
    app.at("/orders/shoes").post(order_shoes);
    app.listen("127.0.0.1:8080").await?;
    Ok(())
}

async fn order_shoes(mut req: Request<()>) -> tide::Result {
    let Animal { name, legs } = req.body_json().await?;
    Ok(format!("Hello, {}! I've put in an order for {} shoes", name, legs).into())
}
```