### PR TITLE
ci: run clippy, docs and fmt checks on stable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,11 +76,6 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: nightly
-        override: true
-
     - name: setup
       run: |
         rustup component add clippy rustfmt
@@ -93,4 +88,4 @@ jobs:
       run: cargo fmt --all -- --check
 
     - name: Docs
-      run: cargo doc --no-deps --features unstable
+      run: cargo doc --no-deps


### PR DESCRIPTION
The build was failing for a while because clippy, doc-tests and cargo fmt are run on rust nightly. Unfortunately the nightly build does not always include all these components. In this case cargo fmt was failing.
It used to be necessary to run clippy on nightly so I assume this is why these steps were run on nightly for the Tide build. This is not necessary anymore. This pr changes the build script to run these steps on rust stable.