### PR TITLE
In `serve_dir`, only strip the prefix from the start of the path once.

### DIFF
--- a/src/fs/serve_dir.rs
+++ b/src/fs/serve_dir.rs
@@ -25,7 +25,7 @@ where
 {
     async fn call(&self, req: Request<State>) -> Result {
         let path = req.url().path();
-        let path = path.trim_start_matches(&self.prefix);
+        let path = path.strip_prefix(&self.prefix).unwrap();
         let path = path.trim_start_matches('/');
         let mut file_path = self.dir.clone();
         for p in Path::new(path) {


### PR DESCRIPTION
Currently, `serve_dir` is using `str::trim_start_matches`, which may strip the prefix multiple times.

I've changed this to use `strip_prefix`, which will only strip it once.

I think this unwrap is okay, because the prefix is guaranteed to be there. Do tell me if I'm wrong.