### PR TITLE
remove the logger from the default middleware

### DIFF
--- a/examples/catflap.rs
+++ b/examples/catflap.rs
@@ -4,6 +4,7 @@ async fn main() -> Result<(), std::io::Error> {
     use std::{env, net::TcpListener, os::unix::io::FromRawFd};
     tide::log::start();
     let mut app = tide::new();
+    app.with(tide::log::LogMiddleware::new());
     app.at("/").get(|_| async { Ok(CHANGE_THIS_TEXT) });
 
     const CHANGE_THIS_TEXT: &str = "hello world!";

--- a/examples/chunked.rs
+++ b/examples/chunked.rs
@@ -4,6 +4,7 @@ use tide::Body;
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
     let mut app = tide::new();
+    app.with(tide::log::LogMiddleware::new());
     app.at("/").get(|_| async {
         // File sends are chunked by default.
         Ok(Body::from_file(file!()).await?)

--- a/examples/concurrent_listeners.rs
+++ b/examples/concurrent_listeners.rs
@@ -4,6 +4,7 @@ use tide::Request;
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
     let mut app = tide::new();
+    app.with(tide::log::LogMiddleware::new());
 
     app.at("/").get(|request: Request<_>| async move {
         Ok(format!(

--- a/examples/cookies.rs
+++ b/examples/cookies.rs
@@ -23,6 +23,7 @@ async fn remove_cookie(_req: Request<()>) -> tide::Result {
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
     let mut app = tide::new();
+    app.with(tide::log::LogMiddleware::new());
 
     app.at("/").get(retrieve_cookie);
     app.at("/set").get(insert_cookie);

--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -7,6 +7,7 @@ use tide::{Body, Request, Response, Result, StatusCode};
 async fn main() -> Result<()> {
     tide::log::start();
     let mut app = tide::new();
+    app.with(tide::log::LogMiddleware::new());
 
     app.with(After(|mut res: Response| async {
         if let Some(err) = res.downcast_error::<async_std::io::Error>() {

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -1,7 +1,10 @@
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
+
     let mut app = tide::new();
+    app.with(tide::log::LogMiddleware::new());
+
     app.at("/").get(|_| async { Ok("Hello, world!") });
     app.listen("127.0.0.1:8080").await?;
     Ok(())

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -11,6 +11,7 @@ struct Cat {
 async fn main() -> tide::Result<()> {
     tide::log::start();
     let mut app = tide::new();
+    app.with(tide::log::LogMiddleware::new());
 
     app.at("/submit").post(|mut req: Request<()>| async move {
         let cat: Cat = req.body_json().await?;

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -2,6 +2,7 @@
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
     let mut app = tide::new();
+    app.with(tide::log::LogMiddleware::new());
     app.at("/").get(|_| async { Ok("Root") });
     app.at("/api").nest({
         let mut api = tide::new();

--- a/examples/redirect.rs
+++ b/examples/redirect.rs
@@ -4,6 +4,7 @@ use tide::{Redirect, Response, StatusCode};
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
     let mut app = tide::new();
+    app.with(tide::log::LogMiddleware::new());
     app.at("/").get(|_| async { Ok("Root") });
 
     // Redirect hackers to YouTube.

--- a/examples/sessions.rs
+++ b/examples/sessions.rs
@@ -2,6 +2,7 @@
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
     let mut app = tide::new();
+    app.with(tide::log::LogMiddleware::new());
 
     app.with(tide::sessions::SessionMiddleware::new(
         tide::sessions::MemoryStore::new(),

--- a/examples/sse.rs
+++ b/examples/sse.rs
@@ -4,6 +4,7 @@ use tide::sse;
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
     let mut app = tide::new();
+    app.with(tide::log::LogMiddleware::new());
     app.at("/sse").get(sse::endpoint(|_req, sender| async move {
         sender.send("fruit", "banana", None).await?;
         sender.send("fruit", "apple", None).await?;

--- a/examples/state.rs
+++ b/examples/state.rs
@@ -18,6 +18,7 @@ impl State {
 async fn main() -> tide::Result<()> {
     tide::log::start();
     let mut app = tide::with_state(State::new());
+    app.with(tide::log::LogMiddleware::new());
     app.at("/").get(|req: tide::Request<State>| async move {
         let state = req.state();
         let value = state.value.load(Ordering::Relaxed);

--- a/examples/static_file.rs
+++ b/examples/static_file.rs
@@ -2,6 +2,7 @@
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
     let mut app = tide::new();
+    app.with(tide::log::LogMiddleware::new());
     app.at("/").get(|_| async { Ok("visit /src/*") });
     app.at("/src").serve_dir("src/")?;
     app.listen("127.0.0.1:8080").await?;

--- a/examples/upload.rs
+++ b/examples/upload.rs
@@ -28,6 +28,7 @@ impl TempDirState {
 async fn main() -> Result<(), IoError> {
     tide::log::start();
     let mut app = tide::with_state(TempDirState::try_new()?);
+    app.with(tide::log::LogMiddleware::new());
 
     // To test this example:
     // $ cargo run --example upload

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,9 @@
 //!
 //! #[async_std::main]
 //! async fn main() -> tide::Result<()> {
+//!     tide::log::start();
 //!     let mut app = tide::new();
+//!     app.with(tide::log::LogMiddleware::new());
 //!     app.at("/orders/shoes").post(order_shoes);
 //!     app.listen("127.0.0.1:8080").await?;
 //!     Ok(())

--- a/src/server.rs
+++ b/src/server.rs
@@ -109,8 +109,6 @@ where
             middleware: Arc::new(vec![
                 #[cfg(feature = "cookies")]
                 Arc::new(cookies::CookiesMiddleware::new()),
-                #[cfg(feature = "logger")]
-                Arc::new(log::LogMiddleware::new()),
             ]),
             state,
         }

--- a/tests/log.rs
+++ b/tests/log.rs
@@ -32,6 +32,7 @@ async fn test_server_listen(logger: &mut logtest::Logger) {
 
 async fn test_only_log_once(logger: &mut logtest::Logger) -> tide::Result<()> {
     let mut app = tide::new();
+    app.with(tide::log::LogMiddleware::new());
     app.at("/").nest({
         let mut app = tide::new();
         app.at("/").get(|_| async { Ok("nested") });


### PR DESCRIPTION
Not a large code change, but probably still worth discussing. Here's a PR for that discussion