### PR TITLE
Add `serve_file` method to route

### DIFF
--- a/examples/static_file.html
+++ b/examples/static_file.html
@@ -1,0 +1,6 @@
+<html>
+  <head><title>Example</title></head>
+  <body>
+    <h1>Example</h1>
+  </body>
+</html>

--- a/examples/static_file.rs
+++ b/examples/static_file.rs
@@ -4,6 +4,7 @@ async fn main() -> Result<(), std::io::Error> {
     let mut app = tide::new();
     app.at("/").get(|_| async { Ok("visit /src/*") });
     app.at("/src").serve_dir("src/")?;
+    app.at("/example").serve_file("examples/static_file.html")?;
     app.listen("127.0.0.1:8080").await?;
     Ok(())
 }

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -1,3 +1,5 @@
 mod serve_dir;
+mod serve_file;
 
 pub(crate) use serve_dir::ServeDir;
+pub(crate) use serve_file::ServeFile;

--- a/src/fs/serve_dir.rs
+++ b/src/fs/serve_dir.rs
@@ -3,8 +3,8 @@ use crate::{Body, Endpoint, Request, Response, Result, StatusCode};
 
 use async_std::path::PathBuf as AsyncPathBuf;
 
-use std::{ffi::OsStr, io};
 use std::path::{Path, PathBuf};
+use std::{ffi::OsStr, io};
 
 pub(crate) struct ServeDir {
     prefix: String,
@@ -51,7 +51,7 @@ where
                     log::warn!("File not found: {:?}", &file_path);
                     Ok(Response::new(StatusCode::NotFound))
                 }
-                Err(e) => Err(e)?,
+                Err(e) => Err(e.into()),
             }
         }
     }

--- a/src/fs/serve_file.rs
+++ b/src/fs/serve_file.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use async_std::path::PathBuf as AsyncPathBuf;
 use async_trait::async_trait;
 
-pub struct ServeFile {
+pub(crate) struct ServeFile {
     path: AsyncPathBuf,
 }
 
@@ -29,7 +29,7 @@ impl<State: Clone + Send + Sync + 'static> Endpoint<State> for ServeFile {
                 log::warn!("File not found: {:?}", &self.path);
                 Ok(Response::new(StatusCode::NotFound))
             }
-            Err(e) => Err(e)?,
+            Err(e) => Err(e.into()),
         }
     }
 }

--- a/src/fs/serve_file.rs
+++ b/src/fs/serve_file.rs
@@ -1,0 +1,84 @@
+use crate::log;
+use crate::{Body, Endpoint, Request, Response, Result, StatusCode};
+use std::io;
+use std::path::Path;
+
+use async_std::path::PathBuf as AsyncPathBuf;
+use async_trait::async_trait;
+
+pub struct ServeFile {
+    file: AsyncPathBuf,
+}
+
+impl ServeFile {
+    /// Create a new instance of `ServeFile`.
+    pub(crate) fn init(file: impl AsRef<Path>) -> io::Result<Self> {
+        let file = file.as_ref().to_owned().canonicalize()?;
+        Ok(Self {
+            file: AsyncPathBuf::from(file),
+        })
+    }
+}
+
+#[async_trait]
+impl<State: Clone + Send + Sync + 'static> Endpoint<State> for ServeFile {
+    async fn call(&self, _: Request<State>) -> Result {
+        if !self.file.exists().await {
+            log::warn!("File not found: {:?}", &self.file);
+            println!("File not found: {:?}", &self.file);
+            Ok(Response::new(StatusCode::NotFound))
+        } else {
+            Ok(Response::builder(StatusCode::Ok)
+                .body(Body::from_file(&self.file).await?)
+                .build())
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use crate::http::{Response, Url};
+    use std::fs::{self, File};
+    use std::io::Write;
+
+    fn serve_file(tempdir: &tempfile::TempDir) -> crate::Result<ServeFile> {
+        let static_dir = tempdir.path().join("static");
+        fs::create_dir(&static_dir)?;
+
+        let file_path = static_dir.join("foo");
+        let mut file = File::create(&file_path)?;
+        write!(file, "Foobar")?;
+
+        Ok(ServeFile::init(file_path)?)
+    }
+
+    fn request(path: &str) -> crate::Request<()> {
+        let request =
+            crate::http::Request::get(Url::parse(&format!("http://localhost/{}", path)).unwrap());
+        crate::Request::new((), request, vec![])
+    }
+
+    #[async_std::test]
+    async fn should_serve_file() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let serve_file = serve_file(&tempdir).unwrap();
+
+        let mut res: Response = serve_file.call(request("static/foo")).await.unwrap().into();
+
+        assert_eq!(res.status(), 200);
+        assert_eq!(res.body_string().await.unwrap(), "Foobar");
+    }
+
+    #[async_std::test]
+    async fn should_serve_404_when_file_missing() {
+        let serve_file = ServeFile {
+            file: AsyncPathBuf::from("gone/file"),
+        };
+
+        let res: Response = serve_file.call(request("static/foo")).await.unwrap().into();
+
+        assert_eq!(res.status(), 404);
+    }
+}

--- a/src/route.rs
+++ b/src/route.rs
@@ -140,6 +140,10 @@ impl<'a, State: Clone + Send + Sync + 'static> Route<'a, State> {
         Ok(())
     }
 
+    /// Serve a static file.
+    ///
+    /// The file will be streamed from disk, and a mime type will be determined
+    /// based on magic bytes. Similar to serve_dir
     pub fn serve_file(&mut self, file: impl AsRef<Path>) -> io::Result<()> {
         self.get(ServeFile::init(file)?);
         Ok(())

--- a/src/route.rs
+++ b/src/route.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::endpoint::MiddlewareEndpoint;
-use crate::fs::ServeDir;
+use crate::fs::{ServeDir, ServeFile};
 use crate::log;
 use crate::{router::Router, Endpoint, Middleware};
 
@@ -137,6 +137,11 @@ impl<'a, State: Clone + Send + Sync + 'static> Route<'a, State> {
         let dir = dir.as_ref().to_owned().canonicalize()?;
         let prefix = self.path().to_string();
         self.at("*").get(ServeDir::new(prefix, dir));
+        Ok(())
+    }
+
+    pub fn serve_file(&mut self, file: impl AsRef<Path>) -> io::Result<()> {
+        self.get(ServeFile::init(file)?);
         Ok(())
     }
 


### PR DESCRIPTION
This pr adds a serve_file method alongside the already existing `serve_dir` method.
