### PR TITLE
docs: do not inline docs from deps that drift

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,6 @@ pub use response_builder::ResponseBuilder;
 pub use route::Route;
 pub use server::Server;
 
-#[doc(inline)]
 pub use http_types::{self as http, Body, Error, Status, StatusCode};
 
 /// Create a new Tide server.


### PR DESCRIPTION
Inlining these docs causes them to be perpetually out-of-date, since Docs.rs only builds on the actual containing crate publish.