### PR TITLE
add a comment to the serve_file example to fix confusion mentioned in issue #796

### DIFF
--- a/examples/static_file.rs
+++ b/examples/static_file.rs
@@ -4,7 +4,10 @@ async fn main() -> Result<(), std::io::Error> {
     let mut app = tide::new();
     app.at("/").get(|_| async { Ok("visit /src/*") });
     app.at("/src/*").serve_dir("src/")?;
+
+    // Make sure examples/static_file.html is available relative to the current-dir this example is run from or replace this with an absolute path.
     app.at("/example").serve_file("examples/static_file.html")?;
+
     app.listen("127.0.0.1:8080").await?;
     Ok(())
 }


### PR DESCRIPTION
There was some confusion how the `serve_file` example worked (https://github.com/http-rs/tide/issues/796)

This comment in the example might prevent this in the future