### PR TITLE
update async-session to 3.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ unstable = []
 
 [dependencies]
 async-h1 = { version = "2.3.0", optional = true }
-async-session  = { version = "2.0.1", optional = true }
+async-session = { version = "3.0", optional = true }
 async-sse = "4.0.1"
 async-std = { version = "1.6.5", features = ["unstable"] }
 async-trait = "0.1.41"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@
 #![forbid(unsafe_code)]
 #![deny(missing_debug_implementations, nonstandard_style)]
 #![warn(missing_docs, unreachable_pub, future_incompatible, rust_2018_idioms)]
+#![allow(clippy::len_without_is_empty)]
 #![doc(test(attr(deny(warnings))))]
 #![doc(test(attr(allow(unused_extern_crates, unused_variables))))]
 #![doc(html_favicon_url = "https://yoshuawuyts.com/assets/http-rs/favicon.ico")]

--- a/src/listener/unix_listener.rs
+++ b/src/listener/unix_listener.rs
@@ -161,11 +161,10 @@ impl<State> Display for UnixListener<State> {
 }
 
 fn unix_socket_addr_to_string(result: io::Result<SocketAddr>) -> Option<String> {
-    result.ok().and_then(|addr| {
-        if let Some(pathname) = addr.as_pathname().and_then(|p| p.canonicalize().ok()) {
-            Some(format!("http+unix://{}", pathname.display()))
-        } else {
-            None
-        }
-    })
+    result
+        .ok()
+        .as_ref()
+        .and_then(SocketAddr::as_pathname)
+        .and_then(|p| p.canonicalize().ok())
+        .map(|pathname| format!("http+unix://{}", pathname.display()))
 }

--- a/src/sessions/middleware.rs
+++ b/src/sessions/middleware.rs
@@ -267,11 +267,11 @@ impl<Store: SessionStore> SessionMiddleware<Store> {
     }
 
     // the following is reused verbatim from
-    // https://github.com/SergioBenitez/cookie-rs/blob/master/src/secure/signed.rs#L33-L43
+    // https://github.com/SergioBenitez/cookie-rs/blob/master/src/secure/signed.rs#L37-46
     /// Signs the cookie's value providing integrity and authenticity.
     fn sign_cookie(&self, cookie: &mut Cookie<'_>) {
         // Compute HMAC-SHA256 of the cookie's value.
-        let mut mac = Hmac::<Sha256>::new_varkey(&self.key.signing()).expect("good key");
+        let mut mac = Hmac::<Sha256>::new_from_slice(&self.key.signing()).expect("good key");
         mac.update(cookie.value().as_bytes());
 
         // Cookie's new value is [MAC | original-value].
@@ -281,7 +281,7 @@ impl<Store: SessionStore> SessionMiddleware<Store> {
     }
 
     // the following is reused verbatim from
-    // https://github.com/SergioBenitez/cookie-rs/blob/master/src/secure/signed.rs#L45-L63
+    // https://github.com/SergioBenitez/cookie-rs/blob/master/src/secure/signed.rs#L51-L66
     /// Given a signed value `str` where the signature is prepended to `value`,
     /// verifies the signed value and returns it. If there's a problem, returns
     /// an `Err` with a string describing the issue.
@@ -295,7 +295,7 @@ impl<Store: SessionStore> SessionMiddleware<Store> {
         let digest = base64::decode(digest_str).map_err(|_| "bad base64 digest")?;
 
         // Perform the verification.
-        let mut mac = Hmac::<Sha256>::new_varkey(&self.key.signing()).expect("good key");
+        let mut mac = Hmac::<Sha256>::new_from_slice(&self.key.signing()).expect("good key");
         mac.update(value.as_bytes());
         mac.verify(&digest)
             .map(|_| value.to_string())


### PR DESCRIPTION
this is a patch level change for tide, as it introduces no changes to the public api

also fixes several unrelated clippies. chose to allow clippy::len_without_is_empty because that's part of the public api and any changes to that should be done in a more considered fashion than "trying to fix a clippy lint"