### PR TITLE
try using routefinder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ log = { version = "0.4.13", features = ["kv_unstable_std"] }
 pin-project-lite = "0.2.0"
 serde = "1.0.117"
 serde_json = "1.0.59"
-routefinder = "0.3.1"
+routefinder = "0.4.0"
 
 [dev-dependencies]
 async-std = { version = "1.6.5", features = ["unstable", "attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,9 @@ http-types = { version = "2.11.0", default-features = false, features = ["fs"] }
 kv-log-macro = "1.0.7"
 log = { version = "0.4.13", features = ["kv_unstable_std"] }
 pin-project-lite = "0.2.0"
-route-recognizer = "0.2.0"
 serde = "1.0.117"
 serde_json = "1.0.59"
+routefinder = "0.1.1"
 
 [dev-dependencies]
 async-std = { version = "1.6.5", features = ["unstable", "attributes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ log = { version = "0.4.13", features = ["kv_unstable_std"] }
 pin-project-lite = "0.2.0"
 serde = "1.0.117"
 serde_json = "1.0.59"
-routefinder = "0.1.1"
+routefinder = "0.3.1"
 
 [dev-dependencies]
 async-std = { version = "1.6.5", features = ["unstable", "attributes"] }

--- a/src/request.rs
+++ b/src/request.rs
@@ -27,13 +27,17 @@ pin_project_lite::pin_project! {
         pub(crate) state: State,
         #[pin]
         pub(crate) req: http::Request,
-        pub(crate) route_params: Vec<Captures>,
+        pub(crate) route_params: Vec<Captures<'static, 'static>>,
     }
 }
 
 impl<State> Request<State> {
     /// Create a new `Request`.
-    pub(crate) fn new(state: State, req: http_types::Request, route_params: Vec<Captures>) -> Self {
+    pub(crate) fn new(
+        state: State,
+        req: http_types::Request,
+        route_params: Vec<Captures<'static, 'static>>,
+    ) -> Self {
         Self {
             state,
             req,

--- a/src/route.rs
+++ b/src/route.rs
@@ -153,13 +153,7 @@ impl<'a, State: Clone + Send + Sync + 'static> Route<'a, State> {
     pub fn method(&mut self, method: http_types::Method, ep: impl Endpoint<State>) -> &mut Self {
         if self.prefix {
             let ep = StripPrefixEndpoint::new(ep);
-
-            self.router.add(
-                &self.path,
-                method,
-                MiddlewareEndpoint::wrap_with_middleware(ep.clone(), &self.middleware),
-            );
-            let wildcard = self.at("*--tide-path-rest");
+            let wildcard = self.at("*");
             wildcard.router.add(
                 &wildcard.path,
                 method,
@@ -181,12 +175,7 @@ impl<'a, State: Clone + Send + Sync + 'static> Route<'a, State> {
     pub fn all(&mut self, ep: impl Endpoint<State>) -> &mut Self {
         if self.prefix {
             let ep = StripPrefixEndpoint::new(ep);
-
-            self.router.add_all(
-                &self.path,
-                MiddlewareEndpoint::wrap_with_middleware(ep.clone(), &self.middleware),
-            );
-            let wildcard = self.at("*--tide-path-rest");
+            let wildcard = self.at("*");
             wildcard.router.add_all(
                 &wildcard.path,
                 MiddlewareEndpoint::wrap_with_middleware(ep, &wildcard.middleware),
@@ -283,7 +272,12 @@ where
             route_params,
         } = req;
 
-        let rest = crate::request::rest(&route_params).unwrap_or("");
+        let rest = route_params
+            .iter()
+            .rev()
+            .find_map(|captures| captures.wildcard())
+            .unwrap_or_default();
+
         req.url_mut().set_path(rest);
 
         self.0

--- a/src/router.rs
+++ b/src/router.rs
@@ -26,7 +26,7 @@ impl<State> std::fmt::Debug for Router<State> {
 /// The result of routing a URL
 pub(crate) struct Selection<'a, State> {
     pub(crate) endpoint: &'a DynEndpoint<State>,
-    pub(crate) params: Captures,
+    pub(crate) params: Captures<'static, 'static>,
 }
 
 impl<State: Clone + Send + Sync + 'static> Router<State> {
@@ -62,12 +62,12 @@ impl<State: Clone + Send + Sync + 'static> Router<State> {
         {
             Selection {
                 endpoint: m.handler(),
-                params: m.captures(),
+                params: m.captures().into_owned(),
             }
         } else if let Some(m) = self.all_method_router.best_match(path) {
             Selection {
                 endpoint: m.handler(),
-                params: m.captures(),
+                params: m.captures().into_owned(),
             }
         } else if method == http_types::Method::Head {
             // If it is a HTTP HEAD request then check if there is a callback in the endpoints map


### PR DESCRIPTION
[routefinder](https://github.com/jbr/routefinder) represents a complete rewrite of the route-recognizer behavior

Breaking changes:
* there can only be one wildcard per route
* unnamed params are not supported
* the prioritization between routes may not be identical in some cases, but there are no known examples of this

There may be an incidental performance improvement of several microseconds per request

closes #783 
a step towards #797