### PR TITLE
Fix route in static_file example

### DIFF
--- a/examples/static_file.rs
+++ b/examples/static_file.rs
@@ -4,7 +4,7 @@ async fn main() -> Result<(), std::io::Error> {
     let mut app = tide::new();
     app.with(tide::log::LogMiddleware::new());
     app.at("/").get(|_| async { Ok("visit /src/*") });
-    app.at("/src/*").serve_dir("src/")?;
+    app.at("/src").serve_dir("src/")?;
 
     // Make sure examples/static_file.html is available relative to the current-dir this example is run from or replace this with an absolute path.
     app.at("/example").serve_file("examples/static_file.html")?;


### PR DESCRIPTION
According to the example, the route should be `/src/*` but this returns a 404 when going to e.g. http://localhost:8080/dir/Cargo.toml, and even a panic when going to http://localhost:8080/dir/dir/Cargo.toml:

```
   3: core::option::Option<T>::unwrap
             at /build/rustc-1.68.2-src/library/core/src/option.rs:823:21
   4: <tide::fs::serve_dir::ServeDir as tide::endpoint::Endpoint<State>>::call::{{closure}}
             at /home/sijmen/.cargo/registry/src/github.com-1ecc6299db9ec823/tide-0.16.0/src/fs/serve_dir.rs:30:20
```

Maybe replacing that `unwrap` with something more graceful is a good idea too?