### PR TITLE
Add `Request::url_mut` method

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -69,7 +69,7 @@ impl<State> Request<State> {
         self.req.method()
     }
 
-    /// Access the request's full URI method.
+    /// Get a reference to request's URI.
     ///
     /// # Examples
     ///

--- a/src/request.rs
+++ b/src/request.rs
@@ -93,6 +93,12 @@ impl<State> Request<State> {
         self.req.url()
     }
 
+    /// Get a mutable reference to request's URI.
+    #[must_use]
+    pub fn url_mut(&mut self) -> &mut Url {
+        self.req.url_mut()
+    }
+
     /// Access the request's HTTP version.
     ///
     /// # Examples


### PR DESCRIPTION
Add `url_mut` method counterpart similar to how it's done for other components, e.g. https://docs.rs/tide/latest/tide/struct.Request.html#method.session_mut
Made sure the documentation is consistent with upstream library used https://docs.rs/http-types/latest/http_types/struct.Request.html#method.url

This is useful, for example, in cases where prefix of a route can contain forward-slashes and a request is to be routed to a nested server and custom routing relying on `response` method needs to be implemented.

For example, if `/a/b/c/_myroute` and `/a/_myroute` should call the same route on some `Server`, then an outer `Server` implementation could add a route on `*`, parse the URI from the request, trim the prefix as required and pass the request with modified URI (via `url_mut`) to the nested `Server` via `Server::respond`