### PR TITLE
Add `Server::bind`

### DIFF
--- a/src/listener/concurrent_listener.rs
+++ b/src/listener/concurrent_listener.rs
@@ -1,4 +1,4 @@
-use crate::listener::{Listener, ToListener};
+use crate::listener::{ListenInfo, Listener, ToListener};
 use crate::Server;
 
 use std::fmt::{self, Debug, Display, Formatter};
@@ -108,6 +108,14 @@ where
             result?;
         }
         Ok(())
+    }
+
+    fn info(&self) -> Vec<ListenInfo> {
+        self.listeners
+            .iter()
+            .map(|listener| listener.info().into_iter())
+            .flatten()
+            .collect()
     }
 }
 

--- a/src/listener/failover_listener.rs
+++ b/src/listener/failover_listener.rs
@@ -5,6 +5,8 @@ use std::fmt::{self, Debug, Display, Formatter};
 
 use async_std::io;
 
+use crate::listener::ListenInfo;
+
 /// FailoverListener allows tide to attempt to listen in a sequential
 /// order to any number of ports/addresses. The first successful
 /// listener is used.
@@ -132,6 +134,16 @@ where
                 io::ErrorKind::AddrNotAvailable,
                 "unable to listen to any supplied listener spec",
             )),
+        }
+    }
+
+    fn info(&self) -> Vec<ListenInfo> {
+        match self.index {
+            Some(index) => match self.listeners.get(index) {
+                Some(Some(listener)) => listener.info(),
+                _ => vec![],
+            },
+            None => vec![],
         }
     }
 }

--- a/src/listener/parsed_listener.rs
+++ b/src/listener/parsed_listener.rs
@@ -19,7 +19,7 @@ pub enum ParsedListener<State> {
     Tcp(TcpListener<State>),
 }
 
-impl<State> fmt::Debug for ParsedListener<State> {
+impl<State> Debug for ParsedListener<State> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             #[cfg(unix)]

--- a/src/listener/parsed_listener.rs
+++ b/src/listener/parsed_listener.rs
@@ -31,12 +31,22 @@ impl Display for ParsedListener {
 }
 
 #[async_trait::async_trait]
-impl<State: Clone + Send + Sync + 'static> Listener<State> for ParsedListener {
-    async fn listen(&mut self, app: Server<State>) -> io::Result<()> {
+impl<State> Listener<State> for ParsedListener
+where
+    State: Clone + Send + Sync + 'static,
+{
+    async fn bind(&mut self) -> io::Result<()> {
         match self {
             #[cfg(unix)]
-            Self::Unix(u) => u.listen(app).await,
-            Self::Tcp(t) => t.listen(app).await,
+            Self::Unix(u) => u.bind().await,
+            Self::Tcp(t) => t.bind().await,
+        }
+    }
+    async fn accept(&mut self, app: Server<State>) -> io::Result<()> {
+        match self {
+            #[cfg(unix)]
+            Self::Unix(u) => u.accept(app).await,
+            Self::Tcp(t) => t.accept(app).await,
         }
     }
 }

--- a/src/listener/parsed_listener.rs
+++ b/src/listener/parsed_listener.rs
@@ -4,7 +4,7 @@ use super::{Listener, TcpListener};
 use crate::Server;
 
 use async_std::io;
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Debug, Display, Formatter};
 
 /// This is an enum that contains variants for each of the listeners
 /// that can be parsed from a string. This is used as the associated
@@ -13,14 +13,23 @@ use std::fmt::{self, Display, Formatter};
 ///
 /// This is currently crate-visible only, and tide users are expected
 /// to create these through [ToListener](crate::ToListener) conversions.
-#[derive(Debug)]
-pub enum ParsedListener {
+pub enum ParsedListener<State> {
     #[cfg(unix)]
     Unix(UnixListener),
-    Tcp(TcpListener),
+    Tcp(TcpListener<State>),
 }
 
-impl Display for ParsedListener {
+impl<State> fmt::Debug for ParsedListener<State> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            #[cfg(unix)]
+            ParsedListener::Unix(unix) => Debug::fmt(tcp, f),
+            ParsedListener::Tcp(tcp) => Debug::fmt(tcp, f),
+        }
+    }
+}
+
+impl<State> Display for ParsedListener<State> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             #[cfg(unix)]
@@ -31,22 +40,23 @@ impl Display for ParsedListener {
 }
 
 #[async_trait::async_trait]
