### PR TITLE
Document security of serve_dir router

### DIFF
--- a/src/route.rs
+++ b/src/route.rs
@@ -118,6 +118,12 @@ impl<'a, State: Clone + Send + Sync + 'static> Route<'a, State> {
     /// Each file will be streamed from disk, and a mime type will be determined
     /// based on magic bytes.
     ///
+    /// # Security
+    /// 
+    /// This handler ensures no folders outside the requested folder can be served,
+    /// and attempts to access such files will return StatusCode::Forbidden to the
+    /// caller 
+    ///
     /// # Examples
     ///
     /// Serve the contents of the local directory `./public/images/*` from

--- a/src/route.rs
+++ b/src/route.rs
@@ -119,7 +119,7 @@ impl<'a, State: Clone + Send + Sync + 'static> Route<'a, State> {
     /// based on magic bytes.
     ///
     /// # Security
-    /// 
+    ///
     /// This handler ensures no folders outside the specified folder can be
     /// served, and attempts to access any path outside this folder (no matter
     /// if it exists or not) will return `StatusCode::Forbidden` to the caller.

--- a/src/route.rs
+++ b/src/route.rs
@@ -120,9 +120,9 @@ impl<'a, State: Clone + Send + Sync + 'static> Route<'a, State> {
     ///
     /// # Security
     /// 
-    /// This handler ensures no folders outside the requested folder can be served,
-    /// and attempts to access such files will return `StatusCode::Forbidden` to the
-    /// caller.
+    /// This handler ensures no folders outside the specified folder can be
+    /// served, and attempts to access any path outside this folder (no matter
+    /// if it exists or not) will return `StatusCode::Forbidden` to the caller.
     ///
     /// # Examples
     ///

--- a/src/route.rs
+++ b/src/route.rs
@@ -121,8 +121,8 @@ impl<'a, State: Clone + Send + Sync + 'static> Route<'a, State> {
     /// # Security
     /// 
     /// This handler ensures no folders outside the requested folder can be served,
-    /// and attempts to access such files will return StatusCode::Forbidden to the
-    /// caller 
+    /// and attempts to access such files will return `StatusCode::Forbidden` to the
+    /// caller.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
As someone new to the library, I worry about the security builtin routes, and here I had to check the (well documented) source to find what i was looking for. This PR adds the information to the route documentation itself.