### PR TITLE
feat: allow Middleware to be added at any time

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -179,8 +179,7 @@ impl<State: Clone + Send + Sync + 'static> Server<State> {
         M: Middleware<State>,
     {
         log::trace!("Adding middleware {}", middleware.name());
-        let m = Arc::get_mut(&mut self.middleware)
-            .expect("Registering middleware is not possible after the Server has started");
+        let m = Arc::make_mut(&mut self.middleware);
         m.push(Arc::new(middleware));
         self
     }


### PR DESCRIPTION
`Arc` has thing kind-of-magic method called [`make_mut`](https://doc.rust-lang.org/std/sync/struct.Arc.html#method.make_mut) which can do an interior clone if there are immutable references.

This uses that to allow middleware to be registered on a server while it is already listening, without interfering with existing requests.

----

To be fair, I'm not 100% sure we should actually do this since supporting this use-case seems a bit questionable but if anyone finds it useful we can totally do it...

Edit: note that this does not cover doing the same for routes, which would require `Router` to be `Clone`.