### PR TITLE
Add 2 examples, and typo locahost -> localhost in examples/upload.rs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ team. Use at your own risk.</sup>
 * [tide-example](https://github.com/jbr/tide-example) (sqlx + askama)
 * [playground-tide-mongodb](https://github.com/yoshuawuyts/playground-tide-mongodb)
 * [tide-morth-example](https://github.com/No9/tide-morth-example/)
+* [tide-graphql-mongodb](https://github.com/zzy/tide-graphql-mongodb)
+  - Clean boilerplate for graphql services using tide, rhai, async-graphql, surf, graphql-client, handlebars-rust, jsonwebtoken, and mongodb.
+  - Graphql Services: User register, Salt and hash a password with PBKDF2 , Sign in， JSON web token authentication, Change password， Profile Update, User's query & mutation, and Project's query & mutation.
+  - Web Application: Client request, bring & parse GraphQL data, Render data to template engine(handlebars-rust)， Define custom helper with Rhai scripting language.
+* [surf](https://github.com/zzy/surfer)
+  - The Blog built on Tide stack, generated from [tide-graphql-mongodb](https://github.com/zzy/tide-graphql-mongodb).
+  - Backend for graphql services using tide, async-graphql, jsonwebtoken, mongodb and so on.
+  - Frontend for web application using tide, rhai, surf, graphql_client, handlebars-rust, cookie and so on.
 
 ## Contributing
 Want to join us? Check out our [The "Contributing" section of the

--- a/examples/upload.rs
+++ b/examples/upload.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<(), IoError> {
 
     // To test this example:
     // $ cargo run --example upload
-    // $ curl -T ./README.md locahost:8080 # this writes the file to a temp directory
+    // $ curl -T ./README.md localhost:8080 # this writes the file to a temp directory
     // $ curl localhost:8080/README.md # this reads the file from the same temp directory
 
     app.at(":file")


### PR DESCRIPTION
Hi, @jbr, I have deleted async-graphql.rs from tide/examples repository, and only added repo links to the example applications list section.

- typo locahost -> localhost in examples/upload.rs.
- Add example tide-graphql-mongodb: Clean boilerplate for graphql services using tide, rhai, async-graphql, surf, graphql-client, handlebars-rust, jsonwebtoken, and mongodb.
  - Graphql Services: User register, Salt and hash a password with PBKDF2 , Sign in， JSON web token authentication, Change password， Profile Update, User's query & mutation, and Project's query & mutation.
  - Web Application: Client request, bring & parse GraphQL data, Render data to template engine(handlebars-rust)， Define custom helper with Rhai scripting language.
- Add example surfer: the complete blog example, built on pure Rust and Tide stack.
  - Backend for graphql services using tide, async-graphql, jsonwebtoken, mongodb and so on.
  - Frontend for web application using tide, rhai, surf, graphql_client, handlebars-rust, cookie and so on.

