### PR TITLE
Remove obsolete mention of Nightly in the Endpoint examples

### DIFF
--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -16,10 +16,6 @@ use crate::{Middleware, Request, Response};
 ///
 /// # Examples
 ///
-/// Endpoints are implemented as asynchronous functions that make use of language features
-/// currently only available in Rust Nightly. For this reason, we have to explicitly enable
-/// the attribute will be omitted in most of the documentation.
-///
 /// A simple endpoint that is invoked on a `GET` request and returns a `String`:
 ///
 /// ```no_run


### PR DESCRIPTION
Remove obsolete part of documentation which refers to attributes which were removed in [commit 6eeb9b33](https://github.com/http-rs/tide/commit/6eeb9b33e0d9ff63ccaca0c161d6389bb6b14f86#diff-b7dd6c6dc06c9c5da00a0c048df395e5fed282392d70a222b1d0e34706d9baf3) (which already removed a line from this paragraph)