### PR TITLE
Update version numbers of deps for README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ runtime. After running `cargo init` add the following lines to your
 # Example, use the version numbers you need
 tide = "0.15.0"
 async-std = { version = "1.8.0", features = ["attributes"] }
+serde = { version = "1.0", features = ["derive"] }
 ```
 
 ## Examples


### PR DESCRIPTION
The example code doesn't build with the old versions anymore.