### PR TITLE
upgrade routefinder to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ log = { version = "0.4.13", features = ["kv_unstable_std"] }
 pin-project-lite = "0.2.0"
 serde = "1.0.117"
 serde_json = "1.0.59"
-routefinder = "0.4.0"
+routefinder = "0.5.0"
 
 [dev-dependencies]
 async-std = { version = "1.6.5", features = ["unstable", "attributes"] }

--- a/src/route.rs
+++ b/src/route.rs
@@ -51,7 +51,7 @@ impl<'a, State: Clone + Send + Sync + 'static> Route<'a, State> {
         }
 
         Route {
-            router: &mut self.router,
+            router: self.router,
             path: p,
             middleware: self.middleware.clone(),
             prefix: false,


### PR DESCRIPTION
See [routefinder@v0.5.0](https://github.com/jbr/routefinder/releases/tag/v0.5.0) release notes. No apis that tide uses directly were changed. There may be a slight performance improvement in this release, but not to a degree that really matters. This is not particularly important for tide, but we might as well keep on latest versions.