### PR TITLE
Graceful shutdown futures lite

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,942 @@
+{ 
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in library 'tide'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "tide",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug example 'cookies'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=cookies",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "cookies",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in example 'cookies'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--example=cookies",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "cookies",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug example 'sessions'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=sessions",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "sessions",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in example 'sessions'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--example=sessions",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "sessions",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug example 'chunked'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=chunked",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "chunked",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in example 'chunked'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--example=chunked",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "chunked",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug example 'sse'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=sse",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "sse",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in example 'sse'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--example=sse",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "sse",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug example 'fib'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=fib",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "fib",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in example 'fib'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--example=fib",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "fib",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug example 'redirect'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=redirect",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "redirect",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in example 'redirect'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--example=redirect",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "redirect",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug example 'upload'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=upload",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "upload",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in example 'upload'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--example=upload",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "upload",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug example 'hello'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=hello",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "hello",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in example 'hello'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--example=hello",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "hello",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug example 'graphql'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=graphql",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "graphql",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in example 'graphql'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--example=graphql",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "graphql",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug example 'json'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=json",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "json",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in example 'json'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--example=json",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "json",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug example 'nested'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=nested",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "nested",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in example 'nested'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--example=nested",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "nested",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug example 'concurrent_listeners'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=concurrent_listeners",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "concurrent_listeners",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in example 'concurrent_listeners'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--example=concurrent_listeners",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "concurrent_listeners",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug example 'catflap'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=catflap",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "catflap",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in example 'catflap'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--example=catflap",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "catflap",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug example 'middleware'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=middleware",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "middleware",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in example 'middleware'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--example=middleware",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "middleware",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug example 'static_file'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=static_file",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "static_file",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in example 'static_file'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--example=static_file",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "static_file",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug example 'error_handling'",
+            "cargo": {
+                "args": [
+                    "build",
+                    "--example=error_handling",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "error_handling",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug unit tests in example 'error_handling'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--example=error_handling",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "error_handling",
+                    "kind": "example"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'cookies'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=cookies",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "cookies",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'nested'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=nested",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "nested",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'sessions'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=sessions",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "sessions",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'response'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=response",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "response",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'chunked-encode-large'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=chunked-encode-large",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "chunked-encode-large",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'chunked-encode-small'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=chunked-encode-small",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "chunked-encode-small",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'unix'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=unix",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "unix",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'log'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=log",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "log",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'server'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=server",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "server",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'params'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=params",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "params",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'test_utils'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=test_utils",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "test_utils",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'route_middleware'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=route_middleware",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "route_middleware",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'function_middleware'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=function_middleware",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "function_middleware",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'endpoint'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=endpoint",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "endpoint",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'serve_dir'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=serve_dir",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "serve_dir",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'wildcard'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=wildcard",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "wildcard",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug benchmark 'router'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--bench=router",
+                    "--package=tide"
+                ],
+                "filter": {
+                    "name": "router",
+                    "kind": "bench"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ async-sse = "4.0.1"
 async-std = { version = "1.6.5", features = ["unstable"] }
 async-trait = "0.1.41"
 femme = { version = "2.1.1", optional = true }
+futures-lite = "1.11.2"
 futures-util = "0.3.6"
 http-client = { version = "6.1.0", default-features = false }
 http-types = "2.5.0"

--- a/src/cancelation_token.rs
+++ b/src/cancelation_token.rs
@@ -1,0 +1,76 @@
+use std::cell::RefCell;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
+
+#[derive(Debug)]
+pub struct CancelationToken {
+	shared_state: Arc<Mutex<CancelationTokenState>>
+}
+
+#[derive(Debug)]
+struct CancelationTokenState {
+	canceled: bool,
+	waker: Option<Waker>
+}
+
+#[derive(Debug)]
+pub struct ReturnOnCancel<T> {
+    result: Mutex<RefCell<Option<T>>>,
+	shared_state: Arc<Mutex<CancelationTokenState>>
+}
+
+/// Future that allows gracefully shutting down the server
+impl CancelationToken {
+	pub fn new() -> CancelationToken {
+		CancelationToken {
+			shared_state: Arc::new(Mutex::new(CancelationTokenState {
+				canceled: false,
+				waker: None
+			}))
+		}
+	}
+
+	/// Call to shut down the server
+	pub fn complete(&self) {
+		let mut shared_state = self.shared_state.lock().unwrap();
+
+		shared_state.canceled = true;
+		if let Some(waker) = shared_state.waker.take() {
+			waker.wake()
+		}
+    }
+    
+    pub fn return_on_cancel<T>(&self, result: T) -> ReturnOnCancel<T> {
+        ReturnOnCancel {
+            result: Mutex::new(RefCell::new(Some(result))),
+            shared_state: self.shared_state.clone()
+        }
+    }
+}
+
+impl<T> Future for ReturnOnCancel<T> {
+    type Output = T;
+
+	fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+		let mut shared_state = self.shared_state.lock().unwrap();
+
+		if shared_state.canceled {
+            let result_refcell = self.result.lock().unwrap();
+            let result = result_refcell.replace(None).expect("Result was already returned");
+            Poll::Ready(result)
+		} else {
+            shared_state.waker = Some(cx.waker().clone());
+            Poll::Pending
+		}
+	}
+}
+
+impl Clone for CancelationToken {
+	fn clone(&self) -> Self {
+		CancelationToken {
+			shared_state: self.shared_state.clone()
+		}
+	}
+} 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@
 #![doc(html_favicon_url = "https://yoshuawuyts.com/assets/http-rs/favicon.ico")]
 #![doc(html_logo_url = "https://yoshuawuyts.com/assets/http-rs/logo-rounded.png")]
 
+mod cancelation_token;
 #[cfg(feature = "cookies")]
 mod cookies;
 mod endpoint;
@@ -85,6 +86,7 @@ pub mod utils;
 #[cfg(feature = "sessions")]
 pub mod sessions;
 
+pub use cancelation_token::CancelationToken;
 pub use endpoint::Endpoint;
 pub use middleware::{Middleware, Next};
 pub use redirect::Redirect;

--- a/src/listener/failover_listener.rs
+++ b/src/listener/failover_listener.rs
@@ -1,5 +1,5 @@
 use crate::listener::{Listener, ToListener};
-use crate::Server;
+use crate::{CancelationToken, Server};
 
 use std::fmt::{self, Debug, Display, Formatter};
 
@@ -123,11 +123,11 @@ where
         ))
     }
 
