### PR TITLE
Add with_cookie_domain method to SessionMiddleware

### DIFF
--- a/tests/sessions.rs
+++ b/tests/sessions.rs
@@ -37,6 +37,7 @@ async fn test_basic_sessions() -> tide::Result<()> {
     let cookies = Cookies::from_response(&response);
     let cookie = &cookies["tide.sid"];
     assert_eq!(cookie.name(), "tide.sid");
+    assert_eq!(cookie.domain(), None);
     assert_eq!(cookie.http_only(), Some(true));
     assert_eq!(cookie.same_site(), Some(SameSite::Strict));
     assert_eq!(cookie.secure(), None); // this request was http://
@@ -62,6 +63,7 @@ async fn test_customized_sessions() -> tide::Result<()> {
         SessionMiddleware::new(MemoryStore::new(), b"12345678901234567890123456789012345")
             .with_cookie_name("custom.cookie.name")
             .with_cookie_path("/nested")
+            .with_cookie_domain("www.rust-lang.org")
             .with_same_site_policy(SameSite::Lax)
             .with_session_ttl(Some(Duration::from_secs(1)))
             .without_save_unchanged(),
@@ -99,6 +101,7 @@ async fn test_customized_sessions() -> tide::Result<()> {
     assert_eq!(cookie.http_only(), Some(true));
     assert_eq!(cookie.same_site(), Some(SameSite::Lax));
     assert_eq!(cookie.path(), Some("/nested"));
+    assert_eq!(cookie.domain(), Some("www.rust-lang.org"));
     let cookie_value = cookie.value().to_string();
 
     let mut second_response = app


### PR DESCRIPTION
We are using tide as a session/authentication context and we need to set the domain of the cookie as the root domain on the SessionMiddleware.

This PR adds the hability to set de cookie domain through the SessionMiddleware builder.