### PR TITLE
Session cookie secure attribute

### DIFF
--- a/src/listener/concurrent_listener.rs
+++ b/src/listener/concurrent_listener.rs
@@ -113,8 +113,7 @@ where
     fn info(&self) -> Vec<ListenInfo> {
         self.listeners
             .iter()
-            .map(|listener| listener.info().into_iter())
-            .flatten()
+            .flat_map(|listener| listener.info().into_iter())
             .collect()
     }
 }

--- a/tests/sessions.rs
+++ b/tests/sessions.rs
@@ -64,7 +64,8 @@ async fn test_customized_sessions() -> tide::Result<()> {
             .with_cookie_name("custom.cookie.name")
             .with_cookie_path("/nested")
             .with_cookie_domain("www.rust-lang.org")
-            .with_same_site_policy(SameSite::Strict)
+            .with_secure(true)
+            .with_same_site_policy(SameSite::Lax)
             .with_session_ttl(Some(Duration::from_secs(1)))
             .without_save_unchanged(),
     );
@@ -99,7 +100,8 @@ async fn test_customized_sessions() -> tide::Result<()> {
     assert!(cookies.get("tide.sid").is_none());
     let cookie = &cookies["custom.cookie.name"];
     assert_eq!(cookie.http_only(), Some(true));
-    assert_eq!(cookie.same_site(), Some(SameSite::Strict));
+    assert_eq!(cookie.secure(), Some(true));
+    assert_eq!(cookie.same_site(), Some(SameSite::Lax));
     assert_eq!(cookie.path(), Some("/nested"));
     assert_eq!(cookie.domain(), Some("www.rust-lang.org"));
     let cookie_value = cookie.value().to_string();


### PR DESCRIPTION
Addresses #811 and allows the session middleware to be configured to override the secure cookie attribute