### PR TITLE
Update server.rs docs to reflect method rename

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -25,7 +25,7 @@ use crate::{Endpoint, Request, Route};
 ///
 /// - Middleware extends the base Tide framework with additional request or
 /// response processing, such as compression, default headers, or logging. To
-/// add middleware to an app, use the [`Server::middleware`] method.
+/// add middleware to an app, use the [`Server::with`] method.
 pub struct Server<State> {
     router: Arc<Router<State>>,
     state: State,


### PR DESCRIPTION
Updates the docs in server.rs to reflect the renaming of Server::middleware to Server::with.