-impl<State> Listener<State> for ParsedListener
+impl<State> Listener<State> for ParsedListener<State>
 where
     State: Clone + Send + Sync + 'static,
 {
-    async fn bind(&mut self) -> io::Result<()> {
+    async fn bind(&mut self, server: Server<State>) -> io::Result<()> {
         match self {
             #[cfg(unix)]
-            Self::Unix(u) => u.bind().await,
-            Self::Tcp(t) => t.bind().await,
+            Self::Unix(u) => u.bind(server).await,
+            Self::Tcp(t) => t.bind(server).await,
         }
     }
-    async fn accept(&mut self, app: Server<State>) -> io::Result<()> {
+
+    async fn accept(&mut self) -> io::Result<()> {
         match self {
             #[cfg(unix)]
-            Self::Unix(u) => u.accept(app).await,
-            Self::Tcp(t) => t.accept(app).await,
+            Self::Unix(u) => u.accept().await,
+            Self::Tcp(t) => t.accept().await,
         }
     }
 }

--- a/src/listener/parsed_listener.rs
+++ b/src/listener/parsed_listener.rs
@@ -1,6 +1,6 @@
 #[cfg(unix)]
 use super::UnixListener;
-use super::{Listener, TcpListener};
+use super::{ListenInfo, Listener, TcpListener};
 use crate::Server;
 
 use async_std::io;
@@ -57,6 +57,14 @@ where
             #[cfg(unix)]
             Self::Unix(u) => u.accept().await,
             Self::Tcp(t) => t.accept().await,
+        }
+    }
+
+    fn info(&self) -> Vec<ListenInfo> {
+        match self {
+            #[cfg(unix)]
+            ParsedListener::Unix(unix) => unix.info(),
+            ParsedListener::Tcp(tcp) => tcp.info(),
         }
     }
 }

--- a/src/listener/parsed_listener.rs
+++ b/src/listener/parsed_listener.rs
@@ -15,7 +15,7 @@ use std::fmt::{self, Debug, Display, Formatter};
 /// to create these through [ToListener](crate::ToListener) conversions.
 pub enum ParsedListener<State> {
     #[cfg(unix)]
-    Unix(UnixListener),
+    Unix(UnixListener<State>),
     Tcp(TcpListener<State>),
 }
 
@@ -23,7 +23,7 @@ impl<State> Debug for ParsedListener<State> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             #[cfg(unix)]
-            ParsedListener::Unix(unix) => Debug::fmt(tcp, f),
+            ParsedListener::Unix(unix) => Debug::fmt(unix, f),
             ParsedListener::Tcp(tcp) => Debug::fmt(tcp, f),
         }
     }

--- a/src/listener/tcp_listener.rs
+++ b/src/listener/tcp_listener.rs
@@ -70,7 +70,7 @@ where
         assert!(self.server.is_none(), "`bind` should only be called once");
         self.server = Some(server);
 
