### PR TITLE
Document behaviour of nested overlapping routes

### DIFF
--- a/src/route.rs
+++ b/src/route.rs
@@ -100,7 +100,7 @@ impl<'a, State: Clone + Send + Sync + 'static> Route<'a, State> {
     ///
     /// # Note
     ///
-    /// The outer server *always* have precedence when disambiguating
+    /// The outer server *always* has precedence when disambiguating
     /// overlapping paths. For example in the following example `/hello` will
     /// return "Unexpected" to the client
     ///


### PR DESCRIPTION
I was surprised by this behavior, so I thought it useful to add it to the documentation