### PR TITLE
Add benchmark for nested routers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,10 @@ required-features = ["sessions"]
 name = "router"
 harness = false
 
+[[bench]]
+name = "nest"
+harness = false
+
 [[example]]
 name = "cookies"
 required-features = ["cookies"]

--- a/benches/nest.rs
+++ b/benches/nest.rs
@@ -1,0 +1,33 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use http_types::{Method, Request, Response, Url};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut app = tide::new();
+    app.at("/x").get(|_| async { Ok("X") });
+    app.at("/x/y").get(|_| async { Ok("Y") });
+    app.at("/x/y/z").get(|_| async { Ok("Z") });
+
+    let route = Url::parse("https://example.com/x/y/z").unwrap();
+    let req = Request::new(Method::Get, route);
+    c.bench_function("plain", |b| {
+        b.iter(|| black_box(app.respond::<_, Response>(req.clone())));
+    });
+
+    let mut appz = tide::new();
+    appz.at("/z").get(|_| async { Ok("Z") });
+    
+    let mut appy = tide::new();
+    appy.at("/y").nest(appz);
+
+    let mut appx = tide::new();
+    appx.at("/x").nest(appy);
+
+    let route = Url::parse("https://example.com/x/y/z").unwrap();
+    let req = Request::new(Method::Get, route);
+    c.bench_function("nested", |b| {
+        b.iter(|| black_box(appx.respond::<_, Response>(req.clone())));
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
I was wondering if a nested router would be slower than adding endpoints on the root server. Documentation or my search in github issues could not anwer that question.

This benchmark shows that for my usecase it doesn't make a difference.