### PR TITLE
Fix #762

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -505,9 +505,8 @@ impl<State> Request<State> {
         let lock = self.ext::<Arc<RwLock<crate::sessions::Session>>>().expect(
             "request session not initialized, did you enable tide::sessions::SessionMiddleware?",
         );
-        let guard = lock.read().unwrap();
 
-        guard
+        lock.read().unwrap()
     }
 
     /// Retrieves a mutable reference to the current session.
@@ -521,9 +520,8 @@ impl<State> Request<State> {
         let lock = self.ext::<Arc<RwLock<crate::sessions::Session>>>().expect(
             "request session not initialized, did you enable tide::sessions::SessionMiddleware?",
         );
-        let guard = lock.write().unwrap();
 
-        guard
+        lock.write().unwrap()
     }
 
     /// Get the length of the body stream, if it has been set.

--- a/src/request.rs
+++ b/src/request.rs
@@ -2,6 +2,7 @@ use async_std::io::{self, prelude::*};
 use async_std::task::{Context, Poll};
 use route_recognizer::Params;
 
+use std::sync::{Arc,RwLock};
 use std::ops::Index;
 use std::pin::Pin;
 
@@ -500,10 +501,13 @@ impl<State> Request<State> {
     /// This method will panic if a tide::sessions:SessionMiddleware has not
     /// been run.
     #[cfg(feature = "sessions")]
-    pub fn session(&self) -> &crate::sessions::Session {
-        self.ext::<crate::sessions::Session>().expect(
+    pub fn session(&self) -> std::sync::RwLockReadGuard<crate::sessions::Session> {
+        let lock = self.ext::<Arc<RwLock<crate::sessions::Session>>>().expect(
             "request session not initialized, did you enable tide::sessions::SessionMiddleware?",
-        )
+        );
+        let guard = lock.read().unwrap();
+
+        guard
     }
 
     /// Retrieves a mutable reference to the current session.
@@ -513,10 +517,13 @@ impl<State> Request<State> {
     /// This method will panic if a tide::sessions:SessionMiddleware has not
     /// been run.
     #[cfg(feature = "sessions")]
-    pub fn session_mut(&mut self) -> &mut crate::sessions::Session {
-        self.ext_mut().expect(
+    pub fn session_mut(&mut self) -> std::sync::RwLockWriteGuard<crate::sessions::Session> {
+        let lock = self.ext::<Arc<RwLock<crate::sessions::Session>>>().expect(
             "request session not initialized, did you enable tide::sessions::SessionMiddleware?",
-        )
+        );
+        let guard = lock.write().unwrap();
+
+        guard
     }
 
     /// Get the length of the body stream, if it has been set.

--- a/src/request.rs
+++ b/src/request.rs
@@ -2,9 +2,9 @@ use async_std::io::{self, prelude::*};
 use async_std::task::{Context, Poll};
 use route_recognizer::Params;
 
-use std::sync::{Arc,RwLock};
 use std::ops::Index;
 use std::pin::Pin;
+use std::sync::{Arc, RwLock};
 
 #[cfg(feature = "cookies")]
 use crate::cookies::CookieData;

--- a/src/request.rs
+++ b/src/request.rs
@@ -501,7 +501,7 @@ impl<State> Request<State> {
     /// This method will panic if a tide::sessions:SessionMiddleware has not
     /// been run.
     #[cfg(feature = "sessions")]
-    pub fn session(&self) -> std::sync::RwLockReadGuard<crate::sessions::Session> {
+    pub fn session(&self) -> std::sync::RwLockReadGuard<'_, crate::sessions::Session> {
         let lock = self.ext::<Arc<RwLock<crate::sessions::Session>>>().expect(
             "request session not initialized, did you enable tide::sessions::SessionMiddleware?",
         );
@@ -516,7 +516,7 @@ impl<State> Request<State> {
     /// This method will panic if a tide::sessions:SessionMiddleware has not
     /// been run.
     #[cfg(feature = "sessions")]
-    pub fn session_mut(&mut self) -> std::sync::RwLockWriteGuard<crate::sessions::Session> {
+    pub fn session_mut(&mut self) -> std::sync::RwLockWriteGuard<'_, crate::sessions::Session> {
         let lock = self.ext::<Arc<RwLock<crate::sessions::Session>>>().expect(
             "request session not initialized, did you enable tide::sessions::SessionMiddleware?",
         );

--- a/src/sessions/middleware.rs
+++ b/src/sessions/middleware.rs
@@ -99,7 +99,7 @@ where
 
         let mut response = next.run(request).await;
 
-        let session = (*session_lock.read().unwrap()).clone();
+        let session = Arc::try_unwrap(session_lock).unwrap().into_inner().unwrap();
 
         if session.is_destroyed() {
             if let Err(e) = self.store.destroy_session(session).await {

--- a/src/sessions/middleware.rs
+++ b/src/sessions/middleware.rs
@@ -6,7 +6,7 @@ use crate::http::{
 use crate::{utils::async_trait, Middleware, Next, Request};
 use std::time::Duration;
 
-use std::sync::{Arc,RwLock};
+use std::sync::{Arc, RwLock};
 
 use async_session::{
     base64,
@@ -94,7 +94,7 @@ where
 
         let secure_cookie = request.url().scheme() == "https";
 
-        let  session_lock = Arc::new(RwLock::new(session));
+        let session_lock = Arc::new(RwLock::new(session));
         request.set_ext(session_lock.clone());
 
         let mut response = next.run(request).await;


### PR DESCRIPTION
Hi @yoshuawuyts  / @No9,
                                              I make this changes trying to fix the bug reported in #762, where the `cookie id` isn't updated ( resent ) when the session is regenerated. I put the `session` behind an `Arc::RwLock` ( std ) when we set the `ext` and then in the request return the `guard` to don't change the `req` api. ( e.g req.session() /  req.session_mut() ).  It's ok to use the RwLock from `std::sync` ? 

Also, I wonder if we still need the `RwLock` and the `Arc` in the `Session` struct  ( https://github.com/http-rs/async-session/blob/main/src/session.rs#L60-L67 )  if we already are using a mutex ( from this pr )  on top to of that struct ?

Open here as draft since I'm not sure if my approach is ok, and the code have this `clippy` warnings that I'm not sure how to resolve.

```
519 |     pub fn session_mut(&mut self) -> std::sync::RwLockWriteGuard<crate::sessions::Session> {
    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: indicate the anonymous lifetime: `std::sync::RwLockWriteGuard<'_, crate::sessions::Session>`
```

Thanks! any feedback is welcome :)

