### PR TITLE
Make several features non-default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ features = ["docs"]
 rustdoc-args = ["--cfg", "feature=\"docs\""]
 
 [features]
-default = ["h1-server", "cookies", "logger", "sessions"]
+default = ["h1-server"]
 cookies = ["http-types/cookies"]
 h1-server = ["async-h1"]
 logger = ["femme"]

--- a/src/log/middleware.rs
+++ b/src/log/middleware.rs
@@ -3,9 +3,7 @@ use crate::{Middleware, Next, Request};
 
 /// Log all incoming requests and responses.
 ///
-/// This middleware is enabled by default in Tide. In the case of
-/// nested applications, this middleware will only run once for each
-/// request.
+/// In the case of nested applications, this middleware will only run once for each request.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
Since we're in the 0.17 beta, we can make breaking API changes, such as
making previously default features non-default.

Leave `h1-server` on by default, since tide isn't an HTTP server without
it. Disable all other optional features by default, and let the user opt
into them as needed.
