### PR TITLE
docs: Add missing `serde` requirement in example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 //! # Example, use the version numbers you need
 //! tide = "0.14.0"
 //! async-std = { version = "1.6.0", features = ["attributes"] }
+//! serde = { version = "1.0", features = ["derive"] }
 //!```
 //!
 //! # Examples


### PR DESCRIPTION
Hello :)

First of all, thank you for creating and maintaining this crate. I enjoy it :)

This PR fixes the documentation for the "Getting started" example inside `lib.rs`. Without `serde` in dependencies, the compiler throws the following error:

```
error[E0463]: can't find crate for `serde`
 --> src/main.rs:5:17
  |
5 | #[derive(Debug, Deserialize)]
  |                 ^^^^^^^^^^^ can't find crate
  |
  = note: this error originates in a derive macro (in Nightly builds, run with -Z macro-backtrace for more info)

error: aborting due to previous error
```

I noted that the similar example in README has `serde` in place and copied it here :)