### PR TITLE
bugfix : serve_dir doesn't precede to other route

### DIFF
--- a/examples/static_file.rs
+++ b/examples/static_file.rs
@@ -3,7 +3,7 @@ async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
     let mut app = tide::new();
     app.at("/").get(|_| async { Ok("visit /src/*") });
-    app.at("/src").serve_dir("src/")?;
+    app.at("/src/*").serve_dir("src/")?;
     app.at("/example").serve_file("examples/static_file.html")?;
     app.listen("127.0.0.1:8080").await?;
     Ok(())

--- a/src/fs/serve_dir.rs
+++ b/src/fs/serve_dir.rs
@@ -25,7 +25,9 @@ where
 {
     async fn call(&self, req: Request<State>) -> Result {
         let path = req.url().path();
-        let path = path.strip_prefix(&self.prefix).unwrap();
+        let path = path
+            .strip_prefix(&self.prefix.trim_end_matches('*'))
+            .unwrap();
         let path = path.trim_start_matches('/');
         let mut file_path = self.dir.clone();
         for p in Path::new(path) {

--- a/src/route.rs
+++ b/src/route.rs
@@ -127,7 +127,7 @@ impl<'a, State: Clone + Send + Sync + 'static> Route<'a, State> {
     /// #[async_std::main]
     /// async fn main() -> Result<(), std::io::Error> {
     ///     let mut app = tide::new();
-    ///     app.at("/images").serve_dir("public/images/")?;
+    ///     app.at("/images/*").serve_dir("public/images/")?;
     ///     app.listen("127.0.0.1:8080").await?;
     ///     Ok(())
     /// }
@@ -136,7 +136,7 @@ impl<'a, State: Clone + Send + Sync + 'static> Route<'a, State> {
         // Verify path exists, return error if it doesn't.
         let dir = dir.as_ref().to_owned().canonicalize()?;
         let prefix = self.path().to_string();
-        self.at("*").get(ServeDir::new(prefix, dir));
+        self.get(ServeDir::new(prefix, dir));
         Ok(())
     }
 

--- a/tests/serve_dir.rs
+++ b/tests/serve_dir.rs
@@ -3,6 +3,10 @@ use tide::{http, Result, Server};
 use std::fs::{self, File};
 use std::io::Write;
 
+fn api() -> Box<dyn tide::Endpoint<()>> {
+    Box::new(|_| async { Ok("api") })
+}
+
 fn app(tempdir: &tempfile::TempDir) -> Result<Server<()>> {
     let static_dir = tempdir.path().join("static");
     fs::create_dir(&static_dir)?;
@@ -12,7 +16,9 @@ fn app(tempdir: &tempfile::TempDir) -> Result<Server<()>> {
     write!(file, "Foobar")?;
 
     let mut app = Server::new();
-    app.at("/static/").serve_dir(static_dir.to_str().unwrap())?;
+    app.at("/static/api").get(api());
+    app.at("/static/*")
+        .serve_dir(static_dir.to_str().unwrap())?;
 
     Ok(app)
 }
@@ -40,4 +46,14 @@ async fn not_found() {
     let res: http::Response = app.respond(request("bar")).await.unwrap();
 
     assert_eq!(res.status(), 404);
+}
+
+#[async_std::test]
+async fn static_endpoint_mixin() {
+    let tempdir = tempfile::tempdir().unwrap();
+    let app = app(&tempdir).unwrap();
+    let mut res: http::Response = app.respond(request("api")).await.unwrap();
+
+    assert_eq!(res.status(), 200);
+    assert_eq!(res.body_string().await.unwrap().as_str(), "api");
 }


### PR DESCRIPTION
Fixes: #777 

I had fixed that `serve_dir` precede to other existing routes. 

It has a little breaking changes that specified routing path of `serve_dir` to add suffix wild card asterisk. 

But unit/integrate test has certainly all passed and it has changed examples as anyone can make sense.