### PR TITLE
docs(readme): correct surfer link

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ team. Use at your own risk.</sup>
   - Clean boilerplate for graphql services using tide, rhai, async-graphql, surf, graphql-client, handlebars-rust, jsonwebtoken, and mongodb.
   - Graphql Services: User register, Salt and hash a password with PBKDF2 , Sign in， JSON web token authentication, Change password， Profile Update, User's query & mutation, and Project's query & mutation.
   - Web Application: Client request, bring & parse GraphQL data, Render data to template engine(handlebars-rust)， Define custom helper with Rhai scripting language.
-* [surf](https://github.com/zzy/surfer)
+* [surfer](https://github.com/zzy/surfer)
   - The Blog built on Tide stack, generated from [tide-graphql-mongodb](https://github.com/zzy/tide-graphql-mongodb).
   - Backend for graphql services using tide, async-graphql, jsonwebtoken, mongodb and so on.
   - Frontend for web application using tide, rhai, surf, graphql_client, handlebars-rust, cookie and so on.


### PR DESCRIPTION
This confused me initially, as I thought https://github.com/http-rs/surf was meant with the title. On another note, as surf is also related, maybe it should be linked too?