### PR TITLE
Percent decode parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ http-client = { version = "6.1.0", default-features = false }
 http-types = { version = "2.10.0", default-features = false, features = ["fs"] }
 kv-log-macro = "1.0.7"
 log = { version = "0.4.13", features = ["kv_unstable_std"] }
+percent-encoding = "2.1.0"
 pin-project-lite = "0.2.0"
 route-recognizer = "0.2.0"
 serde = "1.0.117"

--- a/tests/params.rs
+++ b/tests/params.rs
@@ -35,5 +35,41 @@ async fn hello_world_parametrized() -> Result<()> {
     let req = http_types::Request::new(Method::Get, Url::parse("http://example.com/iron")?);
     let mut res: http_types::Response = server.respond(req).await?;
     assert_eq!(res.body_string().await?, "iron says hello");
+
+    let req = http_types::Request::new(Method::Get, Url::parse("http://example.com/nori%26iron")?);
+    let mut res: http_types::Response = server.respond(req).await?;
+    assert_eq!(res.body_string().await?, "nori&iron says hello");
+
+    Ok(())
+}
+
+#[async_std::test]
+async fn multi_segment_parameter() -> Result<()> {
+    async fn greet(req: tide::Request<()>) -> Result<impl Into<Response>> {
+        let body = req.param("param").unwrap();
+        Ok(Response::builder(200).body(body))
+    }
+
+    let mut server = tide::new();
+    server.at("/*param").get(greet);
+
+    // Should still work with one segment
+    let req = http_types::Request::new(Method::Get, Url::parse("http://example.com/one")?);
+    let mut res: http_types::Response = server.respond(req).await?;
+    assert_eq!(res.body_string().await?, "one");
+
+    // Or two
+    let req = http_types::Request::new(Method::Get, Url::parse("http://example.com/one/two")?);
+    let mut res: http_types::Response = server.respond(req).await?;
+    assert_eq!(res.body_string().await?, "one/two");
+
+    // And it should percent-decode in between the slashes
+    let req = http_types::Request::new(
+        Method::Get,
+        Url::parse("http://example.com/one/two%20three")?,
+    );
+    let mut res: http_types::Response = server.respond(req).await?;
+    assert_eq!(res.body_string().await?, "one/two three");
+
     Ok(())
 }


### PR DESCRIPTION
This pr solves the same problem as https://github.com/http-rs/tide/pull/757 but instead of percent-decoding lazilly (when a user queries a parameter) this does it eagerly, when a request comes in all parameters are decoded.
This has one downside, it's a bit slower. It iterates through all the `Params` in the request, decodes them and stores them in a new `BTreeMap`
But it has a couple of benefits;
- It can return a 401 for a malformed request immediately without involving the users code.
- The api stays the same, no need to return a param as a `String` instead of a `&str`

~~This pr also merges the Vec<Param> into a single BTreeMap<String, String> because it already has to iterate through and copy all the params. This makes other code a bit simpeler.~~