### PR TITLE
Don't make Listener require Sync

### DIFF
--- a/src/listener/mod.rs
+++ b/src/listener/mod.rs
@@ -35,7 +35,7 @@ pub(crate) use unix_listener::UnixListener;
 /// implement at least one [`ToListener`](crate::listener::ToListener) that
 /// outputs your Listener type.
 #[async_trait]
-pub trait Listener<State>: Debug + Display + Send + Sync + 'static
+pub trait Listener<State>: Debug + Display + Send + 'static
 where
     State: Send + Sync + 'static,
 {


### PR DESCRIPTION
The `Listener` trait depends on `Sync` and `Send`, but tide only actually makes
use of `Send`. Remove the `Sync` requirement, which makes it easier to
implement `Listener`.
