### PR TITLE
Logger improvements

### DIFF
--- a/src/log/middleware.rs
+++ b/src/log/middleware.rs
@@ -49,8 +49,13 @@ impl LogMiddleware {
         let status = response.status();
         if status.is_server_error() {
             if let Some(error) = response.error() {
+                #[cfg(debug_assertions)]
+                let message = format!("{:?}", error);
+                #[cfg(not(debug_assertions))]
+                let message = format!("{}", error);
+
                 log::error!("Internal error --> Response sent", {
-                    message: format!("{:?}", error),
+                    message: message,
                     error_type: error.type_name(),
                     method: method,
                     path: path,
@@ -67,8 +72,13 @@ impl LogMiddleware {
             }
         } else if status.is_client_error() {
             if let Some(error) = response.error() {
+                #[cfg(debug_assertions)]
+                let message = format!("{:?}", error);
+                #[cfg(not(debug_assertions))]
+                let message = format!("{}", error);
+
                 log::warn!("Client error --> Response sent", {
-                    message: format!("{:?}", error),
+                    message: message,
                     error_type: error.type_name(),
                     method: method,
                     path: path,

--- a/src/log/middleware.rs
+++ b/src/log/middleware.rs
@@ -1,5 +1,4 @@
-use crate::log;
-use crate::{Middleware, Next, Request};
+use crate::{log, Middleware, Next, Request};
 
 /// Log all incoming requests and responses.
 ///
@@ -45,8 +44,13 @@ impl LogMiddleware {
             path: path,
         });
         let start = std::time::Instant::now();
+
         let response = next.run(req).await;
+
         let status = response.status();
+        let status_str = format!("{} - {}", status as u16, status.canonical_reason());
+        let duration = format!("{:?}", start.elapsed());
+
         if status.is_server_error() {
             if let Some(error) = response.error() {
                 #[cfg(debug_assertions)]
@@ -59,15 +63,15 @@ impl LogMiddleware {
                     error_type: error.type_name(),
                     method: method,
                     path: path,
-                    status: format!("{} - {}", status as u16, status.canonical_reason()),
-                    duration: format!("{:?}", start.elapsed()),
+                    status: status_str,
+                    duration: duration,
                 });
             } else {
                 log::error!("Internal error --> Response sent", {
                     method: method,
                     path: path,
-                    status: format!("{} - {}", status as u16, status.canonical_reason()),
-                    duration: format!("{:?}", start.elapsed()),
+                    status: status_str,
+                    duration: duration,
                 });
             }
         } else if status.is_client_error() {
@@ -82,23 +86,23 @@ impl LogMiddleware {
                     error_type: error.type_name(),
                     method: method,
                     path: path,
-                    status: format!("{} - {}", status as u16, status.canonical_reason()),
-                    duration: format!("{:?}", start.elapsed()),
+                    status: status_str,
+                    duration: duration,
                 });
             } else {
                 log::warn!("Client error --> Response sent", {
                     method: method,
                     path: path,
-                    status: format!("{} - {}", status as u16, status.canonical_reason()),
-                    duration: format!("{:?}", start.elapsed()),
+                    status: status_str,
+                    duration: duration,
                 });
             }
         } else {
             log::info!("--> Response sent", {
                 method: method,
                 path: path,
-                status: format!("{} - {}", status as u16, status.canonical_reason()),
-                duration: format!("{:?}", start.elapsed()),
+                status: status_str,
+                duration: duration,
             });
         }
         Ok(response)


### PR DESCRIPTION
Some minor follow-up for my previous change to the logger which made it use the debug formatter. Very helpful for debugging  but probably annoying in "production-like" logs.

This also does some code deduplication.

I'd like to clean this up more but that probably means investing time in either changing the log format entirely or separating out the key-value formatter from log so that we can call it separately before passing to a log level.