-        if let None = self.listener {
+        if self.listener.is_none() {
             let addrs = self
                 .addrs
                 .take()

--- a/src/listener/to_listener_impls.rs
+++ b/src/listener/to_listener_impls.rs
@@ -5,7 +5,10 @@ use crate::http::url::Url;
 use async_std::io;
 use std::net::ToSocketAddrs;
 
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for Url {
+impl<State> ToListener<State> for Url
+where
+    State: Clone + Send + Sync + 'static,
+{
     type Listener = ParsedListener;
 
     fn to_listener(self) -> io::Result<Self::Listener> {
@@ -48,14 +51,20 @@ impl<State: Clone + Send + Sync + 'static> ToListener<State> for Url {
     }
 }
 
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for String {
+impl<State> ToListener<State> for String
+where
+    State: Clone + Send + Sync + 'static,
+{
     type Listener = ParsedListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
         ToListener::<State>::to_listener(self.as_str())
     }
 }
 
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for &str {
+impl<State> ToListener<State> for &str
+where
+    State: Clone + Send + Sync + 'static,
+{
     type Listener = ParsedListener;
 
     fn to_listener(self) -> io::Result<Self::Listener> {
@@ -75,7 +84,10 @@ impl<State: Clone + Send + Sync + 'static> ToListener<State> for &str {
 }
 
 #[cfg(unix)]
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for async_std::path::PathBuf {
+impl<State> ToListener<State> for async_std::path::PathBuf
+where
+    State: Clone + Send + Sync + 'static,
+{
     type Listener = UnixListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(UnixListener::from_path(self))
@@ -83,28 +95,40 @@ impl<State: Clone + Send + Sync + 'static> ToListener<State> for async_std::path
 }
 
 #[cfg(unix)]
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for std::path::PathBuf {
+impl<State> ToListener<State> for std::path::PathBuf
+where
+    State: Clone + Send + Sync + 'static,
+{
     type Listener = UnixListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(UnixListener::from_path(self))
     }
 }
 
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for async_std::net::TcpListener {
+impl<State> ToListener<State> for async_std::net::TcpListener
+where
+    State: Clone + Send + Sync + 'static,
+{
     type Listener = TcpListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(TcpListener::from_listener(self))
     }
 }
 
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for std::net::TcpListener {
+impl<State> ToListener<State> for std::net::TcpListener
+where
+    State: Clone + Send + Sync + 'static,
+{
     type Listener = TcpListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(TcpListener::from_listener(self))
     }
 }
 
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for (&str, u16) {
+impl<State> ToListener<State> for (&str, u16)
+where
+    State: Clone + Send + Sync + 'static,
+{
     type Listener = TcpListener;
 
     fn to_listener(self) -> io::Result<Self::Listener> {
@@ -113,8 +137,9 @@ impl<State: Clone + Send + Sync + 'static> ToListener<State> for (&str, u16) {
 }
 
 #[cfg(unix)]
-impl<State: Clone + Send + Sync + 'static> ToListener<State>
-    for async_std::os::unix::net::UnixListener
+impl<State> ToListener<State> for async_std::os::unix::net::UnixListener
+where
+    State: Clone + Send + Sync + 'static,
 {
     type Listener = UnixListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
@@ -123,14 +148,20 @@ impl<State: Clone + Send + Sync + 'static> ToListener<State>
 }
 
 #[cfg(unix)]
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for std::os::unix::net::UnixListener {
+impl<State> ToListener<State> for std::os::unix::net::UnixListener
+where
+    State: Clone + Send + Sync + 'static,
+{
     type Listener = UnixListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(UnixListener::from_listener(self))
     }
 }
 
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for TcpListener {
+impl<State> ToListener<State> for TcpListener
+where
+    State: Clone + Send + Sync + 'static,
+{
     type Listener = Self;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(self)
@@ -138,42 +169,61 @@ impl<State: Clone + Send + Sync + 'static> ToListener<State> for TcpListener {
 }
 
 #[cfg(unix)]
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for UnixListener {
+impl<State> ToListener<State> for UnixListener
+where
+    State: Clone + Send + Sync + 'static,
+{
     type Listener = Self;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(self)
     }
 }
 
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for ConcurrentListener<State> {
+impl<State> ToListener<State> for ConcurrentListener<State>
+where
+    State: Clone + Send + Sync + 'static,
+{
     type Listener = Self;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(self)
     }
 }
 
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for ParsedListener {
+impl<State> ToListener<State> for ParsedListener
+where
+    State: Clone + Send + Sync + 'static,
+{
     type Listener = Self;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(self)
     }
 }
 
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for FailoverListener<State> {
+impl<State> ToListener<State> for FailoverListener<State>
+where
+    State: Clone + Send + Sync + 'static,
+{
     type Listener = Self;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(self)
     }
 }
 
-impl<State: Clone + Send + Sync + 'static> ToListener<State> for std::net::SocketAddr {
+impl<State> ToListener<State> for std::net::SocketAddr
+where
+    State: Clone + Send + Sync + 'static,
+{
     type Listener = TcpListener;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(TcpListener::from_addrs(vec![self]))
     }
 }
 
-impl<TL: ToListener<State>, State: Clone + Send + Sync + 'static> ToListener<State> for Vec<TL> {
+impl<L, State> ToListener<State> for Vec<L>
+where
+    L: ToListener<State>,
+    State: Clone + Send + Sync + 'static,
+{
     type Listener = ConcurrentListener<State>;
     fn to_listener(self) -> io::Result<Self::Listener> {
         let mut concurrent_listener = ConcurrentListener::new();
@@ -188,7 +238,7 @@ impl<TL: ToListener<State>, State: Clone + Send + Sync + 'static> ToListener<Sta
 mod parse_tests {
     use super::*;
 
-    fn listen<TL: ToListener<()>>(listener: TL) -> io::Result<TL::Listener> {
+    fn listen<L: ToListener<()>>(listener: L) -> io::Result<L::Listener> {
         listener.to_listener()
     }
 

--- a/src/listener/to_listener_impls.rs
+++ b/src/listener/to_listener_impls.rs
@@ -88,7 +88,7 @@ impl<State> ToListener<State> for async_std::path::PathBuf
 where
     State: Clone + Send + Sync + 'static,
 {
-    type Listener = UnixListener;
+    type Listener = UnixListener<State>;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(UnixListener::from_path(self))
     }
@@ -99,7 +99,7 @@ impl<State> ToListener<State> for std::path::PathBuf
 where
     State: Clone + Send + Sync + 'static,
 {
-    type Listener = UnixListener;
+    type Listener = UnixListener<State>;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(UnixListener::from_path(self))
     }
@@ -141,7 +141,7 @@ impl<State> ToListener<State> for async_std::os::unix::net::UnixListener
 where
     State: Clone + Send + Sync + 'static,
 {
-    type Listener = UnixListener;
+    type Listener = UnixListener<State>;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(UnixListener::from_listener(self))
     }
@@ -152,7 +152,7 @@ impl<State> ToListener<State> for std::os::unix::net::UnixListener
 where
     State: Clone + Send + Sync + 'static,
 {
-    type Listener = UnixListener;
+    type Listener = UnixListener<State>;
     fn to_listener(self) -> io::Result<Self::Listener> {
         Ok(UnixListener::from_listener(self))
     }
@@ -169,7 +169,7 @@ where
 }
 
 #[cfg(unix)]
-impl<State> ToListener<State> for UnixListener
+impl<State> ToListener<State> for UnixListener<State>
 where
     State: Clone + Send + Sync + 'static,
 {
@@ -273,24 +273,12 @@ mod parse_tests {
         #[test]
         fn str_url_to_unix_listener() {
             let listener = listen("http+unix:///var/run/tide/socket").unwrap();
-            assert!(matches!(
-                listener,
-                ParsedListener::Unix(UnixListener::FromPath(_, None))
-            ));
             assert_eq!("http+unix:///var/run/tide/socket", listener.to_string());
 
             let listener = listen("http+unix://./socket").unwrap();
-            assert!(matches!(
-                listener,
-                ParsedListener::Unix(UnixListener::FromPath(_, None))
-            ));
             assert_eq!("http+unix://./socket", listener.to_string());
 
             let listener = listen("http+unix://socket").unwrap();
-            assert!(matches!(
-                listener,
-                ParsedListener::Unix(UnixListener::FromPath(_, None))
-            ));
             assert_eq!("http+unix://socket", listener.to_string());
         }
 

--- a/src/listener/unix_listener.rs
+++ b/src/listener/unix_listener.rs
@@ -71,7 +71,7 @@ where
         assert!(self.server.is_none(), "`bind` should only be called once");
         self.server = Some(server);
 
-        if let None = self.listener {
+        if self.listener.is_none() {
             let path = self.path.take().expect("`bind` should only be called once");
             let listener = net::UnixListener::bind(path).await?;
             self.listener = Some(listener);

--- a/src/listener/unix_listener.rs
+++ b/src/listener/unix_listener.rs
@@ -6,9 +6,9 @@ use crate::{log, Server};
 use std::fmt::{self, Display, Formatter};
 
 use async_std::os::unix::net::{self, SocketAddr, UnixStream};
+use async_std::path::PathBuf;
 use async_std::prelude::*;
 use async_std::{io, task};
-use async_std::path::PathBuf;
 
 /// This represents a tide [Listener](crate::listener::Listener) that
 /// wraps an [async_std::os::unix::net::UnixListener]. It is implemented as an
@@ -146,11 +146,14 @@ impl<State> Display for UnixListener<State> {
         match &self.listener {
             Some(listener) => {
                 let path = listener.local_addr().expect("Could not get local path dir");
-                let pathname = path.as_pathname().and_then(|p| p.canonicalize().ok()).expect("Could not canonicalize path dir");
+                let pathname = path
+                    .as_pathname()
+                    .and_then(|p| p.canonicalize().ok())
+                    .expect("Could not canonicalize path dir");
                 write!(f, "http+unix://{}", pathname.display())
             }
             None => match &self.path {
-                Some(path) =>  write!(f, "http+unix://{}", path.display()),
+                Some(path) => write!(f, "http+unix://{}", path.display()),
                 None => write!(f, "Not listening. Did you forget to call `Listener::bind`?"),
             },
         }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,3 +1,4 @@
 //! The Tide prelude.
 pub use crate::convert::{json, Deserialize, Serialize};
+pub use crate::listener::Listener;
 pub use http_types::Status;

--- a/src/server.rs
+++ b/src/server.rs
@@ -188,12 +188,23 @@ where
         self
     }
 
-    /// Asynchronously serve the app with the supplied listener. For more
-    /// details, see [Listener] and [ToListener]
+    // /// Asynchronously serve the app with the supplied listener. For more
+    // /// details, see [Listener] and [ToListener]
     pub async fn listen<L: ToListener<State>>(self, listener: L) -> io::Result<()> {
         let mut listener = listener.to_listener()?;
-        listener.bind().await?;
-        listener.accept(self).await
+        listener.bind(self).await?;
+        listener.accept().await?;
+        Ok(())
+    }
+
+    /// Asynchronously bind the listener.
+    pub async fn bind<L: ToListener<State>>(
+        self,
+        listener: L,
+    ) -> io::Result<<L as ToListener<State>>::Listener> {
+        let mut listener = listener.to_listener()?;
+        listener.bind(self).await?;
+        Ok(listener)
     }
 
     /// Respond to a `Request` with a `Response`.

--- a/src/server.rs
+++ b/src/server.rs
@@ -67,7 +67,10 @@ impl Default for Server<()> {
     }
 }
 
-impl<State: Clone + Send + Sync + 'static> Server<State> {
+impl<State> Server<State>
+where
+    State: Clone + Send + Sync + 'static,
+{
     /// Create a new Tide server with shared application scoped state.
     ///
     /// Application scoped state is useful for storing items
@@ -185,8 +188,9 @@ impl<State: Clone + Send + Sync + 'static> Server<State> {
         self
     }
 
-    /// Asynchronously serve the app with the supplied listener. For more details, see [Listener] and [ToListener]
-    pub async fn listen<TL: ToListener<State>>(self, listener: TL) -> io::Result<()> {
+    /// Asynchronously serve the app with the supplied listener. For more
+    /// details, see [Listener] and [ToListener]
+    pub async fn listen<L: ToListener<State>>(self, listener: L) -> io::Result<()> {
         listener.to_listener()?.listen(self).await
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -191,7 +191,9 @@ where
     /// Asynchronously serve the app with the supplied listener. For more
     /// details, see [Listener] and [ToListener]
     pub async fn listen<L: ToListener<State>>(self, listener: L) -> io::Result<()> {
-        listener.to_listener()?.listen(self).await
+        let mut listener = listener.to_listener()?;
+        listener.bind().await?;
+        listener.accept(self).await
     }
 
     /// Respond to a `Request` with a `Response`.

--- a/src/server.rs
+++ b/src/server.rs
@@ -188,16 +188,62 @@ where
         self
     }
 
-    // /// Asynchronously serve the app with the supplied listener. For more
-    // /// details, see [Listener] and [ToListener]
+    /// Asynchronously serve the app with the supplied listener.
+    ///
+    /// This is a shorthand for calling `Server::bind`, logging the `ListenInfo`
+    /// instances from `Listener::info`, and then calling `Listener::accept`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use async_std::task::block_on;
+    /// # fn main() -> Result<(), std::io::Error> { block_on(async {
+    /// #
+    /// let mut app = tide::new();
+    /// app.at("/").get(|_| async { Ok("Hello, world!") });
+    /// app.listen("127.0.0.1:8080").await?;
+    /// #
+    /// # Ok(()) }) }
+    /// ```
     pub async fn listen<L: ToListener<State>>(self, listener: L) -> io::Result<()> {
         let mut listener = listener.to_listener()?;
         listener.bind(self).await?;
+        for info in listener.info().iter() {
+            log::info!("Server listening on {}", info);
+        }
         listener.accept().await?;
         Ok(())
     }
 
     /// Asynchronously bind the listener.
+    ///
+    /// Bind the listener. This starts the listening process by opening the
+    /// necessary network ports, but not yet accepting incoming connections.
+    /// `Listener::listen` should be called after this to start accepting
+    /// connections.
+    ///
+    /// When calling `Listener::info` multiple `ListenInfo` instances may be
+    /// returned. This is useful when using for example `ConcurrentListener`
+    /// which enables a single server to listen on muliple ports.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use async_std::task::block_on;
+    /// # fn main() -> Result<(), std::io::Error> { block_on(async {
+    /// #
+    /// use tide::prelude::*;
+    ///
+    /// let mut app = tide::new();
+    /// app.at("/").get(|_| async { Ok("Hello, world!") });
+    /// let mut listener = app.bind("127.0.0.1:8080").await?;
+    /// for info in listener.info().iter() {
+    ///     println!("Server listening on {}", info);
+    /// }
+    /// listener.accept().await?;
+    /// #
+    /// # Ok(()) }) }
+    /// ```
     pub async fn bind<L: ToListener<State>>(
         self,
         listener: L,

--- a/tests/log.rs
+++ b/tests/log.rs
@@ -16,7 +16,7 @@ async fn test_server_listen(logger: &mut logtest::Logger) {
     let port = test_utils::find_port().await;
     let app = tide::new();
     let res = app
-        .listen(("localhost", port))
+        .listen(("127.0.0.1", port))
         .timeout(Duration::from_millis(60))
         .await;
     assert!(res.is_err());
@@ -26,7 +26,7 @@ async fn test_server_listen(logger: &mut logtest::Logger) {
         .unwrap();
     assert_eq!(
         record.args(),
-        format!("Server listening on http://[::1]:{}", port)
+        format!("Server listening on http://127.0.0.1:{}", port)
     );
 }
 


### PR DESCRIPTION
Alternative to #724's `Server::listen_with` implementation, as suggested by @jbr.

## `Server::bind`

This patch introduces a mechanism to "start listening" but don't "start accepting requests" quite yet. This enables logging in between the two actions, which fixes #712  An example:

```rust
use tide::prelude::*;

let mut app = tide::new();
app.at("/").get(|_| async { Ok("Hello, world!") });
let mut listener = app.bind("127.0.0.1:8080").await?;
for info in listener.info().iter() {
    println!("Server listening on {}", info);
}
listener.accept().await?;
```

In order for this to work we had to also adjust `Listener::listen`, breaking it up into `Listener::bind` which opens the connection, and `Listener::accept` which starts accepting the connections. Terminology-wise "listening" is the action of "binding" + "accepting".

## `listener::ConnectionInfo`

In addition to introducing `Server::bind` this patch also introduces the `ListenInfo` struct. This contains various information about the connection: the url in string form, whether the connection is encrypted, and what the underlying transform is. This information is returned through the `Listener::info` method, and always returns a vector because listeners such as `ConcurrentListener` allow the server to listen on multiple connections at once.

The `Server::listen` method uses `log::info` to log out the various connections we're listening on, but using `Server::bind` + `Listener::accept` end-users can choose to author their own log output. This first implementation is mostly intended to provide access to some basics; I hope over time we can polish it as we learn about which information is useful to surface from the listeners.