### PR TITLE
Fix port in `curl` invocation in example.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,10 +44,10 @@
 //! ````
 //!
 //! ```sh
-//! $ curl localhost:8000/orders/shoes -d '{ "name": "Chashu", "legs": 4 }'
+//! $ curl localhost:8080/orders/shoes -d '{ "name": "Chashu", "legs": 4 }'
 //! Hello, Chashu! I've put in an order for 4 shoes
 //!
-//! $ curl localhost:8000/orders/shoes -d '{ "name": "Mary Millipede", "legs": 750 }'
+//! $ curl localhost:8080/orders/shoes -d '{ "name": "Mary Millipede", "legs": 750 }'
 //! number too large to fit in target type
 //! ```
 //! See more examples in the [examples](https://github.com/http-rs/tide/tree/main/examples) directory.


### PR DESCRIPTION
The example server binds port `8080`:
https://github.com/http-rs/tide/blob/46bf28a13be9951e7a61f647f98d5232106d61fb/src/lib.rs#L36

...but the example `curl` invocations post to port `8000`:
https://github.com/http-rs/tide/blob/46bf28a13be9951e7a61f647f98d5232106d61fb/src/lib.rs#L47-L51

This patch modifies the `curl` invocations to post to port `8080`, instead.