### PR TITLE
Set SameSite policy Lax as default

### DIFF
--- a/src/sessions/middleware.rs
+++ b/src/sessions/middleware.rs
@@ -172,7 +172,7 @@ impl<Store: SessionStore> SessionMiddleware<Store> {
             cookie_path: "/".into(),
             cookie_name: "tide.sid".into(),
             cookie_domain: None,
-            same_site_policy: SameSite::Strict,
+            same_site_policy: SameSite::Lax,
             session_ttl: Some(Duration::from_secs(24 * 60 * 60)),
             key: Key::derive_from(secret),
         }
@@ -218,7 +218,7 @@ impl<Store: SessionStore> SessionMiddleware<Store> {
     }
 
     /// Sets the same site policy for the session cookie. Defaults to
-    /// SameSite::Strict. See [incrementally better
+    /// SameSite::Lax. See [incrementally better
     /// cookies](https://tools.ietf.org/html/draft-west-cookie-incrementalism-01)
     /// for more information about this setting
     pub fn with_same_site_policy(mut self, policy: SameSite) -> Self {

--- a/tests/sessions.rs
+++ b/tests/sessions.rs
@@ -39,7 +39,7 @@ async fn test_basic_sessions() -> tide::Result<()> {
     assert_eq!(cookie.name(), "tide.sid");
     assert_eq!(cookie.domain(), None);
     assert_eq!(cookie.http_only(), Some(true));
-    assert_eq!(cookie.same_site(), Some(SameSite::Strict));
+    assert_eq!(cookie.same_site(), Some(SameSite::Lax));
     assert_eq!(cookie.secure(), None); // this request was http://
     assert_eq!(cookie.path(), Some("/"));
 
@@ -64,7 +64,7 @@ async fn test_customized_sessions() -> tide::Result<()> {
             .with_cookie_name("custom.cookie.name")
             .with_cookie_path("/nested")
             .with_cookie_domain("www.rust-lang.org")
-            .with_same_site_policy(SameSite::Lax)
+            .with_same_site_policy(SameSite::Strict)
             .with_session_ttl(Some(Duration::from_secs(1)))
             .without_save_unchanged(),
     );
@@ -99,7 +99,7 @@ async fn test_customized_sessions() -> tide::Result<()> {
     assert!(cookies.get("tide.sid").is_none());
     let cookie = &cookies["custom.cookie.name"];
     assert_eq!(cookie.http_only(), Some(true));
-    assert_eq!(cookie.same_site(), Some(SameSite::Lax));
+    assert_eq!(cookie.same_site(), Some(SameSite::Strict));
     assert_eq!(cookie.path(), Some("/nested"));
     assert_eq!(cookie.domain(), Some("www.rust-lang.org"));
     let cookie_value = cookie.value().to_string();


### PR DESCRIPTION
Closes #801 
Browsers treat SameSite policy as Lax if it is not specified and this behaviour is more intuitive.