### PR TITLE
Upgrade async-sse to 5.1.0 and make it optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ unstable = []
 [dependencies]
 async-h1 = { version = "2.3.0", optional = true }
 async-session = { version = "3.0", optional = true }
-async-sse = "4.0.1"
+async-sse = "5.1.0"
 async-std = { version = "1.6.5", features = ["unstable"] }
 async-trait = "0.1.41"
 femme = { version = "2.1.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,12 +30,13 @@ h1-server = ["async-h1"]
 logger = ["femme"]
 docs = ["unstable"]
 sessions = ["async-session", "cookies"]
+sse = ["async-sse"]
 unstable = []
 
 [dependencies]
 async-h1 = { version = "2.3.0", optional = true }
 async-session = { version = "3.0", optional = true }
-async-sse = "5.1.0"
+async-sse = { version = "5.1.0", optional = true }
 async-std = { version = "1.6.5", features = ["unstable"] }
 async-trait = "0.1.41"
 femme = { version = "2.1.1", optional = true }
@@ -90,3 +91,7 @@ required-features = ["cookies"]
 [[example]]
 name = "sessions"
 required-features = ["sessions"]
+
+[[example]]
+name = "sse"
+required-features = ["sse"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,11 +81,12 @@ pub mod listener;
 pub mod log;
 pub mod prelude;
 pub mod security;
-pub mod sse;
 pub mod utils;
 
 #[cfg(feature = "sessions")]
 pub mod sessions;
+#[cfg(feature = "sse")]
+pub mod sse;
 
 pub use endpoint::Endpoint;
 pub use middleware::{Middleware, Next};


### PR DESCRIPTION
Since we're in the 0.17 beta, we can safely make this feature non-default.