### PR TITLE
Expose the matched route as an extension on the request

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -2,7 +2,7 @@ use async_std::io::{self, prelude::*};
 use async_std::task::{Context, Poll};
 use routefinder::Captures;
 
-use std::ops::Index;
+use std::ops::{Deref, Index};
 use std::pin::Pin;
 
 #[cfg(feature = "cookies")]
@@ -12,6 +12,7 @@ use crate::http::cookies::Cookie;
 use crate::http::format_err;
 use crate::http::headers::{self, HeaderName, HeaderValues, ToHeaderValues};
 use crate::http::{self, Body, Method, Mime, StatusCode, Url, Version};
+use crate::route::MatchedRoute;
 use crate::Response;
 
 pin_project_lite::pin_project! {
@@ -264,6 +265,24 @@ impl<State> Request<State> {
     ///  Access application scoped state.
     pub fn state(&self) -> &State {
         &self.state
+    }
+
+    /// Get the matched route.
+    ///
+    /// Returns the route as a `&str`, borrowed from this `Request`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tide::Request;
+    /// let mut app = tide::Server::new();
+    /// app.at("/route").get(|req: Request<()>| async move {
+    ///     let route = req.route().unwrap_or("No route found");
+    ///     Ok(route.to_string())
+    /// });
+    /// ```
+    pub fn route(&self) -> Option<&str> {
+        self.ext::<MatchedRoute>().map(|r| r.deref())
     }
 
     /// Extract and parse a route parameter by name.

--- a/src/route.rs
+++ b/src/route.rs
@@ -9,6 +9,18 @@ use crate::{router::Router, Endpoint, Middleware};
 
 use kv_log_macro::trace;
 
+/// Extension struct for storing the matched route in the request.
+#[derive(Debug)]
+pub(crate) struct MatchedRoute(pub(crate) String);
+
+impl std::ops::Deref for MatchedRoute {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 /// A handle to a route.
 ///
 /// All HTTP requests are made against resources. After using [`Server::at`] (or

--- a/src/router.rs
+++ b/src/router.rs
@@ -27,6 +27,7 @@ impl<State> std::fmt::Debug for Router<State> {
 pub(crate) struct Selection<'a, State> {
     pub(crate) endpoint: &'a DynEndpoint<State>,
     pub(crate) params: Captures<'static, 'static>,
+    pub(crate) matched_route: Option<String>,
 }
 
 impl<State: Clone + Send + Sync + 'static> Router<State> {
@@ -63,11 +64,13 @@ impl<State: Clone + Send + Sync + 'static> Router<State> {
             Selection {
                 endpoint: m.handler(),
                 params: m.captures().into_owned(),
+                matched_route: Some(m.route().to_string()),
             }
         } else if let Some(m) = self.all_method_router.best_match(path) {
             Selection {
                 endpoint: m.handler(),
                 params: m.captures().into_owned(),
+                matched_route: Some(m.route().to_string()),
             }
         } else if method == http_types::Method::Head {
             // If it is a HTTP HEAD request then check if there is a callback in the endpoints map
@@ -85,11 +88,13 @@ impl<State: Clone + Send + Sync + 'static> Router<State> {
             Selection {
                 endpoint: &method_not_allowed,
                 params: Captures::default(),
+                matched_route: None,
             }
         } else {
             Selection {
                 endpoint: &not_found_endpoint,
                 params: Captures::default(),
+                matched_route: None,
             }
         }
     }


### PR DESCRIPTION
I considered adding it directly to the `Request` struct, though now I'm not sure anymore why I didn't, haha.  I guess this PR is more of an RFC though.  I would be happy with either implementation, but I do have a need for getting the route.

---

Edit: I remembered now why I chose not to add it to the `Request` struct which is that it feels cleaner to have the `Request` struct only deal with the actual client-submitted request, and the concept of a matched route is purely a server-side abstraction.

But since the `Request` already contains the list of captured route parameters I guess this point is a bit moot.  Though I guess if this separation was wanted it wouldn't be unreasonable to remove the `route_params` struct member and turn that into an extension struct as well.