### PR TITLE
Allow cors origin to be dynamically matched

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ pin-project-lite = "0.2.0"
 serde = "1.0.117"
 serde_json = "1.0.59"
 routefinder = "0.5.0"
+regex = "1.5.5"
 
 [dev-dependencies]
 async-std = { version = "1.6.5", features = ["unstable", "attributes"] }


### PR DESCRIPTION
Hi team, thanks for all the work you guys are doing towards tide.

This PR is for issue https://github.com/http-rs/tide/issues/863.

Our use case is that vercel dynamically generates domains for previewing the changes and our test environment is using tide.

There were a couple of decisions that I am happy to rectify if you see any issues.

1.) That it was okay to bring another dependency, in this case latest [regex](https://github.com/http-rs/tide/compare/main...marcoslopes:main#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R51)

2.) Implementing PartialEq and Hash manually is ok, and decided to allow the most permissive implementation, by that I mean, the contents of the Origin variants is what is actually checked, and not only the variants themselves.

Thank you very much in advance.

