### PR TITLE
Add `Request` to not_found and method_not_allowed endpoints

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -96,13 +96,17 @@ impl<State: Clone + Send + Sync + 'static> Router<State> {
 }
 
 async fn not_found_endpoint<State: Clone + Send + Sync + 'static>(
-    _req: Request<State>,
+    req: Request<State>,
 ) -> crate::Result {
-    Ok(Response::new(StatusCode::NotFound))
+    let mut response = Response::new(StatusCode::NotFound);
+    response.insert_ext(req);
+    Ok(response)
 }
 
 async fn method_not_allowed<State: Clone + Send + Sync + 'static>(
-    _req: Request<State>,
+    req: Request<State>,
 ) -> crate::Result {
-    Ok(Response::new(StatusCode::MethodNotAllowed))
+    let mut response = Response::new(StatusCode::MethodNotAllowed);
+    response.insert_ext(req);
+    Ok(response)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -56,6 +56,27 @@ where
 ///     }
 /// }));
 /// ```
+///
+/// # 404 handling
+///
+/// When a path cannot be resolved, a 404 error is returned.
+/// This response can be caught in the `After` handler, and will have set the `Request<State>` as an extension value.
+///
+/// Note that you *must* match the `State` type of your request. e.g. if you use `tide::with_state(MyState { .. })`, you must match on `res.ext::<Request<MyState>>()`.
+///
+/// ```rust
+/// use tide::{utils, http, Response, Request};
+///
+/// let mut app = tide::new();
+/// app.with(utils::After(|res: Response| async move {
+///     if res.status() == http::StatusCode::NotFound {
+///         if let Some(request) = res.ext::<Request<()>>() {
+///             tide::log::info!("404 happened on URL {:?}", request.url());
+///         }
+///     }
+///     Ok(res)
+/// }));
+/// ```
 #[derive(Debug)]
 pub struct After<F>(pub F);
 #[async_trait]


### PR DESCRIPTION
I want to log urls that return a 404 NotFound. The best way to do this seems to be with an `After` middleware. However I am unable to access the URL from the `Response`.

This PR adds the `Request<State>` as an extension value.

Technically this would be a breaking change. Users could set the `Request<State>` themselves in their response, and then have a middleware that does something different based on that. However I suspect this situation won't happen much.