-    async fn accept(&mut self) -> io::Result<()> {
+    async fn accept(&mut self, cancelation_token: CancelationToken) -> io::Result<()> {
         match self.index {
             Some(index) => {
                 let mut listener = self.listeners[index].take().expect("accept called twice");
-                listener.accept().await?;
+                listener.accept(cancelation_token).await?;
                 Ok(())
             }
             None => Err(io::Error::new(

--- a/src/listener/mod.rs
+++ b/src/listener/mod.rs
@@ -17,7 +17,7 @@ use std::fmt::{Debug, Display};
 use async_std::io;
 use async_trait::async_trait;
 
-use crate::Server;
+use crate::{CancelationToken, Server};
 
 pub use concurrent_listener::ConcurrentListener;
 pub use failover_listener::FailoverListener;
@@ -46,7 +46,7 @@ where
 
     /// Start accepting incoming connections. This method must be called only
     /// after `bind` has succeeded.
-    async fn accept(&mut self) -> io::Result<()>;
+    async fn accept(&mut self, cancelation_token: CancelationToken) -> io::Result<()>;
 
     /// Expose information about the connection. This should always return valid
     /// data after `bind` has succeeded.
@@ -63,8 +63,8 @@ where
         self.as_mut().bind(app).await
     }
 
-    async fn accept(&mut self) -> io::Result<()> {
-        self.as_mut().accept().await
+    async fn accept(&mut self, cancelation_token: CancelationToken) -> io::Result<()> {
+        self.as_mut().accept(cancelation_token).await
     }
 
     fn info(&self) -> Vec<ListenInfo> {

--- a/src/listener/parsed_listener.rs
+++ b/src/listener/parsed_listener.rs
@@ -1,7 +1,7 @@
 #[cfg(unix)]
 use super::UnixListener;
 use super::{ListenInfo, Listener, TcpListener};
-use crate::Server;
+use crate::{CancelationToken, Server};
 
 use async_std::io;
 use std::fmt::{self, Debug, Display, Formatter};
@@ -52,11 +52,11 @@ where
         }
     }
 
-    async fn accept(&mut self) -> io::Result<()> {
+    async fn accept(&mut self, cancelation_token: CancelationToken) -> io::Result<()> {
         match self {
             #[cfg(unix)]
-            Self::Unix(u) => u.accept().await,
-            Self::Tcp(t) => t.accept().await,
+            Self::Unix(u) => u.accept(cancelation_token).await,
+            Self::Tcp(t) => t.accept(cancelation_token).await,
         }
     }
 

--- a/src/listener/unix_listener.rs
+++ b/src/listener/unix_listener.rs
@@ -1,7 +1,7 @@
 use super::{is_transient_error, ListenInfo};
 
 use crate::listener::Listener;
-use crate::{log, Server};
+use crate::{CancelationToken, log, Server};
 
 use std::fmt::{self, Display, Formatter};
 
@@ -86,7 +86,7 @@ where
         Ok(())
     }
 
-    async fn accept(&mut self) -> io::Result<()> {
+    async fn accept(&mut self, _cancelation_token: CancelationToken) -> io::Result<()> {
         let server = self
             .server
             .take()

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,7 +2,6 @@
 
 use async_std::io;
 use async_std::sync::Arc;
-use async_std::task::JoinHandle;
 
 #[cfg(feature = "cookies")]
 use crate::cookies;

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 use tide::{Body, CancelationToken, Request};
 
+// Note: Async tests are now supported. Refactor to avoid tast::block_on?
 #[test]
 fn hello_world() -> tide::Result<()> {
 


### PR DESCRIPTION
This is a replacement for https://github.com/http-rs/tide/pull/746. (Too many merge conflicts.)

Fixes #528

It works by awaiting on two futures and returns when the first completes. At this point, this is just a preview of how to cancel the server. Only TcpListener is implemented and tested.

(For context, see https://github.com/http-rs/tide/issues/528#issuecomment-723601893)