### PR TITLE
Fix sse log change to femme and kv_log_macro

### DIFF
--- a/examples/sse.rs
+++ b/examples/sse.rs
@@ -2,7 +2,7 @@ use tide::sse;
 
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
-    tide::log::start();
+    femme::start();
     let mut app = tide::new();
     app.with(tide::log::LogMiddleware::new());
     app.at("/sse").get(sse::endpoint(|_req, sender| async move {

--- a/src/sse/endpoint.rs
+++ b/src/sse/endpoint.rs
@@ -1,11 +1,11 @@
 use crate::http::{mime, Body, StatusCode};
-use crate::log;
 use crate::sse::Sender;
 use crate::{Endpoint, Request, Response, Result};
 
 use async_std::future::Future;
 use async_std::io::BufReader;
 use async_std::task;
+use kv_log_macro::error;
 
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -48,7 +48,7 @@ where
         task::spawn(async move {
             let sender = Sender::new(sender);
             if let Err(err) = handler(req, sender).await {
-                log::error!("SSE handler error: {:?}", err);
+                error!("SSE handler error: {:?}", err);
             }
         });
 

--- a/src/sse/upgrade.rs
+++ b/src/sse/upgrade.rs
@@ -1,5 +1,4 @@
 use crate::http::{mime, Body, StatusCode};
-use crate::log;
 use crate::{Request, Response, Result};
 
 use super::Sender;
@@ -7,6 +6,7 @@ use super::Sender;
 use async_std::future::Future;
 use async_std::io::BufReader;
 use async_std::task;
+use kv_log_macro::error;
 
 /// Upgrade an existing HTTP connection to an SSE connection.
 pub fn upgrade<F, Fut, State>(req: Request<State>, handler: F) -> Response
@@ -19,7 +19,7 @@ where
     task::spawn(async move {
         let sender = Sender::new(sender);
         if let Err(err) = handler(req, sender).await {
-            log::error!("SSE handler error: {:?}", err);
+            error!("SSE handler error: {:?}", err);
         }
     });
 


### PR DESCRIPTION
Fixed below two things in sse.

1. Use the git version of tide, I had below error. Fixed it refere #889.

```rust
error[E0433]: failed to resolve: could not find `error` in `log`
  --> tide/src/sse/endpoint.rs:51:22
   |
51 |                 log::error!("SSE handler error: {:?}", err);
   |                      ^^^^^ could not find `error` in `log`

error[E0433]: failed to resolve: could not find `error` in `log`
  --> tide/src/sse/upgrade.rs:22:18
   |
22 |             log::error!("SSE handler error: {:?}", err);
   |                  ^^^^^ could not find `error` in `log`

For more information about this error, try `rustc --explain E0433`.
error: could not compile `tide` due to 2 previous errors
```

2. example/sse.rs had build error.

```rust
error[E0425]: cannot find function `start` in module `tide::log`
 --> examples/sse.rs:5:16
  |
5 |     tide::log::start();
  |                ^^^^^ not found in `tide::log`
  |
help: consider importing one of these items
  |
1 | use femme::start;
  |
1 | use logtest::start;
  |
help: if you import `start`, refer to it directly
  |
5 -     tide::log::start();
5 +     start();
  |

For more information about this error, try `rustc --explain E0425`.
error: could not compile `tide` due to previous error
```