### PR TITLE
Update async-h1 to v2.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ sessions = ["async-session", "cookies"]
 unstable = []
 
 [dependencies]
-async-h1 = { version = "2.1.2", optional = true }
+async-h1 = { version = "2.3.0", optional = true }
 async-session  = { version = "2.0.1", optional = true }
 async-sse = "4.0.1"
 async-std = { version = "1.6.5", features = ["unstable"] }


### PR DESCRIPTION
This updates us to a secure version of async-h1 as the minimal supported version. For anyone running Tide in production either a fresh install or `cargo update` will get you the latest version async-h1 as well because it's semver-compatible with older versions. However this makes sure that if you update to a recent tide, you will never have an old version of async-h1.