### PR TITLE
Add tide-jwt middleware implementation to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ team. Use at your own risk.</sup>
 ### Auth
 * [tide-http-auth](https://github.com/chrisdickinson/tide-http-auth)
 * [tide-openidconnect](https://github.com/malyn/tide-openidconnect)
+* [tide-jwt](htps://github.com/nyxtom/tide-jwt)
 
 ### Testing
 * [tide-testing](https://github.com/jbr/tide-testing)


### PR DESCRIPTION
I've submitted a simple tide-jwt middleware for supporting jwt authorization bearer tokens. This supports validating, encoding and decoding claims as passed into the utility functions and when configuring the middleware.