### PR TITLE
Fix github ci clippy tests on nonminimal bool test

### DIFF
--- a/src/security/cors.rs
+++ b/src/security/cors.rs
@@ -462,6 +462,7 @@ mod test {
         }
 
         #[test]
+        #[allow(clippy::nonminimal_bool)]
         fn symetrical() {
             let regex = Regex::new(r"e[xzs]a.*le.com*").unwrap();
             let x = Origin::from(regex.clone());


### PR DESCRIPTION
The symmetrical test here fails a nonminimal bool test, but it looks fine to skip in this case