### PR TITLE
Percent-decode url parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ http-client = { version = "6.1.0", default-features = false }
 http-types = { version = "2.10.0", default-features = false, features = ["fs"] }
 kv-log-macro = "1.0.7"
 log = { version = "0.4.13", features = ["kv_unstable_std"] }
+percent-encoding = "2.1.0"
 pin-project-lite = "0.2.0"
 route-recognizer = "0.2.0"
 serde = "1.0.117"

--- a/src/fs/serve_dir.rs
+++ b/src/fs/serve_dir.rs
@@ -2,7 +2,7 @@ use crate::log;
 use crate::{Body, Endpoint, Request, Response, Result, StatusCode};
 
 use async_std::path::PathBuf as AsyncPathBuf;
-
+use percent_encoding::percent_decode_str;
 use std::path::{Path, PathBuf};
 use std::{ffi::OsStr, io};
 
@@ -27,8 +27,9 @@ where
         let path = req.url().path();
         let path = path.strip_prefix(&self.prefix).unwrap();
         let path = path.trim_start_matches('/');
+        let path: String = percent_decode_str(path).decode_utf8_lossy().into();
         let mut file_path = self.dir.clone();
-        for p in Path::new(path) {
+        for p in Path::new(&path) {
             if p == OsStr::new(".") {
                 continue;
             } else if p == OsStr::new("..") {

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,5 +1,6 @@
 use async_std::io::{self, prelude::*};
 use async_std::task::{Context, Poll};
+use percent_encoding::percent_decode_str;
 use route_recognizer::Params;
 
 use std::ops::Index;
@@ -282,7 +283,7 @@ impl<State> Request<State> {
     /// use tide::{Request, Result};
     ///
     /// async fn greet(req: Request<()>) -> Result<String> {
-    ///     let name = req.param("name").unwrap_or("world");
+    ///     let name = req.param("name").unwrap_or("world".to_string());
     ///     Ok(format!("Hello, {}!", name))
     /// }
     ///
@@ -293,11 +294,12 @@ impl<State> Request<State> {
     /// #
     /// # Ok(()) })}
     /// ```
-    pub fn param(&self, key: &str) -> crate::Result<&str> {
+    pub fn param(&self, key: &str) -> crate::Result<String> {
         self.route_params
             .iter()
             .rev()
             .find_map(|params| params.find(key))
+            .map(|param| percent_decode_str(param).decode_utf8_lossy().into())
             .ok_or_else(|| format_err!("Param \"{}\" not found", key.to_string()))
     }
 

--- a/tests/params.rs
+++ b/tests/params.rs
@@ -20,7 +20,10 @@ async fn test_missing_param() -> tide::Result<()> {
 #[async_std::test]
 async fn hello_world_parametrized() -> Result<()> {
     async fn greet(req: tide::Request<()>) -> Result<impl Into<Response>> {
-        let body = format!("{} says hello", req.param("name").unwrap_or("nori".to_string()));
+        let body = format!(
+            "{} says hello",
+            req.param("name").unwrap_or_else(|_| "nori".to_string())
+        );
         Ok(Response::builder(200).body(body))
     }
 
@@ -64,7 +67,10 @@ async fn multi_segment_parameter() -> Result<()> {
     assert_eq!(res.body_string().await?, "one/two");
 
     // And it should percent-decode in between the slashes
-    let req = http_types::Request::new(Method::Get, Url::parse("http://example.com/one/two%20three")?);
+    let req = http_types::Request::new(
+        Method::Get,
+        Url::parse("http://example.com/one/two%20three")?,
+    );
     let mut res: http_types::Response = server.respond(req).await?;
     assert_eq!(res.body_string().await?, "one/two three");
 

--- a/tests/params.rs
+++ b/tests/params.rs
@@ -20,7 +20,7 @@ async fn test_missing_param() -> tide::Result<()> {
 #[async_std::test]
 async fn hello_world_parametrized() -> Result<()> {
     async fn greet(req: tide::Request<()>) -> Result<impl Into<Response>> {
-        let body = format!("{} says hello", req.param("name").unwrap_or("nori"));
+        let body = format!("{} says hello", req.param("name").unwrap_or("nori".to_string()));
         Ok(Response::builder(200).body(body))
     }
 
@@ -35,5 +35,12 @@ async fn hello_world_parametrized() -> Result<()> {
     let req = http_types::Request::new(Method::Get, Url::parse("http://example.com/iron")?);
     let mut res: http_types::Response = server.respond(req).await?;
     assert_eq!(res.body_string().await?, "iron says hello");
+
+    let req = http_types::Request::new(Method::Get, Url::parse("http://example.com/nori%26iron")?);
+    let mut res: http_types::Response = server.respond(req).await?;
+    assert_eq!(res.body_string().await?, "nori&iron says hello");
+
+    Ok(())
+}
     Ok(())
 }

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -24,7 +24,7 @@ async fn add_two(req: Request<()>) -> Result<String, tide::Error> {
 
 async fn echo_path(req: Request<()>) -> Result<String, tide::Error> {
     match req.param("path") {
-        Ok(path) => Ok(path.into()),
+        Ok(path) => Ok(path),
         Err(mut err) => {
             err.set_status(StatusCode::BadRequest);
             Err(err)


### PR DESCRIPTION
This pr fixes a bug where the `param` method on a `Request` would supply the raw value of the parameter instead of the url-decoded or percent-decoded value.
This does change the Tide public API because the `param` method now returns a result of 'String' instead of a '&str'. Returning a reference after conversion would not make much sense anymore.
It also adds a crate-dependency to `percent-decode` version 2.1.0. This was already an indirect dependency, this crate is used via (among others) http-types -> serde_urlencoded -> form_urlencoded to decode query parameters.

decoding is done on-demand when a user of Tide requests a parameter. The `Params` struct still stores parameters encoded. We could also encode eagerly when storing parameters. This could also allow us to change the API back to returning &str. The reason I did things this way is to avoid decoding for unused parameters. (don't pay for what you don't use) the downside is that if a user calls .param multiple times the parameter will be decoded multiple times.

I tested this for parameters from : wildcards and * wildcards that match multiple path segments. I can imagine there might be some edge-cases that were missed. So let me know if you can think of any.